### PR TITLE
🔖(api:minor) bump release to 0.16.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.16.0] - 2024-12-12
+
 ### Changed
 
 - Upgrade fastapi to `0.115.6`
@@ -256,7 +258,8 @@ and this project adheres to
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.15.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.16.0...main
+[0.16.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.12.1...v0.13.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -3,7 +3,7 @@
 #
 [project]
 name = "qualicharge"
-version = "0.15.0"
+version = "0.16.0"
 
 # Third party packages configuration
 [tool.coverage.run]

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"


### PR DESCRIPTION
### Changed

- Upgrade fastapi to `0.115.6`
- Upgrade httpx to `0.28.1`
- Upgrade pyarrow to `18.1.0`
- Upgrade pydantic to `2.10.3`
- Upgrade pydantic-extra-types `2.10.1`
- Upgrade python-multipart to `0.0.19`
- Upgrade sentry-sdk to `2.19.2`
- Upgrade typer to `0.15.1`

### Fixed

- Allow `date_maj` field to be set to "today"
- Forbid `/static/` POST usage for an existing PDC
