### PR TITLE
🔖(minor) bump release to 0.10.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.10.0] - 2024-07-01
+
 ### Changed
 
 - API dynamique bulk requests now returns the number of created items
@@ -132,7 +134,8 @@ and this project adheres to
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.9.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.10.0...main
+[0.10.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.6.0...v0.7.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -3,7 +3,7 @@
 #
 [project]
 name = "qualicharge"
-version = "0.9.0"
+version = "0.10.0"
 
 # Third party packages configuration
 [tool.coverage.run]

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"


### PR DESCRIPTION
### Changed

- API dynamique bulk requests now returns the number of created items
- Upgrade alembic to `1.13.2`
- Upgrade Pydantic to `2.7.4`
- Upgrade pydantic-settings to `2.3.4`
- Upgrade pydantic-extra-types to `2.8.2`
- Upgrade email-validator to `2.2.0`
- Upgrade sentry-sdk to `2.7.1`
