### PR TITLE
🐛(api) fix not thread-safe database session singleton

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 ### Fixed
 
 - Add relevant data examples for Swagger
+- Improve database session management
 
 ## [0.10.0] - 2024-07-01
 

--- a/src/api/qualicharge/db.py
+++ b/src/api/qualicharge/db.py
@@ -41,20 +41,6 @@ class Engine(metaclass=Singleton):
         return self._engine
 
 
-class Session(metaclass=Singleton):
-    """Database session singleton."""
-
-    _session: Optional[SMSession] = None
-
-    def get_session(self, engine: SAEngine) -> SMSession:
-        """Get active session or create a new one."""
-        if self._session is None:
-            logger.debug("Create new session")
-            self._session = SMSession(bind=engine)
-        logger.debug("Getting database session %s", self._session)
-        return self._session
-
-
 class SAQueryCounter:
     """Context manager to count SQLALchemy queries.
 
@@ -88,12 +74,9 @@ def get_engine() -> SAEngine:
 
 def get_session() -> Generator[SMSession, None, None]:
     """Get database session."""
-    session = Session().get_session(get_engine())
-    logger.debug("Getting session %s", session)
-    try:
+    with SMSession(bind=get_engine()) as session:
+        logger.debug("Getting session %s", session)
         yield session
-    finally:
-        session.close()
 
 
 def is_alive() -> bool:


### PR DESCRIPTION
## Purpose

The singleton pattern is not thread-safe leading to database session inconsistency during server heavy load (expired sessions, etc.)

See raised errors in SQLAlchemy docuementation: https://docs.sqlalchemy.org/en/20/errors.html#error-bhk3

## Proposal

Get a new session everytime it needs to be injected. Hope this won't create too many database connections.
