### PR TITLE
Fix bench jobs when a PR is merged

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -184,8 +184,8 @@ jobs:
           name: api-admin-benchmark
           path: ./src/api/bench_admin_stats_stamped.csv
       - name: Generate markdown table
-        # Only when in PR, not when merged
-        if: github.event.pull_request.merged == false
+        # Only when in PR, not when merged to main
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           echo -e "### Current benchmark\n\n" >> bench_admin_stats.md && \
           pipenv run csvlook -I bench_admin_stats_stamped.csv >> bench_admin_stats.md && \
@@ -197,8 +197,8 @@ jobs:
               csvlook -I >> bench_admin_stats.md
           cat bench_admin_stats.md
       - uses: actions/github-script@v7
-        # Only when in PR, not when merged
-        if: github.event.pull_request.merged == false
+        # Only when in PR, not when merged to main
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           script: |
             const fs = require('node:fs');
@@ -217,7 +217,7 @@ jobs:
 
   # Only when a PR is merged
   update-bench-db:
-    if: github.event.pull_request.merged == true
+    if: ${{ github.event_name == 'push' }}
     needs:
       - build-api
       - bench-api


### PR DESCRIPTION
## Purpose

When a PR is merged, we don't want to post a comment in the PR conversation as there is no conversation. Hence, we should skip irrelevant steps in the `bench-api` job.

## Proposal

- [x] fix CI `bench-api` job conditionnal steps
