### PR TITLE
🗃️(api) make `num_pdl` field less provider-specific

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 - Upgrade pyjwt to `2.10.0`
 - Upgrade setuptools to `75.5.0`
 - Send DB query details on Statique API errors only in debug mode
+- Move `num_pdl` field to a 64-chars string
 
 ## [0.14.0] - 2024-11-15
 

--- a/src/api/qualicharge/models/static.py
+++ b/src/api/qualicharge/models/static.py
@@ -165,7 +165,7 @@ class Statique(ModelSchemaMixin, BaseModel):
     restriction_gabarit: str
     station_deux_roues: bool
     raccordement: Optional[RaccordementEnum]
-    num_pdl: Optional[Annotated[str, Field(pattern=r"^\d{14}$")]]
+    num_pdl: Optional[Annotated[str, Field(max_length=64)]]
     date_mise_en_service: Optional[PastDate]
     observations: Optional[str]
     date_maj: PastDate

--- a/src/api/qualicharge/schemas/core.py
+++ b/src/api/qualicharge/schemas/core.py
@@ -236,7 +236,7 @@ class Station(BaseTimestampedSQLModel, table=True):
     horaires: str = Field(regex=r"(.*?)((\d{1,2}:\d{2})-(\d{1,2}:\d{2})|24/7)")
     station_deux_roues: bool
     raccordement: Optional[RaccordementEnum]
-    num_pdl: Optional[str] = Field(regex=r"^\d{14}$")
+    num_pdl: Optional[str] = Field(max_length=64)
     date_maj: PastDate = Field(sa_type=Date)
     date_mise_en_service: Optional[PastDate] = Field(sa_type=Date)
 

--- a/src/api/tests/models/test_static.py
+++ b/src/api/tests/models/test_static.py
@@ -94,3 +94,15 @@ def test_statique_model_afirev_previx_check():
 
     # Default factory behavior should be consistent
     StatiqueFactory.build()
+
+
+def test_statique_model_num_pdl():
+    """Test statique model accept various num_pdf patterns."""
+    statique = StatiqueFactory.build(num_pdl="0" * 14)
+    assert statique.num_pdl == "0" * 14
+
+    statique = StatiqueFactory.build(num_pdl="66666/E2/0000001")
+    assert statique.num_pdl == "66666/E2/0000001"
+
+    with pytest.raises(ValueError, match="String should have at most 64 characters"):
+        StatiqueFactory.build(num_pdl="a" * 65)


### PR DESCRIPTION
## Purpose

The num_pdl field is required to be a 14-characters string for Enedis (French provider) and forbids defining a num_pdl for other providers.  Let's move to a more generic 64-chars string.

## Proposal

- [x] update `Statique` model
- [x] update `Station` schema
