### PR TITLE
✨(api) add `--json` option to the `read-user` CLI command

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
   `QUALICHARGE_UVICORN_WORKERS` environment variable
 - Make database engine connections pool size configurable
   (`DB_CONNECTION_POOL_SIZE` and `DB_CONNECTION_MAX_OVERFLOW` settings)
+- Add a `--json` flag to the `read-user` CLI command
 
 ### Changed
 

--- a/src/api/qualicharge/cli.py
+++ b/src/api/qualicharge/cli.py
@@ -216,12 +216,20 @@ def list_users(ctx: typer.Context):
 
 
 @app.command()
-def read_user(ctx: typer.Context, username: str):
+def read_user(ctx: typer.Context, username: str, json: bool = False):
     """Read detailled user informations."""
     session: SMSession = ctx.obj
 
     db_user = session.exec(select(User).where(User.username == username)).one_or_none()
-    print(db_user)
+
+    if db_user is None:
+        print(f"[bold red]User {username} does not exist![/bold red]")
+        raise typer.Exit(1)
+
+    out = str(db_user)
+    if json:
+        out = db_user.model_dump_json(indent=2)
+    print(out)
 
 
 @app.command()


### PR DESCRIPTION
## Purpose

It's usefull to serialize command output in JSON so that we can pipe the result in a `jq` black magic.

## Proposal

- [x] add `--json` flag to the `read-user` command
