### PR TITLE
🐛(api) return a 403 HTTP status upon authentication failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Add a custom exception handler for authentication failures
+
 ## [0.2.0] - 2024-04-05
 
-## Added
+### Added
 
 - Integrate OIDC support
 - Integrate PostgreSQL database persistency in an asynchronous context

--- a/src/api/qualicharge/api/v1/__init__.py
+++ b/src/api/qualicharge/api/v1/__init__.py
@@ -1,16 +1,30 @@
 """QualiCharge API v1."""
 
 import logging
-from typing import Annotated
+from typing import Annotated, Union
 
-from fastapi import FastAPI, Security
+from fastapi import FastAPI, Request, Security, status
+from fastapi.responses import JSONResponse
 
 from qualicharge.auth.models import IDToken, User
 from qualicharge.auth.oidc import get_token
+from qualicharge.exceptions import OIDCAuthenticationError, OIDCProviderException
 
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="QualiCharge API (v1)")
+
+
+@app.exception_handler(OIDCAuthenticationError)
+@app.exception_handler(OIDCProviderException)
+async def authentication_exception_handler(
+    request: Request, exc: Union[OIDCAuthenticationError, OIDCProviderException]
+):
+    """Handle authentication errors."""
+    return JSONResponse(
+        status_code=status.HTTP_403_FORBIDDEN,
+        content={"message": f"Authentication failed: {exc.name}"},
+    )
 
 
 @app.get("/whoami")

--- a/src/api/qualicharge/auth/oidc.py
+++ b/src/api/qualicharge/auth/oidc.py
@@ -104,7 +104,13 @@ def get_token(
                 "verify_aud": True,
             },
         )
-    except (ExpiredSignatureError, JWTError, JWTClaimsError) as exc:
+    except ExpiredSignatureError as exc:
+        logger.error("Token signature expired: %s", exc)
+        raise OIDCAuthenticationError("Token signature expired") from exc
+    except JWTClaimsError as exc:
+        logger.error("Bad token claims: %s", exc)
+        raise OIDCAuthenticationError("Bad token claims") from exc
+    except JWTError as exc:
         logger.error("Unable to decode the ID token: %s", exc)
         raise OIDCAuthenticationError("Unable to decode ID token") from exc
     logger.debug(f"{decoded_token=}")

--- a/src/api/qualicharge/exceptions.py
+++ b/src/api/qualicharge/exceptions.py
@@ -1,9 +1,17 @@
 """QualiCharge exceptions."""
 
 
-class OIDCAuthenticationError(Exception):
+class QualiChargeExceptionMixin:
+    """A mixin for QualiCharge exceptions."""
+
+    def __init__(self, name: str):
+        """Add name property for our exception handler."""
+        self.name = name
+
+
+class OIDCAuthenticationError(QualiChargeExceptionMixin, Exception):
     """Raised when the OIDC authentication flow fails."""
 
 
-class OIDCProviderException(Exception):
+class OIDCProviderException(QualiChargeExceptionMixin, Exception):
     """Raised when the OIDC provider does not behave as expected."""

--- a/src/api/tests/api/v1/test_root.py
+++ b/src/api/tests/api/v1/test_root.py
@@ -1,6 +1,19 @@
 """Tests for the QualiCharge API root routes."""
 
+from datetime import datetime
+
 from fastapi import status
+from jose import jwt
+
+from qualicharge.auth.factories import IDTokenFactory
+from qualicharge.auth.oidc import discover_provider, get_public_keys
+from qualicharge.conf import settings
+
+
+def setup_function():
+    """Inactivate auth-specific LRU cache."""
+    discover_provider.cache_clear()
+    get_public_keys.cache_clear()
 
 
 def test_whoami_not_auth(client):
@@ -15,3 +28,96 @@ def test_whoami_auth(client_auth):
     response = client_auth.get("/whoami")
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {"email": "john@doe.com"}
+
+
+def test_whoami_expired_signature(
+    client, id_token_factory: IDTokenFactory, httpx_mock, monkeypatch
+):
+    """Test the whoami endpoint when user's token expired."""
+    monkeypatch.setenv("QUALICHARGE_OIDC_PROVIDER_BASE_URL", "http://oidc")
+    httpx_mock.add_response(
+        method="GET",
+        url=str(settings.OIDC_CONFIGURATION_URL),
+        json={
+            "jwks_uri": "https://oidc/certs",
+            "id_token_signing_alg_values_supported": "HS256",
+        },
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://oidc/certs",
+        json=[
+            "secret",
+        ],
+    )
+    # As exp should be set to iat + 300, the token should be expired
+    iat = int(datetime.now().timestamp()) - 500
+    token = jwt.encode(
+        claims=id_token_factory.build(iat=iat).model_dump(),
+        key="secret",
+        algorithm="HS256",
+    )
+    response = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {
+        "message": "Authentication failed: Token signature expired"
+    }
+
+
+def test_whoami_with_bad_token_claims(
+    client, id_token_factory: IDTokenFactory, httpx_mock, monkeypatch
+):
+    """Test the whoami endpoint with bad token claims."""
+    monkeypatch.setenv("QUALICHARGE_OIDC_PROVIDER_BASE_URL", "http://oidc")
+    httpx_mock.add_response(
+        method="GET",
+        url=str(settings.OIDC_CONFIGURATION_URL),
+        json={
+            "jwks_uri": "https://oidc/certs",
+            "id_token_signing_alg_values_supported": "HS256",
+        },
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://oidc/certs",
+        json=[
+            "secret",
+        ],
+    )
+    # As exp should be set to iat + 300, the token should be expired
+    token = jwt.encode(
+        claims=id_token_factory.build(aud="fake").model_dump(),
+        key="secret",
+        algorithm="HS256",
+    )
+    response = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {"message": "Authentication failed: Bad token claims"}
+
+
+def test_whoami_jwt_decoding_error(
+    client, id_token_factory: IDTokenFactory, httpx_mock, monkeypatch
+):
+    """Test the whoami endpoint when JWT decoding fails."""
+    monkeypatch.setenv("QUALICHARGE_OIDC_PROVIDER_BASE_URL", "http://oidc")
+    httpx_mock.add_response(
+        method="GET",
+        url=str(settings.OIDC_CONFIGURATION_URL),
+        json={
+            "jwks_uri": "https://oidc/certs",
+            "id_token_signing_alg_values_supported": "HS256",
+        },
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://oidc/certs",
+        json=[
+            "secret",
+        ],
+    )
+    token = "faketoken"  # noqa: S105
+    response = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {
+        "message": "Authentication failed: Unable to decode ID token"
+    }


### PR DESCRIPTION
## Purpose

When an ID token expires or is invalid, we should respond with a 403 status and an appropriate error message instead of a 500.

## Proposal

- [x] integrate a custom exception handler for authentication failures
- [x] tests all possible failures
