### PR TITLE
Forbid /statique/ POST usage for an existing PDC

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 ### Fixed
 
 - Allow `date_maj` field to be set to "today"
+- Forbid `/static/` POST usage for an existing PDC
 
 ## [0.15.0] - 2024-11-21
 

--- a/src/api/qualicharge/api/v1/routers/static.py
+++ b/src/api/qualicharge/api/v1/routers/static.py
@@ -241,6 +241,20 @@ async def create(
             "You cannot submit data for an organization you are not assigned to"
         )
 
+    # Check if the Point Of Charge does not already exist
+    if (
+        session.exec(
+            select(func.count(cast(SAColumn, PointDeCharge.id))).where(
+                PointDeCharge.id_pdc_itinerance == statique.id_pdc_itinerance
+            )
+        ).one()
+        > 0
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Point of charge {statique.id_pdc_itinerance} already exists",
+        )
+
     transaction = session.begin_nested()
     try:
         db_statique = save_statique(session, statique)

--- a/src/api/tests/api/v1/routers/test_statique.py
+++ b/src/api/tests/api/v1/routers/test_statique.py
@@ -383,6 +383,27 @@ def test_create_for_superuser(client_auth):
     assert json_response["items"][0] == id_pdc_itinerance
 
 
+def test_create_twice(client_auth):
+    """Test the /statique/ create endpoint with the same payload twice."""
+    id_pdc_itinerance = "FR911E1111ER1"
+    data = StatiqueFactory.build(
+        id_pdc_itinerance=id_pdc_itinerance,
+    )
+
+    response = client_auth.post("/statique/", json=json.loads(data.model_dump_json()))
+    assert response.status_code == status.HTTP_201_CREATED
+    json_response = response.json()
+    assert json_response["message"] == "Statique items created"
+    assert json_response["size"] == 1
+    assert json_response["items"][0] == id_pdc_itinerance
+
+    response = client_auth.post("/statique/", json=json.loads(data.model_dump_json()))
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json() == {
+        "detail": f"Point of charge {id_pdc_itinerance} already exists"
+    }
+
+
 @pytest.mark.parametrize(
     "client_auth",
     (


### PR DESCRIPTION
## Purpose

If a user submits the same payload twice using the `/statique/` (POST) endpoint, the API returns a 201 CREATED. And if the payload is slightly modified (with the same `id_pdc_itinerance`), we cannot guaranty what would be created or updated. This use-case should be forbidden.

## Proposal

- [x] check that the PDC does not exist and return a 409 if it does
