### PR TITLE
🔖(api:minor) bump release to 0.11.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.11.0] - 2024-08-14
+
 ### Added
 
 - Allow to configure `API_STATIQUE_PAGE_MAX_SIZE` and `API_STATIQUE_PAGE_SIZE`
@@ -156,7 +158,8 @@ and this project adheres to
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.10.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.11.0...main
+[0.11.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.7.0...v0.8.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -3,7 +3,7 @@
 #
 [project]
 name = "qualicharge"
-version = "0.10.0"
+version = "0.11.0"
 
 # Third party packages configuration
 [tool.coverage.run]

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"


### PR DESCRIPTION
### Added

- Allow to configure `API_STATIQUE_PAGE_MAX_SIZE` and `API_STATIQUE_PAGE_SIZE` independently from `API_STATIQUE_BULK_CREATE_MAX_SIZE`
- Store french administrative levels and geographic boundaries (shapes)

### Changed

- Upgrade fastapi to `0.112.0`
- Upgrade geoalchemy2 to `0.15.2`
- Upgrade pydantic-settings to `2.4.0`
- Upgrade PyJWT to `2.9.0`
- Upgrade sentry-sdk to `2.13.0`
- Upgrade SQLModel to `0.0.21`
- Switched to Psycopg 3.x

### Fixed

- Add relevant data examples for Swagger
- Improve database session management
- `PointDeCharge.id_pdc_itinerance` should be unique
