### PR TITLE
🔖(api:minor) bump release to 0.12.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.12.0] - 2024-09-05
+
 ### Added
 
 - Implement GZip requests support (mostly for bulk endpoints)
@@ -175,7 +177,8 @@ and this project adheres to
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.11.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.12.0...main
+[0.12.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.8.0...v0.9.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -3,7 +3,7 @@
 #
 [project]
 name = "qualicharge"
-version = "0.11.0"
+version = "0.12.0"
 
 # Third party packages configuration
 [tool.coverage.run]

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"


### PR DESCRIPTION
### Added

- Implement GZip requests support (mostly for bulk endpoints)
- Implement Pandas-based `StatiqueImporter`
- CLI: add `import-statique` command

### Changed

- Require the `code_insee_commune` field in both the `Statique` model and the `Localisation` schema
- Allow to submit a single item in bulk endpoints
- Add create or update support for the `/statique/bulk` endpoints (with improved performances)
- Upgrade fastapi to `0.112.2`
- Upgrade typer to `0.12.5`
- Upgrade sqlmodel to `0.0.22`
