### PR TITLE
🐛(api) update Pipenv lock file

### DIFF
--- a/src/api/Pipfile.lock
+++ b/src/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "088b73eb95a7a4c5b1ead8a5e3fc5860f53d5b65a3acf850a27b09773e136c8d"
+            "sha256": "6ae18042da690979f5612476ebef004f6f26483778ab84e915b18d7dc7bad217"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
## Purpose

An out-dated Pipenv lock file breaks the build and underlying deployment.

## Proposal

- [x] update Pipenv lock file checksum
