### PR TITLE
🗃️(api) allow database connections pool configuration

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 - Allow uvicorn workers configuration in start script using the
   `QUALICHARGE_UVICORN_WORKERS` environment variable
+- Make database engine connections pool size configurable
+  (`DB_CONNECTION_POOL_SIZE` and `DB_CONNECTION_MAX_OVERFLOW` settings)
 
 ### Changed
 

--- a/src/api/qualicharge/conf.py
+++ b/src/api/qualicharge/conf.py
@@ -40,6 +40,8 @@ class Settings(BaseSettings):
     DB_USER: str = "qualicharge"
     DB_PASSWORD: str = "pass"
     DB_PORT: int = 5432
+    DB_CONNECTION_POOL_SIZE: int = 5
+    DB_CONNECTION_MAX_OVERFLOW: int = 10
     TEST_DB_NAME: str = "test-qualicharge-api"
 
     @computed_field  # type: ignore[misc]

--- a/src/api/qualicharge/db.py
+++ b/src/api/qualicharge/db.py
@@ -32,18 +32,31 @@ class Engine(metaclass=Singleton):
 
     _engine: Optional[SAEngine] = None
 
-    def get_engine(self, url: PostgresDsn, echo: bool = False) -> SAEngine:
+    def get_engine(
+        self,
+        url: PostgresDsn,
+        echo: bool = False,
+        pool_size: int = 10,
+        max_overflow: int = 20,
+    ) -> SAEngine:
         """Get created engine or create a new one."""
         if self._engine is None:
             logger.debug("Create a new engine")
-            self._engine = create_engine(str(url), echo=echo)
+            self._engine = create_engine(
+                str(url), echo=echo, pool_size=pool_size, max_overflow=max_overflow
+            )
         logger.debug("Getting database engine %s", self._engine)
         return self._engine
 
 
 def get_engine() -> SAEngine:
     """Get database engine."""
-    return Engine().get_engine(url=settings.DATABASE_URL, echo=settings.DEBUG)
+    return Engine().get_engine(
+        url=settings.DATABASE_URL,
+        echo=settings.DEBUG,
+        pool_size=settings.DB_CONNECTION_POOL_SIZE,
+        max_overflow=settings.DB_CONNECTION_MAX_OVERFLOW,
+    )
 
 
 def get_session() -> Generator[SMSession, None, None]:


### PR DESCRIPTION
## Purpose

Default connection pool configuration values are particularily low for a production instance. One may want to adapt those given environment constraints and expected requests per seconds.

## Proposal

- [x] add `DB_CONNECTION_POOL_SIZE` and `DB_CONNECTION_MAX_OVERFLOW` settings
