### PR TITLE
🔖(api:minor) bump release to 0.15.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.15.0] - 2024-11-21
+
 ### Changed
 
 - Upgrade fastapi to `0.115.5`
@@ -238,7 +240,8 @@ and this project adheres to
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.14.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.15.0...main
+[0.15.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/MTES-MCT/qualicharge/compare/v0.12.0...v0.12.1

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -3,7 +3,7 @@
 #
 [project]
 name = "qualicharge"
-version = "0.14.0"
+version = "0.15.0"
 
 # Third party packages configuration
 [tool.coverage.run]

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"


### PR DESCRIPTION
### Changed

- Upgrade fastapi to `0.115.5`
- Upgrade geoalchemy2 to `0.16.0`
- Upgrade pyjwt to `2.10.0`
- Upgrade setuptools to `75.5.0`
- Send DB query details on Statique API errors only in debug mode
- Move `num_pdl` field to a 64-chars string
- Return created objects UUIDs for statuses and sessions
