### PR TITLE
Add row permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - Link `OperationalUnit` to `Station` using AFIREV prefixes
 - Implement `User` and `Group` schemas
 - Implement `User` scopes (fine-tuned permissions)
+- Implement row permissions on API endpoints (given assigned operational units)
 
 ## [0.5.0] - 2024-05-15
 

--- a/src/api/qualicharge/auth/schemas.py
+++ b/src/api/qualicharge/auth/schemas.py
@@ -76,6 +76,15 @@ class User(BaseTimestampedSQLModel, table=True):
         dump["groups"] = [group.name for group in self.groups]
         return dump
 
+    @property
+    def operational_units(self):
+        """Get user's linked operational units."""
+        return [
+            operational_unit
+            for group in self.groups
+            for operational_unit in group.operational_units
+        ]
+
 
 class Group(BaseTimestampedSQLModel, table=True):
     """QualiCharge Group."""

--- a/src/api/qualicharge/factories/dynamic.py
+++ b/src/api/qualicharge/factories/dynamic.py
@@ -1,8 +1,10 @@
 """QualiCharge dynamic factories."""
 
 from polyfactory import Use
+from polyfactory.factories.dataclass_factory import DataclassFactory
 from polyfactory.factories.pydantic_factory import ModelFactory
 
+from ..fixtures.operational_units import prefixes
 from ..models.dynamic import SessionCreate, StatusCreate
 from ..schemas.core import Status
 from . import FrenchDataclassFactory, TimestampedSQLModelFactory
@@ -12,7 +14,8 @@ class SessionCreateFactory(ModelFactory[SessionCreate]):
     """Session model factory."""
 
     id_pdc_itinerance = Use(
-        FrenchDataclassFactory.__faker__.pystr_format, "FR###E######"
+        lambda: DataclassFactory.__random__.choice(prefixes)
+        + FrenchDataclassFactory.__faker__.pystr_format("E######")
     )
 
 
@@ -20,7 +23,8 @@ class StatusCreateFactory(ModelFactory[StatusCreate]):
     """Status model factory."""
 
     id_pdc_itinerance = Use(
-        FrenchDataclassFactory.__faker__.pystr_format, "FR###E######"
+        lambda: DataclassFactory.__random__.choice(prefixes)
+        + FrenchDataclassFactory.__faker__.pystr_format("E######")
     )
 
 

--- a/src/api/qualicharge/models/static.py
+++ b/src/api/qualicharge/models/static.py
@@ -13,11 +13,12 @@ from pydantic import (
     PositiveFloat,
     PositiveInt,
     WithJsonSchema,
+    model_validator,
 )
 from pydantic.types import PastDate
 from pydantic_extra_types.coordinate import Coordinate
 from pydantic_extra_types.phone_numbers import PhoneNumber
-from typing_extensions import Annotated
+from typing_extensions import Annotated, Self
 
 from .utils import ModelSchemaMixin
 
@@ -140,3 +141,15 @@ class Statique(ModelSchemaMixin, BaseModel):
     observations: Optional[str]
     date_maj: PastDate
     cable_t2_attache: Optional[bool]
+
+    @model_validator(mode="after")
+    def check_afirev_prefix(self) -> Self:
+        """Check that id_pdc_itinerance and id_station_itinerance prefixes match."""
+        if self.id_pdc_itinerance[:5] != self.id_station_itinerance[:5]:
+            raise ValueError(
+                (
+                    "AFIREV prefixes from id_station_itinerance and "
+                    "id_pdc_itinerance do not match"
+                )
+            )
+        return self

--- a/src/api/tests/api/v1/routers/test_statique.py
+++ b/src/api/tests/api/v1/routers/test_statique.py
@@ -1,17 +1,21 @@
 """Tests for the QualiCharge API static router."""
 
 import json
+from random import choice, sample
+from typing import cast
 
 import pytest
 from fastapi import status
+from sqlalchemy import Column as SAColumn
 from sqlalchemy import func
 from sqlmodel import select
 
-from qualicharge.auth.schemas import ScopesEnum
+from qualicharge.auth.factories import GroupFactory
+from qualicharge.auth.schemas import GroupOperationalUnit, ScopesEnum, User, UserGroup
 from qualicharge.conf import settings
 from qualicharge.factories.static import StatiqueFactory
-from qualicharge.schemas.core import Station
-from qualicharge.schemas.utils import save_statique, save_statiques
+from qualicharge.schemas.core import OperationalUnit, PointDeCharge, Station
+from qualicharge.schemas.utils import pdc_to_statique, save_statique, save_statiques
 
 
 @pytest.mark.parametrize(
@@ -32,23 +36,8 @@ def test_list_with_missing_scopes(client_auth):
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-@pytest.mark.parametrize(
-    "client_auth",
-    (
-        (True, {"is_superuser": True}),
-        (True, {"is_superuser": False, "scopes": [ScopesEnum.STATIC_READ]}),
-        (
-            True,
-            {
-                "is_superuser": False,
-                "scopes": [ScopesEnum.STATIC_READ, ScopesEnum.STATIC_CREATE],
-            },
-        ),
-    ),
-    indirect=True,
-)
-def test_list(client_auth, db_session):
-    """Test the /statique/ list endpoint."""
+def test_list_for_superuser(client_auth, db_session):
+    """Test the /statique/ list endpoint using a superuser."""
     # Empty response (no statiques exist)
     response = client_auth.get("/statique/")
     assert response.status_code == status.HTTP_200_OK
@@ -80,6 +69,142 @@ def test_list(client_auth, db_session):
         "items": [json.loads(statique.model_dump_json()) for statique in db_statiques],
         "size": 3,
         "total": 3,
+    }
+
+
+@pytest.mark.parametrize(
+    "client_auth",
+    (
+        (
+            True,
+            {
+                "is_superuser": False,
+                "email": "jane@doe.com",
+                "scopes": [ScopesEnum.STATIC_READ],
+            },
+        ),
+        (
+            True,
+            {
+                "is_superuser": False,
+                "email": "jane@doe.com",
+                "scopes": [ScopesEnum.STATIC_READ, ScopesEnum.STATIC_CREATE],
+            },
+        ),
+    ),
+    indirect=True,
+)
+def test_list_for_user(client_auth, db_session):
+    """Test the /statique/ list endpoint."""
+    GroupFactory.__session__ = db_session
+
+    # Get user requesting the server
+    user = db_session.exec(select(User).where(User.email == "jane@doe.com")).one()
+
+    # Create statiques
+    n_statiques = 20
+    list(save_statiques(db_session, StatiqueFactory.batch(n_statiques)))
+
+    # Select operational units linked to stations
+    operational_units = db_session.exec(
+        select(OperationalUnit)
+        .join_from(
+            Station, OperationalUnit, Station.operational_unit_id == OperationalUnit.id
+        )
+        .where(Station.operational_unit_id is not None)
+        .distinct()
+    ).all()
+
+    # Create groups linked to operational units and our user
+    n_groups = 2
+    groups = GroupFactory.create_batch_sync(n_groups)
+    selected_operational_units = sample(operational_units, n_groups)
+    for ou in selected_operational_units:
+        db_session.refresh(ou)
+    unselected_operational_units = [
+        operational_unit
+        for operational_unit in operational_units
+        if operational_unit not in selected_operational_units
+    ]
+    for group, operational_unit in zip(groups, selected_operational_units):
+        db_session.add(
+            GroupOperationalUnit(
+                group_id=group.id, operational_unit_id=operational_unit.id
+            )
+        )
+    # Attach one more operational unit to a group so that all user groups have one
+    # operational_unit except one that should have two
+    extra_operational_unit = choice(unselected_operational_units)  # noqa: S311
+    selected_operational_units += [extra_operational_unit]
+    db_session.add(
+        GroupOperationalUnit(
+            group_id=groups[0].id,
+            operational_unit_id=extra_operational_unit.id,
+        )
+    )
+    # Assign our user to created groups
+    for group in groups:
+        db_session.add(UserGroup(user_id=user.id, group_id=group.id))
+
+    # Expected PDC
+    selected_pdcs = db_session.exec(
+        select(PointDeCharge)
+        .join_from(PointDeCharge, Station, PointDeCharge.station_id == Station.id)
+        .join_from(
+            Station, OperationalUnit, Station.operational_unit_id == OperationalUnit.id
+        )
+        .where(
+            cast(SAColumn, OperationalUnit.id).in_(
+                ou.id for ou in selected_operational_units
+            )
+        )
+        .order_by(PointDeCharge.id_pdc_itinerance)
+    ).all()
+    expected_statiques = [pdc_to_statique(pdc) for pdc in selected_pdcs]
+
+    response = client_auth.get("/statique/")
+    assert response.status_code == status.HTTP_200_OK
+    json_response = response.json()
+    assert json_response == {
+        "limit": 10,
+        "offset": 0,
+        "previous": None,
+        "next": None,
+        "items": [
+            json.loads(statique.model_dump_json()) for statique in expected_statiques
+        ],
+        "size": len(expected_statiques),
+        "total": len(expected_statiques),
+    }
+
+
+@pytest.mark.parametrize(
+    "client_auth",
+    (
+        (
+            True,
+            {
+                "is_superuser": False,
+                "email": "jane@doe.com",
+                "scopes": [ScopesEnum.STATIC_READ],
+            },
+        ),
+    ),
+    indirect=True,
+)
+def test_list_for_user_with_no_operational_units(client_auth):
+    """Test the /statique/ list endpoint for a user with no assigned organization."""
+    response = client_auth.get("/statique/")
+    assert response.status_code == status.HTTP_200_OK
+    json_response = response.json()
+    assert json_response == {
+        "limit": 10,
+        "offset": 0,
+        "previous": None,
+        "next": None,
+        "items": [],
+        "size": 0,
+        "total": 0,
     }
 
 
@@ -143,15 +268,27 @@ def test_list_pagination(client_auth, db_session):
 )
 def test_read_with_missing_scopes(client_auth):
     """Test the /statique/{id_pdc_itinerance} list endpoint scopes."""
-    id_pdc_itinerance = "ESZUNE1111ER1"
+    id_pdc_itinerance = "FR911E1111ER1"
     response = client_auth.get(f"/statique/{id_pdc_itinerance}")
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_read_for_superuser(client_auth, db_session):
+    """Test the /statique/{id_pdc_itinerance} endpoint."""
+    id_pdc_itinerance = "FR911E1111ER1"
+    db_statique = save_statique(
+        db_session, StatiqueFactory.build(id_pdc_itinerance=id_pdc_itinerance)
+    )
+
+    response = client_auth.get(f"/statique/{id_pdc_itinerance}")
+    assert response.status_code == status.HTTP_200_OK
+    json_response = response.json()
+    assert json_response == json.loads(db_statique.model_dump_json())
 
 
 @pytest.mark.parametrize(
     "client_auth",
     (
-        (True, {"is_superuser": True, "scopes": []}),
         (True, {"is_superuser": False, "scopes": [ScopesEnum.STATIC_READ]}),
         (
             True,
@@ -163,12 +300,27 @@ def test_read_with_missing_scopes(client_auth):
     ),
     indirect=True,
 )
-def test_read(client_auth, db_session):
+def test_read_for_user(client_auth, db_session):
     """Test the /statique/{id_pdc_itinerance} endpoint."""
-    id_pdc_itinerance = "ESZUNE1111ER1"
+    GroupFactory.__session__ = db_session
+
+    # Create statique
+    id_pdc_itinerance = "FR911E1111ER1"
     db_statique = save_statique(
         db_session, StatiqueFactory.build(id_pdc_itinerance=id_pdc_itinerance)
     )
+
+    # User has no assigned operational units
+    response = client_auth.get(f"/statique/{id_pdc_itinerance}")
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    # Get user requesting the server
+    user = db_session.exec(select(User).where(User.email == "john@doe.com")).one()
+    # link him to an operational unit
+    operational_unit = db_session.exec(
+        select(OperationalUnit).where(OperationalUnit.code == "FR911")
+    ).one()
+    GroupFactory.create_sync(users=[user], operational_units=[operational_unit])
 
     response = client_auth.get(f"/statique/{id_pdc_itinerance}")
     assert response.status_code == status.HTTP_200_OK
@@ -178,7 +330,7 @@ def test_read(client_auth, db_session):
 
 def test_read_when_statique_does_not_exist(client_auth):
     """Test the /statique/{id_pdc_itinerance} endpoint when item does not exist."""
-    id_pdc_itinerance = "ESZUNE1111ER1"
+    id_pdc_itinerance = "FR911E1111ER1"
     response = client_auth.get(f"/statique/{id_pdc_itinerance}")
     assert response.status_code == status.HTTP_404_NOT_FOUND
     json_response = response.json()
@@ -199,7 +351,7 @@ def test_read_when_statique_does_not_exist(client_auth):
 )
 def test_create_with_missing_scope(client_auth):
     """Test the /statique/ create endpoint scopes."""
-    id_pdc_itinerance = "ESZUNE1111ER1"
+    id_pdc_itinerance = "FR911E1111ER1"
     data = StatiqueFactory.build(
         id_pdc_itinerance=id_pdc_itinerance,
     )
@@ -208,24 +360,9 @@ def test_create_with_missing_scope(client_auth):
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-@pytest.mark.parametrize(
-    "client_auth",
-    (
-        (True, {"is_superuser": True, "scopes": []}),
-        (True, {"is_superuser": False, "scopes": [ScopesEnum.STATIC_CREATE]}),
-        (
-            True,
-            {
-                "is_superuser": False,
-                "scopes": [ScopesEnum.STATIC_READ, ScopesEnum.STATIC_CREATE],
-            },
-        ),
-    ),
-    indirect=True,
-)
-def test_create(client_auth):
+def test_create_for_superuser(client_auth):
     """Test the /statique/ create endpoint."""
-    id_pdc_itinerance = "ESZUNE1111ER1"
+    id_pdc_itinerance = "FR911E1111ER1"
     data = StatiqueFactory.build(
         id_pdc_itinerance=id_pdc_itinerance,
     )
@@ -238,11 +375,54 @@ def test_create(client_auth):
     assert json_response["items"][0]["id_pdc_itinerance"] == id_pdc_itinerance
 
 
+@pytest.mark.parametrize(
+    "client_auth",
+    (
+        (True, {"is_superuser": False, "scopes": [ScopesEnum.STATIC_CREATE]}),
+        (
+            True,
+            {
+                "is_superuser": False,
+                "scopes": [ScopesEnum.STATIC_READ, ScopesEnum.STATIC_CREATE],
+            },
+        ),
+    ),
+    indirect=True,
+)
+def test_create_for_user(client_auth, db_session):
+    """Test the /statique/ create endpoint."""
+    GroupFactory.__session__ = db_session
+
+    # Create statique
+    id_pdc_itinerance = "FR911E1111ER1"
+    data = StatiqueFactory.build(
+        id_pdc_itinerance=id_pdc_itinerance,
+    )
+
+    # User has no assigned operational units
+    response = client_auth.post("/statique/", json=json.loads(data.model_dump_json()))
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    user = db_session.exec(select(User).where(User.email == "john@doe.com")).one()
+    # link him to an operational unit
+    operational_unit = db_session.exec(
+        select(OperationalUnit).where(OperationalUnit.code == "FR911")
+    ).one()
+
+    GroupFactory.create_sync(users=[user], operational_units=[operational_unit])
+    response = client_auth.post("/statique/", json=json.loads(data.model_dump_json()))
+    assert response.status_code == status.HTTP_201_CREATED
+    json_response = response.json()
+    assert json_response["message"] == "Statique items created"
+    assert json_response["size"] == 1
+    assert json_response["items"][0]["id_pdc_itinerance"] == id_pdc_itinerance
+
+
 def test_create_for_unknown_operational_unit(client_auth):
     """Test the /statique/ create endpoint."""
-    id_station_itinerance = "FRFOOP0001"
+    id_pdc_itinerance = "FRFOOE0001"
     data = StatiqueFactory.build(
-        id_station_itinerance=id_station_itinerance,
+        id_pdc_itinerance=id_pdc_itinerance,
     )
 
     response = client_auth.post("/statique/", json=json.loads(data.model_dump_json()))
@@ -268,7 +448,7 @@ def test_create_for_unknown_operational_unit(client_auth):
 )
 def test_update_with_missing_scope(client_auth, db_session):
     """Test the /statique/{id_pdc_itinerance} update endpoint."""
-    id_pdc_itinerance = "ESZUNE1111ER1"
+    id_pdc_itinerance = "FR911E1111ER1"
     db_statique = save_statique(
         db_session, StatiqueFactory.build(id_pdc_itinerance=id_pdc_itinerance)
     )
@@ -283,24 +463,9 @@ def test_update_with_missing_scope(client_auth, db_session):
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-@pytest.mark.parametrize(
-    "client_auth",
-    (
-        (True, {"is_superuser": True, "scopes": []}),
-        (True, {"is_superuser": False, "scopes": [ScopesEnum.STATIC_UPDATE]}),
-        (
-            True,
-            {
-                "is_superuser": False,
-                "scopes": [ScopesEnum.STATIC_READ, ScopesEnum.STATIC_UPDATE],
-            },
-        ),
-    ),
-    indirect=True,
-)
-def test_update(client_auth, db_session):
+def test_update_for_superuser(client_auth, db_session):
     """Test the /statique/{id_pdc_itinerance} update endpoint."""
-    id_pdc_itinerance = "ESZUNE1111ER1"
+    id_pdc_itinerance = "FR911E1111ER1"
     db_statique = save_statique(
         db_session, StatiqueFactory.build(id_pdc_itinerance=id_pdc_itinerance)
     )
@@ -317,40 +482,61 @@ def test_update(client_auth, db_session):
     assert json_response == json.loads(new_statique.model_dump_json())
 
 
-def test_update_for_unknown_operational_unit(client_auth, db_session):
-    """Test the statique update endpoint with unknown operational unit prefix."""
-    id_pdc_itinerance = "ESZUNE1111ER1"
-    db_statique = save_statique(
-        db_session,
-        StatiqueFactory.build(
-            id_pdc_itinerance=id_pdc_itinerance,
+@pytest.mark.parametrize(
+    "client_auth",
+    (
+        (True, {"is_superuser": False, "scopes": [ScopesEnum.STATIC_UPDATE]}),
+        (
+            True,
+            {
+                "is_superuser": False,
+                "scopes": [ScopesEnum.STATIC_READ, ScopesEnum.STATIC_UPDATE],
+            },
         ),
+    ),
+    indirect=True,
+)
+def test_update_for_user(client_auth, db_session):
+    """Test the /statique/{id_pdc_itinerance} update endpoint."""
+    GroupFactory.__session__ = db_session
+
+    # Create statique
+    id_pdc_itinerance = "FR911E1111ER1"
+    db_statique = save_statique(
+        db_session, StatiqueFactory.build(id_pdc_itinerance=id_pdc_itinerance)
+    )
+    new_statique = db_statique.model_copy(
+        update={"contact_oprateur": "john@doe.com"}, deep=True
     )
 
-    id_station_itinerance = "FRFOOP0001"
-    new_statique = db_statique.model_copy(
-        update={
-            "id_station_itinerance": id_station_itinerance,
-        },
-        deep=True,
+    # User has no assigned operational units
+    response = client_auth.put(
+        f"/statique/{id_pdc_itinerance}",
+        json=json.loads(new_statique.model_dump_json()),
     )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    # Get user requesting the server
+    user = db_session.exec(select(User).where(User.email == "john@doe.com")).one()
+    # link him to an operational unit
+    operational_unit = db_session.exec(
+        select(OperationalUnit).where(OperationalUnit.code == "FR911")
+    ).one()
+    GroupFactory.create_sync(users=[user], operational_units=[operational_unit])
 
     response = client_auth.put(
         f"/statique/{id_pdc_itinerance}",
         json=json.loads(new_statique.model_dump_json()),
     )
-    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.status_code == status.HTTP_200_OK
     json_response = response.json()
-    assert (
-        json_response["detail"]
-        == "OperationalUnit with code FRFOO should be created first"
-    )
+    assert json_response == json.loads(new_statique.model_dump_json())
 
 
 def test_update_on_wrong_id_pdc_itinerance(client_auth):
     """Test the /statique/{id_pdc_itinerance} update endpoint with a mismatching id."""
-    id_pdc_itinerance = "ESZUNE1111ER1"
-    mismatching_id_pdc_itinerance = "ESZUNE1111ER2"
+    id_pdc_itinerance = "FR911E1111ER1"
+    mismatching_id_pdc_itinerance = "FR911E1111ER2"
     statique = StatiqueFactory.build(id_pdc_itinerance=mismatching_id_pdc_itinerance)
 
     response = client_auth.put(
@@ -364,7 +550,7 @@ def test_update_on_wrong_id_pdc_itinerance(client_auth):
 
 def test_update_when_statique_does_not_exist(client_auth):
     """Test the /statique/{id_pdc_itinerance} update endpoint with wrong statique."""
-    id_pdc_itinerance = "ESZUNE1111ER1"
+    id_pdc_itinerance = "FR911E1111ER1"
     statique = StatiqueFactory.build(id_pdc_itinerance=id_pdc_itinerance)
 
     response = client_auth.put(
@@ -400,23 +586,8 @@ def test_bulk_with_missing_scope(client_auth):
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-@pytest.mark.parametrize(
-    "client_auth",
-    (
-        (True, {"is_superuser": True, "scopes": []}),
-        (True, {"is_superuser": False, "scopes": [ScopesEnum.STATIC_CREATE]}),
-        (
-            True,
-            {
-                "is_superuser": False,
-                "scopes": [ScopesEnum.STATIC_READ, ScopesEnum.STATIC_CREATE],
-            },
-        ),
-    ),
-    indirect=True,
-)
-def test_bulk(client_auth):
-    """Test the /statique/bulk create endpoint."""
+def test_bulk_for_superuser(client_auth):
+    """Test the /statique/bulk create endpoint (superuser)."""
     data = StatiqueFactory.batch(
         size=2,
     )
@@ -432,15 +603,58 @@ def test_bulk(client_auth):
     assert json_response["items"][1]["id_pdc_itinerance"] == data[1].id_pdc_itinerance
 
 
+@pytest.mark.parametrize(
+    "client_auth",
+    (
+        (True, {"is_superuser": False, "scopes": [ScopesEnum.STATIC_CREATE]}),
+        (
+            True,
+            {
+                "is_superuser": False,
+                "scopes": [ScopesEnum.STATIC_READ, ScopesEnum.STATIC_CREATE],
+            },
+        ),
+    ),
+    indirect=True,
+)
+def test_bulk_for_user(client_auth, db_session):
+    """Test the /statique/bulk create endpoint."""
+    GroupFactory.__session__ = db_session
+
+    data = [StatiqueFactory.build(id_pdc_itinerance=f"FR911E000{i}") for i in range(2)]
+    payload = [json.loads(d.model_dump_json()) for d in data]
+
+    # User has no assigned operational units
+    response = client_auth.post("/statique/bulk", json=payload)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    # Get user requesting the server
+    user = db_session.exec(select(User).where(User.email == "john@doe.com")).one()
+    # link him to an operational unit
+    operational_unit = db_session.exec(
+        select(OperationalUnit).where(OperationalUnit.code == "FR911")
+    ).one()
+    GroupFactory.create_sync(users=[user], operational_units=[operational_unit])
+
+    response = client_auth.post("/statique/bulk", json=payload)
+    assert response.status_code == status.HTTP_201_CREATED
+
+    json_response = response.json()
+    assert json_response["message"] == "Statique items created"
+    assert json_response["size"] == len(payload)
+    assert json_response["items"][0]["id_pdc_itinerance"] == data[0].id_pdc_itinerance
+    assert json_response["items"][1]["id_pdc_itinerance"] == data[1].id_pdc_itinerance
+
+
 def test_bulk_for_unknown_operational_unit(client_auth, db_session):
     """Test the /statique/bulk create endpoint for unknown operational unit."""
-    id_station_itinerance = "FRFOOP0001"
+    id_pdc_itinerance = "FRFOOP0001"
     data = StatiqueFactory.batch(
         size=2,
     )
     data += [
         StatiqueFactory.build(
-            id_station_itinerance=id_station_itinerance,
+            id_pdc_itinerance=id_pdc_itinerance,
         )
     ]
     data += StatiqueFactory.batch(
@@ -464,7 +678,7 @@ def test_bulk_for_unknown_operational_unit(client_auth, db_session):
 
 def test_bulk_with_outbound_sizes(client_auth):
     """Test the /statique/bulk create endpoint with a single or too many entries."""
-    id_pdc_itinerance = "ESZUNE1111ER1"
+    id_pdc_itinerance = "FR911E1111ER1"
 
     data = StatiqueFactory.build(
         id_pdc_itinerance=id_pdc_itinerance,

--- a/src/api/tests/models/test_static.py
+++ b/src/api/tests/models/test_static.py
@@ -65,3 +65,25 @@ def test_statique_model_json_schema():
     assert schema["properties"]["coordonneesXY"]["title"] == "coordonneesXY"
     assert schema["properties"]["coordonneesXY"]["description"] == expected_description
     assert schema["properties"]["coordonneesXY"]["examples"] == ["[12.3, 41.5]"]
+
+
+def test_statique_model_afirev_previx_check():
+    """Test the id_pdc/station_itinerance consistency."""
+    with pytest.raises(
+        ValueError,
+        match=(
+            "AFIREV prefixes from id_station_itinerance and "
+            "id_pdc_itinerance do not match"
+        ),
+    ):
+        StatiqueFactory.build(
+            id_pdc_itinerance="FR147E0042", id_station_itinerance="FR073P00001"
+        )
+
+    # Should be a valid usage
+    StatiqueFactory.build(
+        id_pdc_itinerance="FR073E0042", id_station_itinerance="FR073P00001"
+    )
+
+    # Default factory behavior should be consistent
+    StatiqueFactory.build()


### PR DESCRIPTION
## Purpose

We need to ensure that request user only have access to data link to its organization, _e.g._ its groups and related operational units.

## Proposal

- [x] add endpoints row-permissions filtering
- [x] fix broken tests
