### PR TITLE
🐛(project) fix version fetching in Sentry integration

### DIFF
--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,1 +1,3 @@
 """QualiCharge package root."""
+
+__version__ = "0.6.0"

--- a/src/api/qualicharge/api/__init__.py
+++ b/src/api/qualicharge/api/__init__.py
@@ -1,6 +1,5 @@
 """QualiCharge API root."""
 
-import importlib.metadata
 from contextlib import asynccontextmanager
 
 import sentry_sdk
@@ -9,6 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
 
+from .. import __version__
 from ..conf import settings
 from ..db import get_engine
 from .v1 import app as v1
@@ -25,7 +25,7 @@ async def lifespan(app: FastAPI):
             dsn=str(settings.SENTRY_DSN),
             enable_tracing=True,
             traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
-            release=importlib.metadata.version("qualicharge"),
+            release=__version__,
             environment=settings.EXECUTION_ENVIRONMENT,
             integrations=[
                 StarletteIntegration(),


### PR DESCRIPTION
## Purpose

Depending on the way QualiCharge is installed, the package version may not be available using importlib.metadata module. Leading to deployment failure during application's boot.

## Proposal

Let's use a less elegant but explicit way to declare/fetch project's version using a root `__version__` variable.
