### PR TITLE
🔖(api:minor) bump release to 0.13.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.13.0] - 2024-10-11
+
 ### Fixed
 
 - Migrate administrative boundaries tables schema and data
@@ -200,7 +202,8 @@ and this project adheres to
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.12.1...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.13.0...main
+[0.13.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/MTES-MCT/qualicharge/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.10.0...v0.11.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -3,7 +3,7 @@
 #
 [project]
 name = "qualicharge"
-version = "0.12.1"
+version = "0.13.0"
 
 # Third party packages configuration
 [tool.coverage.run]

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.12.1"
+__version__ = "0.13.0"


### PR DESCRIPTION
### Fixed

- Migrate administrative boundaries tables schema and data

### Changed

- Add geo-boundaries population and area fields
- Upgrade alembic to `1.13.3`
- Upgrade fastapi to `0.115.0`
- Upgrade pandas to `2.2.3`
- Upgrade Psycopg to `3.2.3`
- Upgrade Pydantic to `2.9.1`
- Upgrade pydantic-settings to `2.5.2`
- Upgrade pyinstrument to `4.7.3`
- Upgrade python-multipart to `0.0.12`
- Upgrade sentry-sdk to `74.1.2`
