### PR TITLE
API: improve database queries

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Prefetch user-related groups and operational units in `get_user` dependency
+
 ## [0.16.0] - 2024-12-12
 
 ### Changed

--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Changed
 
 - Prefetch user-related groups and operational units in `get_user` dependency
+- Improve bulk endpoints permissions checking
 
 ## [0.16.0] - 2024-12-12
 

--- a/src/api/qualicharge/api/v1/routers/static.py
+++ b/src/api/qualicharge/api/v1/routers/static.py
@@ -39,6 +39,7 @@ from qualicharge.models.static import Statique
 from qualicharge.schemas.core import OperationalUnit, PointDeCharge, Station
 from qualicharge.schemas.sql import StatiqueImporter
 from qualicharge.schemas.utils import (
+    are_pdcs_allowed_for_user,
     build_statique,
     is_pdc_allowed_for_user,
     list_statique,
@@ -277,11 +278,10 @@ async def bulk(
     session: Session = Depends(get_session),
 ) -> StatiqueItemsCreatedResponse:
     """Create a set of statique items."""
-    for statique in statiques:
-        if not is_pdc_allowed_for_user(statique.id_pdc_itinerance, user):
-            raise PermissionDenied(
-                "You cannot submit data for an organization you are not assigned to"
-            )
+    if not are_pdcs_allowed_for_user([s.id_pdc_itinerance for s in statiques], user):
+        raise PermissionDenied(
+            "You cannot submit data for an organization you are not assigned to"
+        )
 
     # Convert statiques to a Pandas DataFrame
     df = pd.read_json(

--- a/src/api/qualicharge/db.py
+++ b/src/api/qualicharge/db.py
@@ -5,7 +5,7 @@ from typing import Generator, Optional
 
 from pydantic import PostgresDsn
 from sqlalchemy import Engine as SAEngine
-from sqlalchemy import text
+from sqlalchemy import event, text
 from sqlalchemy.exc import OperationalError
 from sqlmodel import Session as SMSession
 from sqlmodel import create_engine
@@ -47,6 +47,32 @@ class Engine(metaclass=Singleton):
             )
         logger.debug("Getting database engine %s", self._engine)
         return self._engine
+
+
+class SAQueryCounter:
+    """Context manager to count SQLALchemy queries.
+
+    Inspired by: https://stackoverflow.com/a/71337784
+    """
+
+    def __init__(self, connection):
+        """Initialize the counter for a given connection."""
+        self.connection = connection.engine
+        self.count = 0
+
+    def __enter__(self):
+        """Start listening `before_cursor_execute` event."""
+        event.listen(self.connection, "before_cursor_execute", self.callback)
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        """Stop listening `before_cursor_execute` event."""
+        event.remove(self.connection, "before_cursor_execute", self.callback)
+
+    def callback(self, *args, **kwargs):
+        """Increment the counter every time the `before_cursor_execute` event occurs."""
+        self.count += 1
+        logger.debug(f"Database query [{self.count=}] >> {args=} {kwargs=}")
 
 
 def get_engine() -> SAEngine:

--- a/src/api/qualicharge/schemas/utils.py
+++ b/src/api/qualicharge/schemas/utils.py
@@ -278,3 +278,12 @@ def is_pdc_allowed_for_user(id_pdc_itinerance: str, user: User) -> bool:
     if id_pdc_itinerance[:5] in [ou.code for ou in user.operational_units]:
         return True
     return False
+
+
+def are_pdcs_allowed_for_user(ids_pdc_itinerance: set | list, user) -> bool:
+    """Check of a user can create/read/update a list of PDCs given their identifiers."""
+    if user.is_superuser:
+        return True
+    operational_unit_codes: set = {id_[:5] for id_ in ids_pdc_itinerance}
+    user_operational_unit_codes: set = {ou.code for ou in user.operational_units}
+    return operational_unit_codes.issubset(user_operational_unit_codes)

--- a/src/api/tests/auth/test_oidc.py
+++ b/src/api/tests/auth/test_oidc.py
@@ -7,21 +7,24 @@ import httpx
 import jwt
 import pytest
 from fastapi.security import HTTPAuthorizationCredentials, SecurityScopes
+from sqlmodel import select
 
-from qualicharge.auth.factories import IDTokenFactory, UserFactory
+from qualicharge.auth.factories import GroupFactory, IDTokenFactory, UserFactory
 from qualicharge.auth.oidc import (
     discover_provider,
     get_public_keys,
     get_token,
     get_user,
 )
-from qualicharge.auth.schemas import ScopesEnum
+from qualicharge.auth.schemas import GroupOperationalUnit, ScopesEnum
 from qualicharge.conf import settings
+from qualicharge.db import SAQueryCounter
 from qualicharge.exceptions import (
     AuthenticationError,
     OIDCProviderException,
     PermissionDenied,
 )
+from qualicharge.schemas.core import OperationalUnit
 
 
 def setup_function():
@@ -298,3 +301,51 @@ def test_get_user_for_user_with_limited_scopes(
             token=id_token_factory.build(),
             session=db_session,
         )
+
+
+def test_get_user_number_of_queries(id_token_factory: IDTokenFactory, db_session):
+    """Test the OIDC get user utility number of queries for a standard user."""
+    UserFactory.__session__ = db_session
+    GroupFactory.__session__ = db_session
+
+    token = id_token_factory.build()
+
+    # Create groups linked to Operational Units
+    groups = GroupFactory.create_batch_sync(3)
+    operational_units = db_session.exec(select(OperationalUnit).limit(3)).all()
+    for group, operational_unit in zip(groups, operational_units, strict=True):
+        db_session.add(
+            GroupOperationalUnit(
+                group_id=group.id, operational_unit_id=operational_unit.id
+            )
+        )
+
+    # Create user linked to this groups and related operational units
+    user = UserFactory.create_sync(
+        email=token.email,
+        is_superuser=False,
+        is_active=True,
+        groups=groups,
+        scopes=[ScopesEnum.ALL_CREATE],
+    )
+
+    # Test the number of queries
+    with SAQueryCounter(db_session.connection()) as counter:
+        user = get_user(
+            security_scopes=SecurityScopes(scopes=[ScopesEnum.ALL_CREATE]),
+            token=token,
+            session=db_session,
+        )
+    assert counter.count == 1
+
+    # When getting groups...
+    with SAQueryCounter(db_session.connection()) as counter:
+        assert {g.id for g in user.groups} == {g.id for g in groups}
+    assert counter.count == 0
+
+    # ... and related operational units
+    with SAQueryCounter(db_session.connection()) as counter:
+        assert {ou.id for g in user.groups for ou in g.operational_units} == {
+            ou.id for ou in operational_units
+        }
+    assert counter.count == 0


### PR DESCRIPTION
## Purpose

The request user is injected in every API endpoint. Not prefetching related objects such as groups and operational units generates a huge number of unexpected queries and slows down API response time.

## Proposal

- [x] prefetch user-related groups and operational units
- [x] improve bulk endpoints permissions checking
