### PR TITLE
🔖(api:minor) bump release to 0.14.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.14.0] - 2024-11-15
+
 ### Added
 
 - Allow uvicorn workers configuration in start script using the
@@ -226,7 +228,8 @@ and this project adheres to
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.13.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.14.0...main
+[0.14.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/MTES-MCT/qualicharge/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.11.0...v0.12.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -3,7 +3,7 @@
 #
 [project]
 name = "qualicharge"
-version = "0.13.0"
+version = "0.14.0"
 
 # Third party packages configuration
 [tool.coverage.run]

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"


### PR DESCRIPTION
### Added

- Allow uvicorn workers configuration in start script using the `QUALICHARGE_UVICORN_WORKERS` environment variable
- Make database engine connections pool size configurable (`DB_CONNECTION_POOL_SIZE` and `DB_CONNECTION_MAX_OVERFLOW` settings)
- Add a `--json` flag to the `read-user` CLI command

### Changed

- Upgrade alembic to `1.14.0`
- Upgrade fastapi to `0.115.4`
- Upgrade pyarrow to `18.0.0`
- Upgrade pydantic-extras-types to `2.10.0`
- Upgrade pydantic-settings to `2.6.1`
- Upgrade pyinstrument to `5.0.0`
- Upgrade python-multipart to `0.0.17`
- Upgrade sentry-sdk to `2.18.0`
- Set fk to `NULL` when related table entry is deleted for the `Station` table

### Fixed

- Add missing City / Department table foreign key constraints
