### PR TITLE
🌱(dashboard) add consent development fixtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,6 +332,7 @@ seed-dashboard: ## seed dashboard
 	@$(COMPOSE_UP) --wait postgresql
 	@echo "Seeding dashboard…"#
 	@bin/manage loaddata dashboard/fixtures/dsfr_fixtures.json
+	@bin/manage seed_consent
 .PHONY: seed-dashboard
 
 # -- API

--- a/src/dashboard/apps/consent/fixtures/__init__.py
+++ b/src/dashboard/apps/consent/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Dashboard consent app fixtures."""

--- a/src/dashboard/apps/consent/fixtures/consent.py
+++ b/src/dashboard/apps/consent/fixtures/consent.py
@@ -1,0 +1,41 @@
+"""Dashboard consent dev fixture."""
+
+from apps.auth.factories import UserFactory
+from apps.consent.factories import ConsentFactory
+from apps.core.factories import DeliveryPointFactory, EntityFactory
+from apps.core.models import DeliveryPoint
+
+
+def seed_consent():
+    """Creates development fixtures for consent management system.
+
+    This function performs the following tasks:
+    1. Creates three user instances using UserFactory.
+    2. Creates three entity instances with assigned users using EntityFactory.
+    3. Creates multiple delivery points for each entity using DeliveryPointFactory.
+    4. Generates consent instances for each delivery point using ConsentFactory.
+    """
+    # create users
+    user1 = UserFactory(username="user1")
+    user2 = UserFactory(username="user2")
+    user3 = UserFactory(username="user3")
+    user4 = UserFactory(username="user4")
+    user5 = UserFactory(username="user5")
+
+    # create entities
+    entity1 = EntityFactory(users=(user1,))
+    entity2 = EntityFactory(users=(user2, user4))
+    entity3 = EntityFactory(users=(user3,), proxy_for=(entity1, entity2))
+    entity4 = EntityFactory(users=(user5,))
+
+
+    # create delivery points
+    for i in range(1, 4):
+        DeliveryPointFactory(provider_assigned_id=f"entity1_{i}", entity=entity1)
+        DeliveryPointFactory(provider_assigned_id=f"entity2_{i}", entity=entity2)
+        DeliveryPointFactory(provider_assigned_id=f"entity3_{i}", entity=entity3)
+        DeliveryPointFactory(provider_assigned_id=f"entity4_{i}", entity=entity4)
+
+    # create awaiting consents
+    for delivery_point in DeliveryPoint.objects.all():
+        ConsentFactory(delivery_point=delivery_point, created_by=user1)

--- a/src/dashboard/apps/consent/management/__init__.py
+++ b/src/dashboard/apps/consent/management/__init__.py
@@ -1,0 +1,1 @@
+"""Dashboard consent app management."""

--- a/src/dashboard/apps/consent/management/commands/__init__.py
+++ b/src/dashboard/apps/consent/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Dashboard consent app management commands."""

--- a/src/dashboard/apps/consent/management/commands/seed_consent.py
+++ b/src/dashboard/apps/consent/management/commands/seed_consent.py
@@ -1,0 +1,19 @@
+"""Consent management commands."""
+
+from django.core.management.base import BaseCommand
+
+from apps.consent.fixtures.consent import seed_consent
+
+
+class Command(BaseCommand):
+    """Create development fixtures for the consent management system."""
+
+    help = __doc__
+
+    def handle(self, *args, **kwargs):
+        """Executes the command for creating development consent fixtures."""
+        self.stdout.write(self.style.NOTICE("Seeding database with consents..."))
+        seed_consent()
+        self.stdout.write(
+            self.style.SUCCESS("Done.")
+        )


### PR DESCRIPTION
## Purpose

Add fixtures to streamline the development of consent management features

## Add

- [x] Create development fixtures with factory boy
- [x] Create a Django command to run the fixtures
- [x] Add Django command to Makefile seed-dashboard 