### PR TITLE
👷(github) fix Pipenv cache issues

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pipenv"
+          cache-dependency-path: "src/api/Pipfile.lock"
       - name: Install dependencies
         run: |
           cd src/api
@@ -44,6 +45,7 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pipenv"
+          cache-dependency-path: "src/api/Pipfile.lock"
       - name: Lint with Black
         run: pipenv run black qualicharge tests
       - name: Lint with Ruff
@@ -82,6 +84,7 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pipenv"
+          cache-dependency-path: "src/api/Pipfile.lock"
       - name: Run migrations
         run: pipenv run alembic -c qualicharge/alembic.ini upgrade head
         env:
@@ -126,6 +129,7 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pipenv"
+          cache-dependency-path: "src/api/Pipfile.lock"
       - name: Test with pytest
         run: pipenv run pytest
         env:

--- a/.github/workflows/prefect.yml
+++ b/.github/workflows/prefect.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pipenv"
+          cache-dependency-path: "src/prefect/Pipfile.lock"
       - name: Install dependencies
         run: |
           cd src/prefect
@@ -44,6 +45,7 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pipenv"
+          cache-dependency-path: "src/prefect/Pipfile.lock"
       - name: Lint with Black
         run: pipenv run black indicators tests
       - name: Lint with Ruff
@@ -87,5 +89,6 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pipenv"
+          cache-dependency-path: "src/prefect/Pipfile.lock"
       - name: Test with pytest
         run: pipenv run pytest


### PR DESCRIPTION
## Purpose

Since we've added Prefect CI, we encounter cache-related issues: the CI behaves as if no dependency were installed and cached.

## Proposal

As we are dealing with a mono-repository project, we suspect that we need to explicitly set the cache dependency path per service.
