### PR TITLE
👷(github) release client only when tagging client release

### DIFF
--- a/.github/workflows/python-packages.yml
+++ b/.github/workflows/python-packages.yml
@@ -1,8 +1,9 @@
 name: Publish python packages
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*-client'
 
 jobs:
   release-build:


### PR DESCRIPTION
## Proposal

Instead of failing during PyPI package publication, we now only build/publish the client python package when releasing the client and only the client.
