### PR TITLE
⚰️(api) remove unused OIDCAuthenticationError

### DIFF
--- a/src/api/qualicharge/api/v1/__init__.py
+++ b/src/api/qualicharge/api/v1/__init__.py
@@ -8,7 +8,6 @@ from fastapi.responses import JSONResponse
 
 from qualicharge.exceptions import (
     AuthenticationError,
-    OIDCAuthenticationError,
     OIDCProviderException,
     PermissionDenied,
 )
@@ -33,11 +32,10 @@ async def authorization_exception_handler(
 
 
 @app.exception_handler(AuthenticationError)
-@app.exception_handler(OIDCAuthenticationError)
 @app.exception_handler(OIDCProviderException)
 async def authentication_exception_handler(
     request: Request,
-    exc: Union[AuthenticationError, OIDCAuthenticationError, OIDCProviderException],
+    exc: Union[AuthenticationError, OIDCProviderException],
 ):
     """Handle authentication errors."""
     return JSONResponse(

--- a/src/api/qualicharge/auth/oidc.py
+++ b/src/api/qualicharge/auth/oidc.py
@@ -100,7 +100,7 @@ def get_token(
         id_token (IDToken): Authenticated user ID token.
 
     Raises:
-        OIDCAuthenticationError
+        AuthenticationError
     """
     logger.debug(f"{token=}")
 

--- a/src/api/qualicharge/exceptions.py
+++ b/src/api/qualicharge/exceptions.py
@@ -17,10 +17,6 @@ class PermissionDenied(QualiChargeExceptionMixin, Exception):
     """Raised when authenticated user does not have required permissions."""
 
 
-class OIDCAuthenticationError(QualiChargeExceptionMixin, Exception):
-    """Raised when the OIDC authentication flow fails."""
-
-
 class OIDCProviderException(QualiChargeExceptionMixin, Exception):
     """Raised when the OIDC provider does not behave as expected."""
 


### PR DESCRIPTION
## Proposal

We now use the more generic AuthenticationError that works for both OIDC and OAuth2 password flows.
