### PR TITLE
Add gzip compression support in bulk endpoints

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Implement GZip requests support (mostly for bulk endpoints)
 - Implement Pandas-based `StatiqueImporter`
 - CLI: add `import-statique` command
 

--- a/src/api/qualicharge/api/__init__.py
+++ b/src/api/qualicharge/api/__init__.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 import sentry_sdk
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import HTMLResponse
 from pyinstrument import Profiler
 from sentry_sdk.integrations.fastapi import FastApiIntegration
@@ -65,6 +66,11 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["GET"],
     allow_headers=["*"],
+)
+app.add_middleware(
+    GZipMiddleware,
+    minimum_size=settings.GZIP_MIDDLEWARE_MINIMUM_SIZE,
+    compresslevel=settings.GZIP_MIDDLEWARE_COMPRESSION_LEVEL,
 )
 
 # Mount v1 API

--- a/src/api/qualicharge/api/utils.py
+++ b/src/api/qualicharge/api/utils.py
@@ -1,0 +1,34 @@
+"""QualiCharge API utilities."""
+
+import gzip
+from typing import Callable
+
+from fastapi import Request, Response
+from fastapi.routing import APIRoute
+
+
+class GzipRequest(Request):
+    """Handle Gzip compressed requests."""
+
+    async def body(self) -> bytes:
+        """Decompress the body beforehand."""
+        if not hasattr(self, "_body"):
+            body = await super().body()
+            if "gzip" in self.headers.getlist("Content-Encoding"):
+                body = gzip.decompress(body)
+            self._body = body
+        return self._body
+
+
+class GzipRoute(APIRoute):
+    """Handle Gzip compressed requests in defined routes."""
+
+    def get_route_handler(self) -> Callable:
+        """Use the GzipRequest handler by default."""
+        original_route_handler = super().get_route_handler()
+
+        async def custom_route_handler(request: Request) -> Response:
+            request = GzipRequest(request.scope, request.receive)
+            return await original_route_handler(request)
+
+        return custom_route_handler

--- a/src/api/qualicharge/api/v1/__init__.py
+++ b/src/api/qualicharge/api/v1/__init__.py
@@ -16,6 +16,7 @@ from .routers import auth, dynamic, static
 
 logger = logging.getLogger(__name__)
 
+
 app = FastAPI(title="QualiCharge API (v1)")
 
 

--- a/src/api/qualicharge/api/v1/routers/dynamic.py
+++ b/src/api/qualicharge/api/v1/routers/dynamic.py
@@ -11,6 +11,7 @@ from sqlalchemy import func
 from sqlalchemy.schema import Column as SAColumn
 from sqlmodel import Session, join, select
 
+from qualicharge.api.utils import GzipRoute
 from qualicharge.auth.oidc import get_user
 from qualicharge.auth.schemas import ScopesEnum, User
 from qualicharge.conf import settings
@@ -30,6 +31,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(
     prefix="/dynamique",
     tags=["IRVE Dynamique"],
+    route_class=GzipRoute,
 )
 
 BulkStatusCreateList = Annotated[

--- a/src/api/qualicharge/api/v1/routers/static.py
+++ b/src/api/qualicharge/api/v1/routers/static.py
@@ -23,6 +23,7 @@ from sqlalchemy.exc import IntegrityError, OperationalError, ProgrammingError
 from sqlalchemy.schema import Column as SAColumn
 from sqlmodel import Session, select
 
+from qualicharge.api.utils import GzipRoute
 from qualicharge.auth.oidc import get_user
 from qualicharge.auth.schemas import ScopesEnum, User
 from qualicharge.conf import settings
@@ -47,9 +48,11 @@ from qualicharge.schemas.utils import (
 
 logger = logging.getLogger(__name__)
 
+
 router = APIRouter(
     prefix="/statique",
     tags=["IRVE Statique"],
+    route_class=GzipRoute,
 )
 
 

--- a/src/api/qualicharge/conf.py
+++ b/src/api/qualicharge/conf.py
@@ -22,6 +22,10 @@ class Settings(BaseSettings):
         "http://localhost:8010",
     ]
 
+    # Middlewares
+    GZIP_MIDDLEWARE_MINIMUM_SIZE: int = 1000
+    GZIP_MIDDLEWARE_COMPRESSION_LEVEL: int = 5
+
     # API Core Root path
     # (used at least by everything that is alembic-configuration-related)
     ROOT_PATH: Path = Path(__file__).parent

--- a/src/client/CHANGELOG.md
+++ b/src/client/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Changed
 
+- Compress requests for bulk endpoints
 - Upgrade Pydantic to `2.7.4`
 - Upgrade pydantic-settings to `2.4.0`
 - Upgrade typer to `0.12.5`

--- a/src/client/qcc/conf.py
+++ b/src/client/qcc/conf.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
 
     # API usage
     API_BULK_CREATE_MAX_SIZE: int = 10
+    GZIP_COMPRESSION_LEVEL: int = 9
 
     model_config = SettingsConfigDict(
         case_sensitive=True,

--- a/src/client/tests/endpoints/test_dynamic.py
+++ b/src/client/tests/endpoints/test_dynamic.py
@@ -237,6 +237,23 @@ async def test_dynamic_status_bulk(client, httpx_mock):
 
 
 @pytest.mark.anyio
+async def test_dynamic_status_bulk_gzip_compression(client, httpx_mock):
+    """Test the /dynamique/status/bulk endpoint request is compressed."""
+    status = Status(client)
+
+    total = 5
+    httpx_mock.add_response(
+        method="POST",
+        url="http://example.com/api/v1/dynamique/status/bulk",
+        match_headers={"Content-Encoding": "gzip"},
+        json={"size": total},
+    )
+
+    statuses = [{"id_pdc_itinerance": f"FRS63E00{x:02d}"} for x in range(total)]
+    assert await status.bulk(statuses, chunk_size=10) == total
+
+
+@pytest.mark.anyio
 async def test_dynamic_session_create(client, httpx_mock):
     """Test the /dynamique/session endpoint call."""
     session = Session(client)
@@ -324,3 +341,20 @@ async def test_dynamic_session_bulk(client, httpx_mock):
         await session.bulk(sessions, chunk_size=chunk_size, ignore_errors=True)
         == chunk_size
     )
+
+
+@pytest.mark.anyio
+async def test_dynamic_session_bulk_gzip_compression(client, httpx_mock):
+    """Test the /dynamique/session/bulk endpoint request is compressed."""
+    session = Session(client)
+
+    total = 5
+    httpx_mock.add_response(
+        method="POST",
+        url="http://example.com/api/v1/dynamique/session/bulk",
+        match_headers={"Content-Encoding": "gzip"},
+        json={"size": total},
+    )
+
+    sessions = [{"id_pdc_itinerance": f"FRS63E00{x:02d}"} for x in range(total)]
+    assert await session.bulk(sessions, chunk_size=10) == total

--- a/src/client/tests/endpoints/test_static.py
+++ b/src/client/tests/endpoints/test_static.py
@@ -196,3 +196,20 @@ async def test_static_bulk(client, httpx_mock):
         await static.bulk(statiques, chunk_size=chunk_size, ignore_errors=True)
         == chunk_size
     )
+
+
+@pytest.mark.anyio
+async def test_static_bulk_gzip_compression(client, httpx_mock):
+    """Test the /statique/bulk endpoint request is compressed."""
+    static = Static(client)
+
+    total = 5
+    httpx_mock.add_response(
+        method="POST",
+        url="http://example.com/api/v1/statique/bulk",
+        match_headers={"Content-Encoding": "gzip"},
+        json={"size": total},
+    )
+
+    statiques = [{"id_pdc_itinerance": f"FRS63E00{x:02d}"} for x in range(total)]
+    assert await static.bulk(statiques, chunk_size=10) == total


### PR DESCRIPTION
## Purpose

We need to limit bandwidth usage when dealing with heavy payload, particularly for `/bulk` endpoints now accepting a huge number of items.

## Proposal

- [x] API: implement gzipped requests + responses support
- [x] Client: compress requests to bulk endpoints
