### PR TITLE
🔇(api) send DB query details on error only in debug mode

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - Upgrade geoalchemy2 to `0.16.0`
 - Upgrade pyjwt to `2.10.0`
 - Upgrade setuptools to `75.5.0`
+- Send DB query details on Statique API errors only in debug mode
 
 ## [0.14.0] - 2024-11-15
 


### PR DESCRIPTION
## Purpose

We don't want to provide debug information for all our users as it should only be used in development.

## Proposal

- [x] add sql-related debug info when DEBUG mode is activated
