### PR TITLE
Add IRVE static schema and API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ MANIFEST
 .cache
 .local
 
+# Directories
+data
+
 # -- Environments
 .env
 .venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Implement `/statique` endpoints and models
+
+### Changed
+
+- Moved to `/whoami` endpoint to the `/auth` router
+
 ## [0.2.1] - 2024-04-08
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,29 @@ COMPOSE_RUN            = $(COMPOSE) run --rm --no-deps
 COMPOSE_RUN_API        = $(COMPOSE_RUN) api
 COMPOSE_RUN_API_PIPENV = $(COMPOSE_RUN_API) pipenv run
 
+# -- Tools
+CURL = $(COMPOSE_RUN) curl
+
+# -- Ressources
+IRVE_STATIC_DATASET_URL = https://www.data.gouv.fr/fr/datasets/r/eb76d20a-8501-400e-b336-d85724de5435
+
 # ==============================================================================
 # RULES
 
 default: help
 
+# -- Files
+data:
+	mkdir data
+
+data/irve-statique.csv: data
+	$(CURL) -L -o /work/data/irve-statique.csv $(IRVE_STATIC_DATASET_URL)
+
+
 # -- Docker/compose
 bootstrap: ## bootstrap the project for development
 bootstrap: \
+  data/irve-statique.csv \
   build \
   migrate-api \
   create-api-test-db \

--- a/bin/pipenv
+++ b/bin/pipenv
@@ -3,4 +3,3 @@
 set -eo pipefail
 
 docker compose run --rm --no-deps -u "pipenv:pipenv" api pipenv "$@"
-docker compose build api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,3 +47,9 @@ services:
   # -- tools
   dockerize:
     image: jwilder/dockerize
+
+  curl:
+    image: curlimages/curl:8.7.1
+    user: ${DOCKER_USER:-1000}
+    volumes:
+      - .:/work

--- a/src/api/Pipfile
+++ b/src/api/Pipfile
@@ -5,10 +5,12 @@ name = "pypi"
 
 [packages]
 alembic = "==1.13.1"
+annotated-types = "==0.6.0"
 email-validator = "==2.1.1"
 fastapi = "==0.110.1"
 httpx = "==0.27.0"
 psycopg2-binary = "==2.9.9"
+pydantic-extra-types = {extras = ["all"], version = "==2.6.0"}
 pydantic-settings = "==2.2.1"
 python-jose = {extras = ["cryptography"], version = "==3.3.0"}
 setuptools = "==69.2.0"
@@ -21,10 +23,11 @@ honcho = "==1.1.0"
 mypy = "==1.9.0"
 polyfactory = "==2.15.0"
 pytest = "==8.1.1"
+pytest-cov = "==5.0.0"
 pytest-httpx = "==0.30.0"
 ruff = "==0.3.5"
 types-python-jose = "==3.3.4.20240106"
-pytest-cov = "==5.0.0"
+csvkit = "==1.5.0"
 
 [requires]
 python_version = "3.12"

--- a/src/api/Pipfile.lock
+++ b/src/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1dad61b37b7ec4af0de6a2c34d7991eaeb8c2be92ba59df59d7b3b0b897ad597"
+            "sha256": "db37fe30f419dd3909ce1967dc59cfa5d2c71c603bff72bad7f0c3087657b497"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -30,6 +30,7 @@
                 "sha256:0641064de18ba7a25dee8f96403ebc39113d0cb953a01429249d5c7564666a43",
                 "sha256:563339e807e53ffd9c267e99fc6d9ea23eb8443c08f112651963e24e22f84a5d"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==0.6.0"
         },
@@ -162,11 +163,11 @@
         },
         "ecdsa": {
             "hashes": [
-                "sha256:190348041559e21b22a1d65cee485282ca11a6f81d503fddb84d5017e9ed1e49",
-                "sha256:80600258e7ed2f16b9aa1d7c295bd70194109ad5a30fdee0eaeefef1d4c559dd"
+                "sha256:2cea9b88407fdac7bbeca0833b189e4c9c53f2ef1e1eaa29f6224dbc809b707a",
+                "sha256:60eaad1199659900dd0af521ed462b793bbdf867432b3948e87416ae4caf6bf8"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.18.0"
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.19.0"
         },
         "email-validator": {
             "hashes": [
@@ -398,6 +399,101 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.1.5"
         },
+        "pendulum": {
+            "hashes": [
+                "sha256:04a1094a5aa1daa34a6b57c865b25f691848c61583fb22722a4df5699f6bf74c",
+                "sha256:0a15b90129765b705eb2039062a6daf4d22c4e28d1a54fa260892e8c3ae6e157",
+                "sha256:0a78ad3635d609ceb1e97d6aedef6a6a6f93433ddb2312888e668365908c7120",
+                "sha256:0c2308af4033fa534f089595bcd40a95a39988ce4059ccd3dc6acb9ef14ca44a",
+                "sha256:0c717eab1b6d898c00a3e0fa7781d615b5c5136bbd40abe82be100bb06df7a56",
+                "sha256:138afa9c373ee450ede206db5a5e9004fd3011b3c6bbe1e57015395cd076a09f",
+                "sha256:17fe4b2c844bbf5f0ece69cfd959fa02957c61317b2161763950d88fed8e13b9",
+                "sha256:1a3604e9fbc06b788041b2a8b78f75c243021e0f512447806a6d37ee5214905d",
+                "sha256:1c134ba2f0571d0b68b83f6972e2307a55a5a849e7dac8505c715c531d2a8795",
+                "sha256:2165a8f33cb15e06c67070b8afc87a62b85c5a273e3aaa6bc9d15c93a4920d6f",
+                "sha256:22e7944ffc1f0099a79ff468ee9630c73f8c7835cd76fdb57ef7320e6a409df4",
+                "sha256:235d64e87946d8f95c796af34818c76e0f88c94d624c268693c85b723b698aa9",
+                "sha256:28f49d8d1e32aae9c284a90b6bb3873eee15ec6e1d9042edd611b22a94ac462f",
+                "sha256:2cf9e53ef11668e07f73190c805dbdf07a1939c3298b78d5a9203a86775d1bfd",
+                "sha256:2e169cc2ca419517f397811bbe4589cf3cd13fca6dc38bb352ba15ea90739ebb",
+                "sha256:314c4038dc5e6a52991570f50edb2f08c339debdf8cea68ac355b32c4174e820",
+                "sha256:3725245c0352c95d6ca297193192020d1b0c0f83d5ee6bb09964edc2b5a2d508",
+                "sha256:385680812e7e18af200bb9b4a49777418c32422d05ad5a8eb85144c4a285907b",
+                "sha256:3b1f74d1e6ffe5d01d6023870e2ce5c2191486928823196f8575dcc786e107b1",
+                "sha256:3d897eb50883cc58d9b92f6405245f84b9286cd2de6e8694cb9ea5cb15195a32",
+                "sha256:3ddd1d66d1a714ce43acfe337190be055cdc221d911fc886d5a3aae28e14b76d",
+                "sha256:409e64e41418c49f973d43a28afe5df1df4f1dd87c41c7c90f1a63f61ae0f1f7",
+                "sha256:4386bffeca23c4b69ad50a36211f75b35a4deb6210bdca112ac3043deb7e494a",
+                "sha256:440215347b11914ae707981b9a57ab9c7b6983ab0babde07063c6ee75c0dc6e7",
+                "sha256:4b2c5675769fb6d4c11238132962939b960fcb365436b6d623c5864287faa319",
+                "sha256:4e8e36a8130819d97a479a0e7bf379b66b3b1b520e5dc46bd7eb14634338df8c",
+                "sha256:597e66e63cbd68dd6d58ac46cb7a92363d2088d37ccde2dae4332ef23e95cd00",
+                "sha256:5acb1d386337415f74f4d1955c4ce8d0201978c162927d07df8eb0692b2d8533",
+                "sha256:5b0ec85b9045bd49dd3a3493a5e7ddfd31c36a2a60da387c419fa04abcaecb23",
+                "sha256:5d034998dea404ec31fae27af6b22cff1708f830a1ed7353be4d1019bb9f584e",
+                "sha256:5ebc65ea033ef0281368217fbf59f5cb05b338ac4dd23d60959c7afcd79a60a0",
+                "sha256:60fb6f415fea93a11c52578eaa10594568a6716602be8430b167eb0d730f3332",
+                "sha256:660434a6fcf6303c4efd36713ca9212c753140107ee169a3fc6c49c4711c2a05",
+                "sha256:6a881d9c2a7f85bc9adafcfe671df5207f51f5715ae61f5d838b77a1356e8b7b",
+                "sha256:6c035f03a3e565ed132927e2c1b691de0dbf4eb53b02a5a3c5a97e1a64e17bec",
+                "sha256:6c58227ac260d5b01fc1025176d7b31858c9f62595737f350d22124a9a3ad82d",
+                "sha256:729e9f93756a2cdfa77d0fc82068346e9731c7e884097160603872686e570f07",
+                "sha256:773c3bc4ddda2dda9f1b9d51fe06762f9200f3293d75c4660c19b2614b991d83",
+                "sha256:77d8839e20f54706aed425bec82a83b4aec74db07f26acd039905d1237a5e1d4",
+                "sha256:78f8f4e7efe5066aca24a7a57511b9c2119f5c2b5eb81c46ff9222ce11e0a7a5",
+                "sha256:7dc843253ac373358ffc0711960e2dd5b94ab67530a3e204d85c6e8cb2c5fa10",
+                "sha256:822172853d7a9cf6da95d7b66a16c7160cb99ae6df55d44373888181d7a06edc",
+                "sha256:825799c6b66e3734227756fa746cc34b3549c48693325b8b9f823cb7d21b19ac",
+                "sha256:826d6e258052715f64d05ae0fc9040c0151e6a87aae7c109ba9a0ed930ce4000",
+                "sha256:83a44e8b40655d0ba565a5c3d1365d27e3e6778ae2a05b69124db9e471255c4a",
+                "sha256:83d9031f39c6da9677164241fd0d37fbfc9dc8ade7043b5d6d62f56e81af8ad2",
+                "sha256:840de1b49cf1ec54c225a2a6f4f0784d50bd47f68e41dc005b7f67c7d5b5f3ae",
+                "sha256:860aa9b8a888e5913bd70d819306749e5eb488e6b99cd6c47beb701b22bdecf5",
+                "sha256:8af95e03e066826f0f4c65811cbee1b3123d4a45a1c3a2b4fc23c4b0dff893b5",
+                "sha256:92c307ae7accebd06cbae4729f0ba9fa724df5f7d91a0964b1b972a22baa482b",
+                "sha256:99a0f8172e19f3f0c0e4ace0ad1595134d5243cf75985dc2233e8f9e8de263ca",
+                "sha256:9a59637cdb8462bdf2dbcb9d389518c0263799189d773ad5c11db6b13064fa79",
+                "sha256:9eec91cd87c59fb32ec49eb722f375bd58f4be790cae11c1b70fac3ee4f00da0",
+                "sha256:a38ad2121c5ec7c4c190c7334e789c3b4624798859156b138fcc4d92295835dc",
+                "sha256:a5346d08f3f4a6e9e672187faa179c7bf9227897081d7121866358af369f44f9",
+                "sha256:a6fc26907eb5fb8cc6188cc620bc2075a6c534d981a2f045daa5f79dfe50d512",
+                "sha256:a789e12fbdefaffb7b8ac67f9d8f22ba17a3050ceaaa635cd1cc4645773a4b1e",
+                "sha256:a90d4d504e82ad236afac9adca4d6a19e4865f717034fc69bafb112c320dcc8f",
+                "sha256:ac65eeec2250d03106b5e81284ad47f0d417ca299a45e89ccc69e36130ca8bc7",
+                "sha256:ad5e65b874b5e56bd942546ea7ba9dd1d6a25121db1c517700f1c9de91b28518",
+                "sha256:ad769e98dc07972e24afe0cff8d365cb6f0ebc7e65620aa1976fcfbcadc4c6f3",
+                "sha256:afde30e8146292b059020fbc8b6f8fd4a60ae7c5e6f0afef937bbb24880bdf01",
+                "sha256:b11aceea5b20b4b5382962b321dbc354af0defe35daa84e9ff3aae3c230df694",
+                "sha256:b30a137e9e0d1f751e60e67d11fc67781a572db76b2296f7b4d44554761049d6",
+                "sha256:b69f6b4dbcb86f2c2fe696ba991e67347bcf87fe601362a1aba6431454b46bde",
+                "sha256:bb8f6d7acd67a67d6fedd361ad2958ff0539445ef51cbe8cd288db4306503cd0",
+                "sha256:c95984037987f4a457bb760455d9ca80467be792236b69d0084f228a8ada0162",
+                "sha256:d29c6e578fe0f893766c0d286adbf0b3c726a4e2341eba0917ec79c50274ec16",
+                "sha256:d2aae97087872ef152a0c40e06100b3665d8cb86b59bc8471ca7c26132fccd0f",
+                "sha256:d4cdecde90aec2d67cebe4042fd2a87a4441cc02152ed7ed8fb3ebb110b94ec4",
+                "sha256:d4e2512f4e1a4670284a153b214db9719eb5d14ac55ada5b76cbdb8c5c00399d",
+                "sha256:d7762d2076b9b1cb718a6631ad6c16c23fc3fac76cbb8c454e81e80be98daa34",
+                "sha256:d9fef18ab0386ef6a9ac7bad7e43ded42c83ff7ad412f950633854f90d59afa8",
+                "sha256:dc00f8110db6898360c53c812872662e077eaf9c75515d53ecc65d886eec209a",
+                "sha256:deaba8e16dbfcb3d7a6b5fabdd5a38b7c982809567479987b9c89572df62e027",
+                "sha256:dee9e5a48c6999dc1106eb7eea3e3a50e98a50651b72c08a87ee2154e544b33e",
+                "sha256:dfbcf1661d7146d7698da4b86e7f04814221081e9fe154183e34f4c5f5fa3bf8",
+                "sha256:e586acc0b450cd21cbf0db6bae386237011b75260a3adceddc4be15334689a9a",
+                "sha256:f17c3084a4524ebefd9255513692f7e7360e23c8853dc6f10c64cc184e1217ab",
+                "sha256:fa30af36bd8e50686846bdace37cf6707bdd044e5cb6e1109acbad3277232e04",
+                "sha256:fb551b9b5e6059377889d2d878d940fd0bbb80ae4810543db18e6f77b02c5ef6",
+                "sha256:fd69b15374bef7e4b4440612915315cc42e8575fcda2a3d7586a0d88192d0c88",
+                "sha256:fde4d0b2024b9785f66b7f30ed59281bd60d63d9213cda0eb0910ead777f6d37"
+            ],
+            "version": "==3.0.0"
+        },
+        "phonenumbers": {
+            "hashes": [
+                "sha256:7c2676be07b7d0f74411e275e0660380a0ec3ee0d359f070d719424bd2c5f62e",
+                "sha256:bc0bb5d3bab29e28549194f6bf57cb3ca03c3dd84238af12674fe24031631bda"
+            ],
+            "version": "==8.13.34"
+        },
         "psycopg2-binary": {
             "hashes": [
                 "sha256:03ef7df18daf2c4c07e2695e8cfd5ee7f748a1d54d802330985a78d2a5a6dca9",
@@ -484,6 +580,13 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==0.6.0"
+        },
+        "pycountry": {
+            "hashes": [
+                "sha256:00569d82eaefbc6a490a311bfa84a9c571cff9ddbf8b0a4f4e7b4f868b4ad925",
+                "sha256:2ff91cff4f40ff61086e773d61e72005fe95de4a57bfc765509db05695dc50ab"
+            ],
+            "version": "==23.12.11"
         },
         "pycparser": {
             "hashes": [
@@ -586,6 +689,17 @@
             "markers": "python_version >= '3.8'",
             "version": "==2.16.3"
         },
+        "pydantic-extra-types": {
+            "extras": [
+                "all"
+            ],
+            "hashes": [
+                "sha256:d291d521c2e2bf2e6f11971caf8d639518124ae26a76d2e712599e98c4ef2b2b",
+                "sha256:e9a93cfb245158462acb76621785219f80ad112303a0a7784d2ada65e6ed6cba"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.6.0"
+        },
         "pydantic-settings": {
             "hashes": [
                 "sha256:00b9f6a5e95553590434c0fa01ead0b216c3e10bc54ae02e37f359948643c5ed",
@@ -594,6 +708,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==2.2.1"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.9.0.post0"
         },
         "python-dotenv": {
             "hashes": [
@@ -612,6 +734,13 @@
                 "sha256:9b1376b023f8b298536eedd47ae1089bcdb848f1535ab30555cd92002d78923a"
             ],
             "version": "==3.3.0"
+        },
+        "python-ulid": {
+            "hashes": [
+                "sha256:45779c68b9060beb6fca72338a0620114489e1bbe274935149f14d1f776d4c43",
+                "sha256:e2c739e27e6d760136e5f411f311cdd3ec9c4c89696932fe803fa09a4dcd6ebe"
+            ],
+            "version": "==2.4.0.post0"
         },
         "pyyaml": {
             "hashes": [
@@ -774,13 +903,83 @@
             "markers": "python_version >= '3.8'",
             "version": "==0.37.2"
         },
+        "time-machine": {
+            "hashes": [
+                "sha256:0312b47f220e46f1bbfaded7fc1469882d9c2a27c6daf44e119aea7006b595cc",
+                "sha256:06e913d570d7ee3e199e3316f10f10c8046287049141b0a101197712b4eac106",
+                "sha256:0a39dba3033d9c28347d2db16bcb16041bbf4e9032e2b70023686b6f95deac9d",
+                "sha256:0e120f95c17bf8e0c097fd8863a8eb24054f9b17d9b17c465694be50f8348a3a",
+                "sha256:107caed387438d689180b692e8d84aa1ebe8918790df83dc5e2146e60e5e0859",
+                "sha256:15cf3623a4ba2bb4fce4529295570acd5f6c6b44bcbfd1b8d0756ce56c38fe82",
+                "sha256:19db257117739b2dda1d57e149bb715a593313899b3902a7e6d752c5f1d22542",
+                "sha256:27f735cba4c6352ad7bc53ce2d86b715379261a634e690b79fac329081e26fb6",
+                "sha256:2c774f4b603a36ca2611327c57aa8ce0d5042298da008238ee5234b31ce7b22c",
+                "sha256:30a4a18357fa6cf089eeefcb37e9549b42523aebb5933894770a8919e6c398e1",
+                "sha256:31e6e9bff89b7c6e4cbc169ba1d00d6c107b3abc43173b2799352b6995cf7cb2",
+                "sha256:364353858708628655bf9fa4c2825febd679c729d9e1dd424ff86845828bac05",
+                "sha256:36aa4f17adcd73a6064bf4991a29126cac93521f0690805edb91db837c4e1453",
+                "sha256:39de6d37a14ff8882d4f1cbd50c53268b54e1cf4ef9be2bfe590d10a51ccd314",
+                "sha256:39fceeb131e6c07b386de042ce1016be771576e9516124b78e75cbab94ae5041",
+                "sha256:3b94274abe24b6a90d8a5c042167a9a7af2d3438b42ac8eb5ede50fbc73c08db",
+                "sha256:416d94eab7723c7d8a37fe6b3b1882046fdbf3c31b9abec3cac87cf35dbb8230",
+                "sha256:442d42f1b0ef006f03a5a34905829a1d3ac569a5bcda64d29706e6dc60832f94",
+                "sha256:4f00f67d532da82538c4dfbbddc587e70c82664f168c11e1c2915d0c85ec2fc8",
+                "sha256:528d588d1e8ba83e45319a74acab4be0569eb141113fdf50368045d0a7d79cee",
+                "sha256:57dc7efc1dde4331902d1bdefd34e8ee890a5c28533157e3b14a429c86b39533",
+                "sha256:59a02c3d3b3b29e2dc3a708e775c5d6b951b0024c4013fed883f0d2205305c9e",
+                "sha256:5e19b19d20bfbff8c97949e06e150998cf9d0a676e1641fb90597e59a9d7d5e2",
+                "sha256:5f3d5c21884aee10e13b00ef45fab893a43db9d59ec27271573528bd359b0ef5",
+                "sha256:6706eb06487354a5e219cacea709fb3ec44dec3842c6218237d5069fa5f1ad64",
+                "sha256:6ced9de5eff1fb37efb12984ab7b63f31f0aeadeedec4be6d0404ec4fa91f2e7",
+                "sha256:7161cea2ff3244cc6075e365fab89000df70ead63a3da9d473983d580558d2de",
+                "sha256:72a153b085b4aee652d6b3bf9019ca897f1597ba9869b640b06f28736b267182",
+                "sha256:7fd7d188b4f9d358c6bd477daf93b460d9b244a4c296ddd065945f2b6193c2bd",
+                "sha256:87e80408e6b6670e9ce33f94b1cc6b72b1a9b646f5e19f586908129871f74b40",
+                "sha256:90725f936ad8b123149bc82a46394dd7057e63157ee11ba878164053fa5bd8ad",
+                "sha256:993ab140eb5678d1ee7f1197f08e4499dc8ea883ad6b8858737de70d509ec5b5",
+                "sha256:99e6f013e67c4f74a9d8f57e34173b2047f2ad48f764e44c38f3ee5344a38c01",
+                "sha256:a75e24e59f58059bbbc50e7f97aa6d126bbc2f603a8a5cd1e884beffcf130d8f",
+                "sha256:a927d87501da8b053a27e80f5d0e1e58fbde4b50d70df2d3853ed67e89a731cf",
+                "sha256:adfbfa796dd96383400b44681eacc5ab06d3cbfad39c30878e5ead0bfdca808a",
+                "sha256:b0f8ba70fbb71d7fbc6d6adb90bed72a83db15b3318c7af0060467539b2f1b63",
+                "sha256:b951b6f4b8a752ab8c441df422e21954a721a0a5276aa3814ce8cf7205aeb6da",
+                "sha256:bb3a2518c52aa944989b541e5297b833388eb3fe72d91eb875b21fe771597b04",
+                "sha256:be215eb63d74a3d580f7924bb4209c783fabcfb3253073f4dcb3424d57d0f518",
+                "sha256:c69c0cb498c86ef843cd15964714e76465cc25d64464da57d5d1318f499de099",
+                "sha256:c77a616561dd4c7c442e9eee8cbb915750496e9a5a7fca6bcb11a9860226d2d0",
+                "sha256:cab4abf4d1490a7da35db5a321ff8a4d4a2195f4832a792c75b626ffc4a5584c",
+                "sha256:d45bd60bea85869615b117667f10a821e3b0d3603c47bfd105b45d1f67156fc8",
+                "sha256:d63ef00d389fa6d2c76c863af580b3e4a8f0ccc6a9aea8e64590588e37f13c00",
+                "sha256:dc48d3934109b0bdbbdc5e9ce577213f7148a92fed378420ee13453503fe4db9",
+                "sha256:dd26039a9ffea2d5ee1309f2ec9b656d4925371c65563822d52e4037a4186eca",
+                "sha256:ddbbba954e9a409e7d66d60df2b6b8daeb897f8338f909a92d9d20e431ec70d1",
+                "sha256:e030d2051bb515251d7f6edd9bbcf79b2b47811e2c402aba9c126af713843d26",
+                "sha256:e7fa70a6bdca40cc4a8386fd85bc1bae0a23ab11e49604ef853ab3ce92be127f",
+                "sha256:edea570f3835a036e8860bb8d6eb8d08473c59313db86e36e3b207f796fd7b14",
+                "sha256:ee68597bd3fa5ab94633c8a9d3ebd4032091559610e078381818a732910002bc",
+                "sha256:f5d371a5218318121a6b44c21438258b6408b8bfe7ccccb754cf8eb880505576",
+                "sha256:fb467d6c9e9ab615c8cf22d751d34296dacf801be323a57adeb4ff345cf72473",
+                "sha256:fd8645b820f7895fdafbc4412d1ce376956e36ad4fd05a43269aa06c3132afc3",
+                "sha256:fe508a6c43fb72fa4f66b50b14684cf58d3db95fed617177ec197a7a90427bae"
+            ],
+            "markers": "implementation_name != 'pypy'",
+            "version": "==2.14.1"
+        },
         "typing-extensions": {
             "hashes": [
-                "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
-                "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
+                "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0",
+                "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.10.0"
+            "version": "==4.11.0"
+        },
+        "tzdata": {
+            "hashes": [
+                "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd",
+                "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252"
+            ],
+            "markers": "python_version >= '2'",
+            "version": "==2024.1"
         },
         "uvicorn": {
             "extras": [
@@ -988,6 +1187,34 @@
         }
     },
     "develop": {
+        "agate": {
+            "hashes": [
+                "sha256:1cf329510b3dde07c4ad1740b7587c9c679abc3dcd92bb1107eabc10c2e03c50",
+                "sha256:bc60880c2ee59636a2a80cd8603d63f995be64526abf3cbba12f00767bcd5b3d"
+            ],
+            "version": "==1.9.1"
+        },
+        "agate-dbf": {
+            "hashes": [
+                "sha256:98a2b53757136cc74dc297e59e2101d34f6d48f41f74156bb6c0de26bba2aa3f",
+                "sha256:b36e5a8321f9c42f812750256cadd600f779a19e334a80fee6e032395c0b9aa0"
+            ],
+            "version": "==0.2.3"
+        },
+        "agate-excel": {
+            "hashes": [
+                "sha256:28426618c90747111e6d566e983d838f1e2fae641ea6970d7acb0e9d4b384091",
+                "sha256:398f214cb24e3debcb6cc75f52dc558dee84d594f5f4b5e73997299c6c786158"
+            ],
+            "version": "==0.4.1"
+        },
+        "agate-sql": {
+            "hashes": [
+                "sha256:9b1b30284a573fd416759437273dcc5c81022bdf2facb24b4aa029a62afd53b0",
+                "sha256:be1cb9a99b3e4ec7f6106278dfb7b534be9629c8a983abb168c3effacc79dd10"
+            ],
+            "version": "==0.7.2"
+        },
         "anyio": {
             "hashes": [
                 "sha256:048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8",
@@ -995,6 +1222,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==4.3.0"
+        },
+        "babel": {
+            "hashes": [
+                "sha256:6919867db036398ba21eb5c7a0f6b28ab8cbc3ae7a73a44ebe34ae74a4e7d363",
+                "sha256:efb1a25b7118e67ce3a259bed20545c29cb68be8ad2c784c83689981b7a57287"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.14.0"
         },
         "black": {
             "hashes": [
@@ -1102,13 +1337,100 @@
             "markers": "python_version >= '3.8'",
             "version": "==7.4.4"
         },
+        "csvkit": {
+            "hashes": [
+                "sha256:3f81e6f9af1774688ee30f4bdf8abd7f927995c85cad6491cf7478c658cfe7be",
+                "sha256:967a8be8fc58edf5621225b5a6a697b0e8730b962ea68085916a91860b22211c"
+            ],
+            "index": "pypi",
+            "version": "==1.5.0"
+        },
+        "dbfread": {
+            "hashes": [
+                "sha256:07c8a9af06ffad3f6f03e8fe91ad7d2733e31a26d2b72c4dd4cfbae07ee3b73d",
+                "sha256:f604def58c59694fa0160d7be5d0b8d594467278d2bb6a47d46daf7162c84cec"
+            ],
+            "version": "==2.0.7"
+        },
+        "et-xmlfile": {
+            "hashes": [
+                "sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c",
+                "sha256:a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.1.0"
+        },
         "faker": {
             "hashes": [
-                "sha256:998c29ee7d64429bd59204abffa9ba11f784fb26c7b9df4def78d1a70feb36a7",
-                "sha256:a5ddccbe97ab691fad6bd8036c31f5697cfaa550e62e000078d1935fa8a7ec2e"
+                "sha256:1a46466b22c6bf5925448f725f90c6e0d8bf085819906520ddaa15aec58a6df5",
+                "sha256:2f70a7817b4147d67c544192e169c5653060fce8aef758db0ea8823d89caac94"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==24.4.0"
+            "version": "==24.8.0"
+        },
+        "greenlet": {
+            "hashes": [
+                "sha256:01bc7ea167cf943b4c802068e178bbf70ae2e8c080467070d01bfa02f337ee67",
+                "sha256:0448abc479fab28b00cb472d278828b3ccca164531daab4e970a0458786055d6",
+                "sha256:086152f8fbc5955df88382e8a75984e2bb1c892ad2e3c80a2508954e52295257",
+                "sha256:098d86f528c855ead3479afe84b49242e174ed262456c342d70fc7f972bc13c4",
+                "sha256:149e94a2dd82d19838fe4b2259f1b6b9957d5ba1b25640d2380bea9c5df37676",
+                "sha256:1551a8195c0d4a68fac7a4325efac0d541b48def35feb49d803674ac32582f61",
+                "sha256:15d79dd26056573940fcb8c7413d84118086f2ec1a8acdfa854631084393efcc",
+                "sha256:1996cb9306c8595335bb157d133daf5cf9f693ef413e7673cb07e3e5871379ca",
+                "sha256:1a7191e42732df52cb5f39d3527217e7ab73cae2cb3694d241e18f53d84ea9a7",
+                "sha256:1ea188d4f49089fc6fb283845ab18a2518d279c7cd9da1065d7a84e991748728",
+                "sha256:1f672519db1796ca0d8753f9e78ec02355e862d0998193038c7073045899f305",
+                "sha256:2516a9957eed41dd8f1ec0c604f1cdc86758b587d964668b5b196a9db5bfcde6",
+                "sha256:2797aa5aedac23af156bbb5a6aa2cd3427ada2972c828244eb7d1b9255846379",
+                "sha256:2dd6e660effd852586b6a8478a1d244b8dc90ab5b1321751d2ea15deb49ed414",
+                "sha256:3ddc0f794e6ad661e321caa8d2f0a55ce01213c74722587256fb6566049a8b04",
+                "sha256:3ed7fb269f15dc662787f4119ec300ad0702fa1b19d2135a37c2c4de6fadfd4a",
+                "sha256:419b386f84949bf0e7c73e6032e3457b82a787c1ab4a0e43732898a761cc9dbf",
+                "sha256:43374442353259554ce33599da8b692d5aa96f8976d567d4badf263371fbe491",
+                "sha256:52f59dd9c96ad2fc0d5724107444f76eb20aaccb675bf825df6435acb7703559",
+                "sha256:57e8974f23e47dac22b83436bdcf23080ade568ce77df33159e019d161ce1d1e",
+                "sha256:5b51e85cb5ceda94e79d019ed36b35386e8c37d22f07d6a751cb659b180d5274",
+                "sha256:649dde7de1a5eceb258f9cb00bdf50e978c9db1b996964cd80703614c86495eb",
+                "sha256:64d7675ad83578e3fc149b617a444fab8efdafc9385471f868eb5ff83e446b8b",
+                "sha256:68834da854554926fbedd38c76e60c4a2e3198c6fbed520b106a8986445caaf9",
+                "sha256:6b66c9c1e7ccabad3a7d037b2bcb740122a7b17a53734b7d72a344ce39882a1b",
+                "sha256:70fb482fdf2c707765ab5f0b6655e9cfcf3780d8d87355a063547b41177599be",
+                "sha256:7170375bcc99f1a2fbd9c306f5be8764eaf3ac6b5cb968862cad4c7057756506",
+                "sha256:73a411ef564e0e097dbe7e866bb2dda0f027e072b04da387282b02c308807405",
+                "sha256:77457465d89b8263bca14759d7c1684df840b6811b2499838cc5b040a8b5b113",
+                "sha256:7f362975f2d179f9e26928c5b517524e89dd48530a0202570d55ad6ca5d8a56f",
+                "sha256:81bb9c6d52e8321f09c3d165b2a78c680506d9af285bfccbad9fb7ad5a5da3e5",
+                "sha256:881b7db1ebff4ba09aaaeae6aa491daeb226c8150fc20e836ad00041bcb11230",
+                "sha256:894393ce10ceac937e56ec00bb71c4c2f8209ad516e96033e4b3b1de270e200d",
+                "sha256:99bf650dc5d69546e076f413a87481ee1d2d09aaaaaca058c9251b6d8c14783f",
+                "sha256:9da2bd29ed9e4f15955dd1595ad7bc9320308a3b766ef7f837e23ad4b4aac31a",
+                "sha256:afaff6cf5200befd5cec055b07d1c0a5a06c040fe5ad148abcd11ba6ab9b114e",
+                "sha256:b1b5667cced97081bf57b8fa1d6bfca67814b0afd38208d52538316e9422fc61",
+                "sha256:b37eef18ea55f2ffd8f00ff8fe7c8d3818abd3e25fb73fae2ca3b672e333a7a6",
+                "sha256:b542be2440edc2d48547b5923c408cbe0fc94afb9f18741faa6ae970dbcb9b6d",
+                "sha256:b7dcbe92cc99f08c8dd11f930de4d99ef756c3591a5377d1d9cd7dd5e896da71",
+                "sha256:b7f009caad047246ed379e1c4dbcb8b020f0a390667ea74d2387be2998f58a22",
+                "sha256:bba5387a6975598857d86de9eac14210a49d554a77eb8261cc68b7d082f78ce2",
+                "sha256:c5e1536de2aad7bf62e27baf79225d0d64360d4168cf2e6becb91baf1ed074f3",
+                "sha256:c5ee858cfe08f34712f548c3c363e807e7186f03ad7a5039ebadb29e8c6be067",
+                "sha256:c9db1c18f0eaad2f804728c67d6c610778456e3e1cc4ab4bbd5eeb8e6053c6fc",
+                "sha256:d353cadd6083fdb056bb46ed07e4340b0869c305c8ca54ef9da3421acbdf6881",
+                "sha256:d46677c85c5ba00a9cb6f7a00b2bfa6f812192d2c9f7d9c4f6a55b60216712f3",
+                "sha256:d4d1ac74f5c0c0524e4a24335350edad7e5f03b9532da7ea4d3c54d527784f2e",
+                "sha256:d73a9fe764d77f87f8ec26a0c85144d6a951a6c438dfe50487df5595c6373eac",
+                "sha256:da70d4d51c8b306bb7a031d5cff6cc25ad253affe89b70352af5f1cb68e74b53",
+                "sha256:daf3cb43b7cf2ba96d614252ce1684c1bccee6b2183a01328c98d36fcd7d5cb0",
+                "sha256:dca1e2f3ca00b84a396bc1bce13dd21f680f035314d2379c4160c98153b2059b",
+                "sha256:dd4f49ae60e10adbc94b45c0b5e6a179acc1736cf7a90160b404076ee283cf83",
+                "sha256:e1f145462f1fa6e4a4ae3c0f782e580ce44d57c8f2c7aae1b6fa88c0b2efdb41",
+                "sha256:e3391d1e16e2a5a1507d83e4a8b100f4ee626e8eca43cf2cadb543de69827c4c",
+                "sha256:fcd2469d6a2cf298f198f0487e0a5b1a47a42ca0fa4dfd1b6862c999f018ebbf",
+                "sha256:fd096eb7ffef17c456cfa587523c5f92321ae02427ff955bebe9e3c63bc9f0da",
+                "sha256:fe754d231288e1e64323cfad462fcee8f0288654c10bdf4f603a39ed923bef33"
+            ],
+            "markers": "platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))",
+            "version": "==3.0.3"
         },
         "h11": {
             "hashes": [
@@ -1159,6 +1481,20 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.0.0"
         },
+        "isodate": {
+            "hashes": [
+                "sha256:0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96",
+                "sha256:48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9"
+            ],
+            "version": "==0.6.1"
+        },
+        "leather": {
+            "hashes": [
+                "sha256:18290bc93749ae39039af5e31e871fcfad74d26c4c3ea28ea4f681f4571b3a2b",
+                "sha256:f964bec2086f3153a6c16e707f20cb718f811f57af116075f4c0f4805c608b95"
+            ],
+            "version": "==0.4.0"
+        },
         "mypy": {
             "hashes": [
                 "sha256:0235391f1c6f6ce487b23b9dbd1327b4ec33bb93934aa986efe8a9563d9349e6",
@@ -1201,6 +1537,22 @@
             "markers": "python_version >= '3.5'",
             "version": "==1.0.0"
         },
+        "olefile": {
+            "hashes": [
+                "sha256:543c7da2a7adadf21214938bb79c83ea12b473a4b6ee4ad4bf854e7715e13d1f",
+                "sha256:599383381a0bf3dfbd932ca0ca6515acd174ed48870cbf7fee123d698c192c1c"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.47"
+        },
+        "openpyxl": {
+            "hashes": [
+                "sha256:a6f5977418eff3b2d5500d54d9db50c8277a368436f4e4f8ddb1be3422870184",
+                "sha256:f91456ead12ab3c6c2e9491cf33ba6d08357d802192379bb482f1033ade496f5"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.1.2"
+        },
         "packaging": {
             "hashes": [
                 "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
@@ -1208,6 +1560,13 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==24.0"
+        },
+        "parsedatetime": {
+            "hashes": [
+                "sha256:4cb368fbb18a0b7231f4d76119165451c8d2e35951455dfee97c62a87b04d455",
+                "sha256:cb96edd7016872f58479e35879294258c71437195760746faffedb692aef000b"
+            ],
+            "version": "==2.6"
         },
         "pathspec": {
             "hashes": [
@@ -1277,6 +1636,21 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.9.0.post0"
         },
+        "python-slugify": {
+            "hashes": [
+                "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8",
+                "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==8.0.4"
+        },
+        "pytimeparse": {
+            "hashes": [
+                "sha256:04b7be6cc8bd9f5647a6325444926c3ac34ee6bc7e69da4367ba282f076036bd",
+                "sha256:e86136477be924d7e670646a98561957e8ca7308d44841e21f5ddea757556a0a"
+            ],
+            "version": "==1.1.8"
+        },
         "ruff": {
             "hashes": [
                 "sha256:122de171a147c76ada00f76df533b54676f6e321e61bd8656ae54be326c10296",
@@ -1317,6 +1691,68 @@
             "markers": "python_version >= '3.7'",
             "version": "==1.3.1"
         },
+        "sqlalchemy": {
+            "hashes": [
+                "sha256:01d10638a37460616708062a40c7b55f73e4d35eaa146781c683e0fa7f6c43fb",
+                "sha256:04c487305ab035a9548f573763915189fc0fe0824d9ba28433196f8436f1449c",
+                "sha256:0dfefdb3e54cd15f5d56fd5ae32f1da2d95d78319c1f6dfb9bcd0eb15d603d5d",
+                "sha256:0f3ca96af060a5250a8ad5a63699180bc780c2edf8abf96c58af175921df847a",
+                "sha256:205f5a2b39d7c380cbc3b5dcc8f2762fb5bcb716838e2d26ccbc54330775b003",
+                "sha256:25664e18bef6dc45015b08f99c63952a53a0a61f61f2e48a9e70cec27e55f699",
+                "sha256:296195df68326a48385e7a96e877bc19aa210e485fa381c5246bc0234c36c78e",
+                "sha256:2a0732dffe32333211801b28339d2a0babc1971bc90a983e3035e7b0d6f06b93",
+                "sha256:3071ad498896907a5ef756206b9dc750f8e57352113c19272bdfdc429c7bd7de",
+                "sha256:308ef9cb41d099099fffc9d35781638986870b29f744382904bf9c7dadd08513",
+                "sha256:334184d1ab8f4c87f9652b048af3f7abea1c809dfe526fb0435348a6fef3d380",
+                "sha256:38b624e5cf02a69b113c8047cf7f66b5dfe4a2ca07ff8b8716da4f1b3ae81567",
+                "sha256:471fcb39c6adf37f820350c28aac4a7df9d3940c6548b624a642852e727ea586",
+                "sha256:4c142852ae192e9fe5aad5c350ea6befe9db14370b34047e1f0f7cf99e63c63b",
+                "sha256:4f6d971255d9ddbd3189e2e79d743ff4845c07f0633adfd1de3f63d930dbe673",
+                "sha256:52c8011088305476691b8750c60e03b87910a123cfd9ad48576d6414b6ec2a1d",
+                "sha256:52de4736404e53c5c6a91ef2698c01e52333988ebdc218f14c833237a0804f1b",
+                "sha256:5c7b02525ede2a164c5fa5014915ba3591730f2cc831f5be9ff3b7fd3e30958e",
+                "sha256:5ef3fbccb4058355053c51b82fd3501a6e13dd808c8d8cd2561e610c5456013c",
+                "sha256:5f20cb0a63a3e0ec4e169aa8890e32b949c8145983afa13a708bc4b0a1f30e03",
+                "sha256:61405ea2d563407d316c63a7b5271ae5d274a2a9fbcd01b0aa5503635699fa1e",
+                "sha256:77d29cb6c34b14af8a484e831ab530c0f7188f8efed1c6a833a2c674bf3c26ec",
+                "sha256:7b184e3de58009cc0bf32e20f137f1ec75a32470f5fede06c58f6c355ed42a72",
+                "sha256:7e614d7a25a43a9f54fcce4675c12761b248547f3d41b195e8010ca7297c369c",
+                "sha256:8197d6f7a3d2b468861ebb4c9f998b9df9e358d6e1cf9c2a01061cb9b6cf4e41",
+                "sha256:87a1d53a5382cdbbf4b7619f107cc862c1b0a4feb29000922db72e5a66a5ffc0",
+                "sha256:8c37f1050feb91f3d6c32f864d8e114ff5545a4a7afe56778d76a9aec62638ba",
+                "sha256:90453597a753322d6aa770c5935887ab1fc49cc4c4fdd436901308383d698b4b",
+                "sha256:988569c8732f54ad3234cf9c561364221a9e943b78dc7a4aaf35ccc2265f1930",
+                "sha256:99a1e69d4e26f71e750e9ad6fdc8614fbddb67cfe2173a3628a2566034e223c7",
+                "sha256:9b19836ccca0d321e237560e475fd99c3d8655d03da80c845c4da20dda31b6e1",
+                "sha256:9d6753305936eddc8ed190e006b7bb33a8f50b9854823485eed3a886857ab8d1",
+                "sha256:a13b917b4ffe5a0a31b83d051d60477819ddf18276852ea68037a144a506efb9",
+                "sha256:a88913000da9205b13f6f195f0813b6ffd8a0c0c2bd58d499e00a30eb508870c",
+                "sha256:b2a0e3cf0caac2085ff172c3faacd1e00c376e6884b5bc4dd5b6b84623e29e4f",
+                "sha256:b5d7ed79df55a731749ce65ec20d666d82b185fa4898430b17cb90c892741520",
+                "sha256:bab41acf151cd68bc2b466deae5deeb9e8ae9c50ad113444151ad965d5bf685b",
+                "sha256:bd9566b8e58cabd700bc367b60e90d9349cd16f0984973f98a9a09f9c64e86f0",
+                "sha256:bda7ce59b06d0f09afe22c56714c65c957b1068dee3d5e74d743edec7daba552",
+                "sha256:c2f9c762a2735600654c654bf48dad388b888f8ce387b095806480e6e4ff6907",
+                "sha256:c4520047006b1d3f0d89e0532978c0688219857eb2fee7c48052560ae76aca1e",
+                "sha256:d96710d834a6fb31e21381c6d7b76ec729bd08c75a25a5184b1089141356171f",
+                "sha256:dba622396a3170974f81bad49aacebd243455ec3cc70615aeaef9e9613b5bca5",
+                "sha256:dc4ee2d4ee43251905f88637d5281a8d52e916a021384ec10758826f5cbae305",
+                "sha256:dddaae9b81c88083e6437de95c41e86823d150f4ee94bf24e158a4526cbead01",
+                "sha256:de7202ffe4d4a8c1e3cde1c03e01c1a3772c92858837e8f3879b497158e4cb44",
+                "sha256:e5bbe55e8552019c6463709b39634a5fc55e080d0827e2a3a11e18eb73f5cdbd",
+                "sha256:ea311d4ee9a8fa67f139c088ae9f905fcf0277d6cd75c310a21a88bf85e130f5",
+                "sha256:fecd5089c4be1bcc37c35e9aa678938d2888845a134dd016de457b942cf5a758"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.29"
+        },
+        "text-unidecode": {
+            "hashes": [
+                "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8",
+                "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"
+            ],
+            "version": "==1.3"
+        },
         "types-pyasn1": {
             "hashes": [
                 "sha256:5d54dcb33f69dd269071ca098e923ac20c5f03c814631fa7f3ed9ee035a5da3a",
@@ -1336,11 +1772,19 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
-                "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
+                "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0",
+                "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.10.0"
+            "version": "==4.11.0"
+        },
+        "xlrd": {
+            "hashes": [
+                "sha256:6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd",
+                "sha256:f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==2.0.1"
         }
     }
 }

--- a/src/api/qualicharge/api/v1/__init__.py
+++ b/src/api/qualicharge/api/v1/__init__.py
@@ -1,18 +1,19 @@
 """QualiCharge API v1."""
 
 import logging
-from typing import Annotated, Union
+from typing import Union
 
 from fastapi import FastAPI, Request, Security, status
 from fastapi.responses import JSONResponse
 
-from qualicharge.auth.models import IDToken, User
 from qualicharge.auth.oidc import get_token
 from qualicharge.exceptions import OIDCAuthenticationError, OIDCProviderException
 
+from .routers import auth, statique
+
 logger = logging.getLogger(__name__)
 
-app = FastAPI(title="QualiCharge API (v1)")
+app = FastAPI(title="QualiCharge API (v1)", dependencies=[Security(get_token)])
 
 
 @app.exception_handler(OIDCAuthenticationError)
@@ -27,8 +28,5 @@ async def authentication_exception_handler(
     )
 
 
-@app.get("/whoami")
-async def me(token: Annotated[IDToken, Security(get_token)]) -> User:
-    """A test endpoint to validate user authentication."""
-    logger.debug(f"{token=}")
-    return User(email=token.email)
+app.include_router(auth.router)
+app.include_router(statique.router)

--- a/src/api/qualicharge/api/v1/routers/__init__.py
+++ b/src/api/qualicharge/api/v1/routers/__init__.py
@@ -1,0 +1,1 @@
+"""QualiCharge API v1 routers."""

--- a/src/api/qualicharge/api/v1/routers/auth.py
+++ b/src/api/qualicharge/api/v1/routers/auth.py
@@ -1,0 +1,23 @@
+"""QualiCharge API v1 auth router."""
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Security
+
+from qualicharge.auth.models import IDToken, User
+from qualicharge.auth.oidc import get_token
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/auth",
+    tags=["Authentication"],
+)
+
+
+@router.get("/whoami")
+async def me(token: Annotated[IDToken, Security(get_token)]) -> User:
+    """A test endpoint to validate user authentication."""
+    logger.debug(f"{token=}")
+    return User(email=token.email)

--- a/src/api/qualicharge/api/v1/routers/statique.py
+++ b/src/api/qualicharge/api/v1/routers/statique.py
@@ -1,0 +1,62 @@
+"""QualiCharge API v1 statique router."""
+
+import logging
+from typing import Annotated, List
+
+from annotated_types import Len
+from fastapi import APIRouter, status
+from pydantic import BaseModel, computed_field
+
+from qualicharge.conf import settings
+from qualicharge.factories.static import StatiqueFactory
+from qualicharge.models.static import Statique
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/statique",
+    tags=["IRVE Statique schema"],
+)
+
+
+class StatiqueItemsCreatedResponse(BaseModel):
+    """API response model used when Statique items are created."""
+
+    message: str = "Statique items created"
+    items: List[Statique]
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def size(self) -> int:
+        """The number of items created."""
+        return len(self.items)
+
+
+BulkStatiqueList = Annotated[List[Statique], Len(2, settings.API_BULK_CREATE_MAX_SIZE)]
+
+
+@router.get("/")
+async def list() -> List[Statique]:
+    """List statique items."""
+    telephone_operateur = "0123456789"
+    id_station_itinerance = "ESZUNP8891687432127666088"
+    id_pdc_itinerance = "ESZUNE1111ER1"
+
+    return StatiqueFactory.batch(
+        size=10,
+        telephone_operateur=telephone_operateur,
+        id_station_itinerance=id_station_itinerance,
+        id_pdc_itinerance=id_pdc_itinerance,
+    )
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED)
+async def create(statique: Statique) -> StatiqueItemsCreatedResponse:
+    """Create a statique item."""
+    return StatiqueItemsCreatedResponse(items=[statique])
+
+
+@router.post("/bulk", status_code=status.HTTP_201_CREATED)
+async def bulk(statiques: BulkStatiqueList) -> StatiqueItemsCreatedResponse:
+    """Create a set of statique items."""
+    return StatiqueItemsCreatedResponse(items=statiques)

--- a/src/api/qualicharge/conf.py
+++ b/src/api/qualicharge/conf.py
@@ -88,6 +88,9 @@ class Settings(BaseSettings):
             + f"/{self.OIDC_CONFIGURATION_PATH}",
         )
 
+    # API
+    API_BULK_CREATE_MAX_SIZE: int = 10
+
     model_config = SettingsConfigDict(
         case_sensitive=True, env_nested_delimiter="__", env_prefix="QUALICHARGE_"
     )

--- a/src/api/qualicharge/factories/__init__.py
+++ b/src/api/qualicharge/factories/__init__.py
@@ -1,0 +1,1 @@
+"""QualiCharge factories."""

--- a/src/api/qualicharge/factories/static.py
+++ b/src/api/qualicharge/factories/static.py
@@ -1,0 +1,9 @@
+"""QualiCharge static factories."""
+
+from polyfactory.factories.pydantic_factory import ModelFactory
+
+from ..models.static import Statique
+
+
+class StatiqueFactory(ModelFactory[Statique]):
+    """Statique model factory."""

--- a/src/api/qualicharge/models/__init__.py
+++ b/src/api/qualicharge/models/__init__.py
@@ -1,0 +1,1 @@
+"""QualiCharge models."""

--- a/src/api/qualicharge/models/static.py
+++ b/src/api/qualicharge/models/static.py
@@ -1,0 +1,142 @@
+"""QualiCharge static models."""
+
+import json
+from enum import StrEnum
+from typing import Optional
+
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    EmailStr,
+    Field,
+    PlainSerializer,
+    PositiveFloat,
+    PositiveInt,
+    WithJsonSchema,
+)
+from pydantic.types import PastDate
+from pydantic_extra_types.coordinate import Coordinate
+from pydantic_extra_types.phone_numbers import PhoneNumber
+from typing_extensions import Annotated
+
+
+class ImplantationStationEnum(StrEnum):
+    """Statique.implantation_station field enum."""
+
+    VOIRIE = "Voirie"
+    PARKING_PUBLIC = "Parking public"
+    PARKING_PRIVE_USAGE_PUBLIC = "Parking privé à usage public"
+    PARKING_PRIVE_CLIENTELE = "Parking privé réservé à la clientèle"
+    STATION_RECHARGE_RAPIDE = "Station dédiée à la recharge rapide"
+
+
+class ConditionAccesEnum(StrEnum):
+    """Statique.condition_acces field enum."""
+
+    ACCESS_LIBRE = "Accès libre"
+    ACCESS_RESERVE = "Accès réservé"
+
+
+class AccessibilitePMREnum(StrEnum):
+    """Statique.accessibilite_pmr field enum."""
+
+    RESERVE_PMR = "Réservé PMR"
+    NON_RESERVE = "Accessible mais non réservé PMR"
+    NON_ACCESSIBLE = "Non accessible"
+    INCONNUE = "Accessibilité inconnue"
+
+
+class RaccordementEmum(StrEnum):
+    """Statique.raccordement field enum."""
+
+    DIRECT = "Direct"
+    INDIRECT = "Indirect"
+
+
+class FrenchPhoneNumber(PhoneNumber):
+    """A phone number with french defaults."""
+
+    default_region_code = "FR"
+
+
+# A pivot type to handle DataGouv coordinates de/serialization.
+DataGouvCoordinate = Annotated[
+    Coordinate,
+    # Input string format is: "[longitude: float, latitude: float]". It is converted to
+    # a reversed tuple (latitude: float, longitude: float) that will be used as
+    # Coordinate input.
+    BeforeValidator(
+        lambda x: tuple(reversed(json.loads(x))) if isinstance(x, str) else x
+    ),
+    # When serializing a coordinate we want a string array: "[long,lat]"
+    PlainSerializer(lambda x: f"[{x.longitude},{x.latitude}]", return_type=str),
+    # Document expected longitude/latitude order in the description
+    WithJsonSchema(
+        {
+            "type": "string",
+            "title": "coordonneesXY",
+            "description": (
+                "coordonneesXY is supposed to be a "
+                "'[longitude,latitude]' array string"
+            ),
+            "examples": [
+                "[12.3, 41.5]",
+            ],
+        },
+    ),
+]
+
+
+class Statique(BaseModel):
+    """IRVE static model."""
+
+    nom_amenageur: Optional[str]
+    siren_amenageur: Optional[Annotated[str, Field(pattern=r"^\d{9}$")]]
+    contact_amenageur: Optional[EmailStr]
+    nom_operateur: Optional[str]
+    contact_operateur: EmailStr
+    telephone_operateur: Optional[FrenchPhoneNumber]
+    nom_enseigne: str
+    id_station_itinerance: Annotated[
+        str, Field(pattern="(?:(?:^|,)(^[A-Z]{2}[A-Z0-9]{4,33}$|Non concerné))+$")
+    ]
+    id_station_local: Optional[str]
+    nom_station: str
+    implantation_station: ImplantationStationEnum
+    adresse_station: str
+    code_insee_commune: Optional[
+        Annotated[str, Field(pattern=r"^([013-9]\d|2[AB1-9])\d{3}$")]
+    ]
+    coordonneesXY: DataGouvCoordinate
+    nbre_pdc: PositiveInt
+    id_pdc_itinerance: Optional[
+        Annotated[
+            str, Field(pattern="(?:(?:^|,)(^[A-Z]{2}[A-Z0-9]{4,33}$|Non concerné))+$")
+        ]
+    ]
+    id_pdc_local: Optional[str]
+    puissance_nominale: PositiveFloat
+    prise_type_ef: bool
+    prise_type_2: bool
+    prise_type_combo_ccs: bool
+    prise_type_chademo: bool
+    prise_type_autre: bool
+    gratuit: Optional[bool]
+    paiement_acte: bool
+    paiement_cb: Optional[bool]
+    paiement_autre: Optional[bool]
+    tarification: Optional[str]
+    condition_acces: ConditionAccesEnum
+    reservation: bool
+    horaires: Annotated[
+        str, Field(pattern=r"(.*?)((\d{1,2}:\d{2})-(\d{1,2}:\d{2})|24/7)")
+    ]
+    accessibilite_pmr: AccessibilitePMREnum
+    restriction_gabarit: str
+    station_deux_roues: bool
+    raccordement: Optional[RaccordementEmum]
+    num_pdl: Optional[Annotated[str, Field(pattern=r"^\d{14}$")]]
+    date_mise_en_service: Optional[PastDate]
+    observations: Optional[str]
+    date_maj: PastDate
+    cable_t2_attache: Optional[bool]

--- a/src/api/tests/api/v1/routers/__init__.py
+++ b/src/api/tests/api/v1/routers/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the QualiCharge API routers."""

--- a/src/api/tests/api/v1/routers/test_auth.py
+++ b/src/api/tests/api/v1/routers/test_auth.py
@@ -1,4 +1,4 @@
-"""Tests for the QualiCharge API root routes."""
+"""Tests for the QualiCharge API auth router."""
 
 from datetime import datetime
 
@@ -18,14 +18,14 @@ def setup_function():
 
 def test_whoami_not_auth(client):
     """Test the whoami endpoint when user is not authenticated."""
-    response = client.get("/whoami")
+    response = client.get("/auth/whoami")
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert response.json() == {"detail": "Not authenticated"}
 
 
 def test_whoami_auth(client_auth):
     """Test the whoami endpoint when user is authenticated."""
-    response = client_auth.get("/whoami")
+    response = client_auth.get("/auth/whoami")
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {"email": "john@doe.com"}
 
@@ -57,7 +57,7 @@ def test_whoami_expired_signature(
         key="secret",
         algorithm="HS256",
     )
-    response = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+    response = client.get("/auth/whoami", headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert response.json() == {
         "message": "Authentication failed: Token signature expired"
@@ -90,7 +90,7 @@ def test_whoami_with_bad_token_claims(
         key="secret",
         algorithm="HS256",
     )
-    response = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+    response = client.get("/auth/whoami", headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert response.json() == {"message": "Authentication failed: Bad token claims"}
 
@@ -116,7 +116,7 @@ def test_whoami_jwt_decoding_error(
         ],
     )
     token = "faketoken"  # noqa: S105
-    response = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+    response = client.get("/auth/whoami", headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert response.json() == {
         "message": "Authentication failed: Unable to decode ID token"

--- a/src/api/tests/api/v1/routers/test_statique.py
+++ b/src/api/tests/api/v1/routers/test_statique.py
@@ -1,0 +1,86 @@
+"""Tests for the QualiCharge API statique router."""
+
+import json
+
+from fastapi import status
+
+from qualicharge.conf import settings
+from qualicharge.factories.static import StatiqueFactory
+
+
+def test_list(client_auth):
+    """Test the /statique/ list endpoint."""
+    response = client_auth.get("/statique/")
+    assert response.status_code == status.HTTP_200_OK
+    json_response = response.json()
+    expected_size = 10
+    assert len(json_response) == expected_size
+
+
+def test_create(client_auth):
+    """Test the /statique/ create endpoint."""
+    telephone_operateur = "0123456789"
+    id_station_itinerance = "ESZUNP8891687432127666088"
+    id_pdc_itinerance = "ESZUNE1111ER1"
+    data = StatiqueFactory.build(
+        telephone_operateur=telephone_operateur,
+        id_station_itinerance=id_station_itinerance,
+        id_pdc_itinerance=id_pdc_itinerance,
+    )
+
+    response = client_auth.post("/statique/", json=json.loads(data.model_dump_json()))
+    assert response.status_code == status.HTTP_201_CREATED
+    json_response = response.json()
+    assert json_response["message"] == "Statique items created"
+    assert json_response["size"] == 1
+    assert json_response["items"][0]["id_pdc_itinerance"] == id_pdc_itinerance
+
+
+def test_bulk(client_auth):
+    """Test the /statique/bulk create endpoint."""
+    telephone_operateur = "0123456789"
+    id_station_itinerance = "ESZUNP8891687432127666088"
+    id_pdc_itinerance = "ESZUNE1111ER1"
+    data = StatiqueFactory.batch(
+        size=2,
+        telephone_operateur=telephone_operateur,
+        id_station_itinerance=id_station_itinerance,
+        id_pdc_itinerance=id_pdc_itinerance,
+    )
+
+    payload = [json.loads(d.model_dump_json()) for d in data]
+    response = client_auth.post("/statique/bulk", json=payload)
+
+    assert response.status_code == status.HTTP_201_CREATED
+    json_response = response.json()
+    assert json_response["message"] == "Statique items created"
+    assert json_response["size"] == len(payload)
+    assert json_response["items"][0]["id_pdc_itinerance"] == id_pdc_itinerance
+    assert json_response["items"][1]["id_pdc_itinerance"] == id_pdc_itinerance
+
+
+def test_bulk_with_outbound_sizes(client_auth):
+    """Test the /statique/bulk create endpoint with a single or too many entries."""
+    telephone_operateur = "0123456789"
+    id_station_itinerance = "ESZUNP8891687432127666088"
+    id_pdc_itinerance = "ESZUNE1111ER1"
+
+    data = StatiqueFactory.build(
+        telephone_operateur=telephone_operateur,
+        id_station_itinerance=id_station_itinerance,
+        id_pdc_itinerance=id_pdc_itinerance,
+    )
+    response = client_auth.post(
+        "/statique/bulk", json=[json.loads(data.model_dump_json())]
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    data = StatiqueFactory.batch(
+        size=settings.API_BULK_CREATE_MAX_SIZE + 1,
+        telephone_operateur=telephone_operateur,
+        id_station_itinerance=id_station_itinerance,
+        id_pdc_itinerance=id_pdc_itinerance,
+    )
+    payload = [json.loads(d.model_dump_json()) for d in data]
+    response = client_auth.post("/statique/bulk", json=payload)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/src/api/tests/models/__init__.py
+++ b/src/api/tests/models/__init__.py
@@ -1,0 +1,1 @@
+"""QualiCharge models tests."""

--- a/src/api/tests/models/test_static.py
+++ b/src/api/tests/models/test_static.py
@@ -1,0 +1,58 @@
+"""QualiCharge static models tests."""
+
+from pydantic_extra_types.coordinate import Coordinate
+
+from qualicharge.factories.static import StatiqueFactory
+from qualicharge.models.static import Statique
+
+
+def test_statique_model_coordonneesXY():
+    """Test the Statique model coordonneesXY field."""
+    telephone_operateur = "0123456789"
+    id_station_itinerance = "ESZUNP8891687432127666088"
+    id_pdc_itinerance = "ESZUNE1111ER1"
+    longitude = 12.3
+    latitude = 16.2
+
+    # Expected raw input
+    record = StatiqueFactory.build(
+        telephone_operateur=telephone_operateur,
+        id_station_itinerance=id_station_itinerance,
+        id_pdc_itinerance=id_pdc_itinerance,
+        coordonneesXY=f"[{longitude},{latitude}]",
+    )
+    assert record.coordonneesXY.longitude == longitude
+    assert record.coordonneesXY.latitude == latitude
+
+    # Tuple input
+    record = StatiqueFactory.build(
+        telephone_operateur=telephone_operateur,
+        id_station_itinerance=id_station_itinerance,
+        id_pdc_itinerance=id_pdc_itinerance,
+        coordonneesXY=(latitude, longitude),
+    )
+    assert record.coordonneesXY.longitude == longitude
+    assert record.coordonneesXY.latitude == latitude
+
+    # Coordinate input
+    record = StatiqueFactory.build(
+        telephone_operateur=telephone_operateur,
+        id_station_itinerance=id_station_itinerance,
+        id_pdc_itinerance=id_pdc_itinerance,
+        coordonneesXY=Coordinate(latitude, longitude),
+    )
+    assert record.coordonneesXY.longitude == longitude
+    assert record.coordonneesXY.latitude == latitude
+
+
+def test_statique_model_json_schema():
+    """Test the Statique model generated JSON schema."""
+    schema = Statique.model_json_schema()
+
+    expected_description = (
+        "coordonneesXY is supposed to be a '[longitude,latitude]' array string"
+    )
+    assert schema["properties"]["coordonneesXY"]["type"] == "string"
+    assert schema["properties"]["coordonneesXY"]["title"] == "coordonneesXY"
+    assert schema["properties"]["coordonneesXY"]["description"] == expected_description
+    assert schema["properties"]["coordonneesXY"]["examples"] == ["[12.3, 41.5]"]


### PR DESCRIPTION
## Purpose

We need to support the official IRVE statique data schema [1] to create and fetch statique entries.

## Proposal

- [x] add Statique model & factory
- [x] add base auth/statique routers
- [x] add statique create / bulk endpoints
- [x] add statique test dataset
- [x] refine API endpoints response model
- [x] test API endpoints

## References

1. https://schema.data.gouv.fr/etalab/schema-irve-statique/2.3.1/documentation.html
