### PR TITLE
🐛(api) allow `date_maj` field to be set to "today"

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to
 - Upgrade sentry-sdk to `2.19.2`
 - Upgrade typer to `0.15.1`
 
+### Fixed
+
+- Allow `date_maj` field to be set to "today"
+
 ## [0.15.0] - 2024-11-21
 
 ### Changed

--- a/src/api/qualicharge/schemas/core.py
+++ b/src/api/qualicharge/schemas/core.py
@@ -35,6 +35,7 @@ from ..models.static import (
     DataGouvCoordinate,
     FrenchPhoneNumber,
     ImplantationStationEnum,
+    NotFutureDate,
     RaccordementEnum,
 )
 from . import BaseTimestampedSQLModel
@@ -237,7 +238,7 @@ class Station(BaseTimestampedSQLModel, table=True):
     station_deux_roues: bool
     raccordement: Optional[RaccordementEnum]
     num_pdl: Optional[str] = Field(max_length=64)
-    date_maj: PastDate = Field(sa_type=Date)
+    date_maj: NotFutureDate = Field(sa_type=Date)
     date_mise_en_service: Optional[PastDate] = Field(sa_type=Date)
 
     # Relationships

--- a/src/api/tests/models/test_static.py
+++ b/src/api/tests/models/test_static.py
@@ -1,5 +1,7 @@
 """QualiCharge static models tests."""
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from pydantic_extra_types.coordinate import Coordinate
 
@@ -106,3 +108,18 @@ def test_statique_model_num_pdl():
 
     with pytest.raises(ValueError, match="String should have at most 64 characters"):
         StatiqueFactory.build(num_pdl="a" * 65)
+
+
+def test_statique_model_date_maj():
+    """Test statique model accepts only a `date_maj` not in the future."""
+    today = datetime.now(timezone.utc).date()
+    statique = StatiqueFactory.build(date_maj=today)
+    assert statique.date_maj == today
+
+    yesterday = today - timedelta(days=1)
+    statique = StatiqueFactory.build(date_maj=yesterday)
+    assert statique.date_maj == yesterday
+
+    tomorrow = today + timedelta(days=1)
+    with pytest.raises(ValueError, match=f"{tomorrow} is in the future"):
+        StatiqueFactory.build(date_maj=tomorrow)

--- a/src/api/tests/schemas/test_static.py
+++ b/src/api/tests/schemas/test_static.py
@@ -325,6 +325,23 @@ def test_station_events(db_session):
     assert other_operational_unit.stations[0] == station
 
 
+def test_station_date_maj(db_session):
+    """Test station schema accepts only a `date_maj` not in the future."""
+    StationFactory.__session__ = db_session
+
+    today = datetime.now(timezone.utc).date()
+    station = StationFactory.create_sync(date_maj=today)
+    assert station.date_maj == today
+
+    yesterday = today - timedelta(days=1)
+    station = StationFactory.create_sync(date_maj=yesterday)
+    assert station.date_maj == yesterday
+
+    tomorrow = today + timedelta(days=1)
+    with pytest.raises(ValueError, match=f"{tomorrow} is in the future"):
+        StationFactory.create_sync(date_maj=tomorrow)
+
+
 def test_operational_unit_create_stations_fk_no_station(db_session):
     """Test OperationalUnit.create_stations_fk method with no matching station."""
     OperationalUnitFactory.__session__ = db_session


### PR DESCRIPTION
## Purpose

Today is not a past date but is a perfectly acceptable value for the `date_maj` field.

## Proposal

- [x] update `date_maj` field type to `NotFutureDate`
