### PR TITLE
🔖(client:minor) bump release to 0.2.0

### DIFF
--- a/src/client/CHANGELOG.md
+++ b/src/client/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-09-05
+
 ### Changed
 
 - Compress requests for bulk endpoints
@@ -23,5 +25,6 @@ and this project adheres to
 - Add `QCC` QualiCharge API client
 - Add `qcc` CLI
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.1.0-cli...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.2.0-cli...main
+[0.2.0]: https://github.com/MTES-MCT/qualicharge/releases/tag/v0.1.0-cli...v0.2.0-cli
 [0.1.0]: https://github.com/MTES-MCT/qualicharge/releases/tag/v0.1.0-cli

--- a/src/client/pyproject.toml
+++ b/src/client/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qualicharge-client"
-version = "0.1.0"
+version = "0.2.0"
 description = "A python client and CLI for the QualiCharge API"
 authors = ["Julien Maupetit <julien@maupetit.net>"]
 license = "MIT"


### PR DESCRIPTION
### Changed

- Compress requests for bulk endpoints
- Upgrade Pydantic to `2.7.4`
- Upgrade pydantic-settings to `2.4.0`
- Upgrade typer to `0.12.5`
- Upgrade httpx to `0.27.2`
