### PR TITLE
Improve database transactions handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - Document API authentication flow
 - Document API data schemas
 
+### Fixed
+
+- Improve database transactions in statique endpoints
+
 ## [0.8.0] - 2024-05-31
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ migrate-api:  ## run alembic database migrations for the api service
 create-superuser: ## create super user
 	@echo "Creating super user…"
 	@$(COMPOSE_RUN_API_PIPENV) python -m qualicharge create-user \
-		--username admin \
+		admin \
 		--email admin@example.com \
 		--password admin \
 		--is-active \

--- a/src/api/tests/api/v1/routers/test_statique.py
+++ b/src/api/tests/api/v1/routers/test_statique.py
@@ -418,8 +418,11 @@ def test_create_for_user(client_auth, db_session):
     assert json_response["items"][0]["id_pdc_itinerance"] == id_pdc_itinerance
 
 
-def test_create_for_unknown_operational_unit(client_auth):
+def test_create_for_unknown_operational_unit(client_auth, db_session):
     """Test the /statique/ create endpoint."""
+    n_pdc = db_session.exec(select(func.count(PointDeCharge.id))).one()
+    assert n_pdc == 0
+
     id_pdc_itinerance = "FRFOOE0001"
     data = StatiqueFactory.build(
         id_pdc_itinerance=id_pdc_itinerance,
@@ -432,6 +435,9 @@ def test_create_for_unknown_operational_unit(client_auth):
         json_response["detail"]
         == "OperationalUnit with code FRFOO should be created first"
     )
+
+    n_pdc = db_session.exec(select(func.count(PointDeCharge.id))).one()
+    assert n_pdc == 0
 
 
 @pytest.mark.parametrize(

--- a/src/api/tests/schemas/test_utils.py
+++ b/src/api/tests/schemas/test_utils.py
@@ -323,7 +323,7 @@ def test_save_statiques_number_of_database_queries(db_session):
             1,  # list already existing pdc
             6 * n_statiques,  # look for existing PDC-related entries
             6,  # create non existing PDC-related entries
-            2,  # update foreign keys
+            6,  # update foreign keys
             6 * n_statiques,  # PDC to statique
             2 * n_statiques,  # get station's linked operational unit and link it
         )


### PR DESCRIPTION
## Purpose

When creating a new statique entry using the API for a charging station with an unknown operational unit, we may register partial statique-related objects (_e.g._ a charge point but no station, etc.).

## Proposal

-   [x] Create a nested transaction in API routes creating statiques
-   [x] Never commit database transactions in a database utility
