### PR TITLE
🔧(docs) configure gitbook

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,1 @@
+root: ./docs/


### PR DESCRIPTION
## Purpose

We want our documentation to live in `./docs`.

## Proposal

- [x] add `.gitbook.yaml` configuration file
- [x] add `docs/` directory
