### PR TITLE
✨(dashboard) add the global consent

### DIFF
--- a/src/dashboard/apps/consent/fixtures/consent.py
+++ b/src/dashboard/apps/consent/fixtures/consent.py
@@ -29,11 +29,11 @@ def seed_consent():
     entity4 = EntityFactory(users=(user5,))
 
     # create delivery points
-    for i in range(1, 4):
-        DeliveryPointFactory(provider_assigned_id=f"entity1_{i}", entity=entity1)
-        DeliveryPointFactory(provider_assigned_id=f"entity2_{i}", entity=entity2)
-        DeliveryPointFactory(provider_assigned_id=f"entity3_{i}", entity=entity3)
-        DeliveryPointFactory(provider_assigned_id=f"entity4_{i}", entity=entity4)
+    for _ in range(1, 4):
+        DeliveryPointFactory(entity=entity1)
+        DeliveryPointFactory(entity=entity2)
+        DeliveryPointFactory(entity=entity3)
+        DeliveryPointFactory(entity=entity4)
 
     # create awaiting consents
     for delivery_point in DeliveryPoint.objects.all():

--- a/src/dashboard/apps/consent/forms.py
+++ b/src/dashboard/apps/consent/forms.py
@@ -1,0 +1,26 @@
+"""Dashboard consent app forms."""
+
+from django import forms
+from django.forms.widgets import CheckboxInput
+from django.utils.translation import gettext_lazy as _
+
+
+class ConsentCheckboxInput(CheckboxInput):
+    """Custom CheckboxInput widget for rendering a checkbox input field."""
+
+    template_name = "consent/forms/widgets/checkbox.html"
+
+
+class ConsentForm(forms.Form):
+    """Save user consent through a checkbox field."""
+
+    consent_agreed = forms.BooleanField(
+        required=True,
+        initial=False,
+        widget=ConsentCheckboxInput(
+            attrs={
+                "label": _("I agree to give my consent"),
+                "help_text": _("Please confirm your consent by checking this box."),
+            },
+        ),
+    )

--- a/src/dashboard/apps/consent/mixins.py
+++ b/src/dashboard/apps/consent/mixins.py
@@ -1,0 +1,37 @@
+"""Dashboard consent app mixins."""
+
+from django.views.generic.base import ContextMixin
+from django_stubs_ext import StrOrPromise
+
+
+class BreadcrumbContextMixin(ContextMixin):
+    """Mixin to simplify usage of the `dsfr_breadcrumb` in class based views.
+
+    Add the breadcrumb elements in the view context for the dsfr breadcrumb:
+    https://numerique-gouv.github.io/django-dsfr/components/breadcrumb/.
+
+    ```python
+        breadcrumb_links = [{"url": "first-url", "title": "First title"}, {...}],
+        breadcrumb_current: "Current page title",
+        breadcrumb_root_dir: "the root directory, if the site is not installed at the
+        root of the domain"
+    }
+    ```
+    """
+
+    breadcrumb_links: list[dict[StrOrPromise, StrOrPromise]] | None = None
+    breadcrumb_current: StrOrPromise | None = None
+    breadcrumb_root_dir: StrOrPromise | None = None
+
+    def get_context_data(self, **kwargs) -> dict:
+        """Add breadcrumb context to the view."""
+        context = super().get_context_data(**kwargs)
+
+        context["breadcrumb_data"] = {
+            "links": self.breadcrumb_links,
+            "current": self.breadcrumb_current,
+        }
+        if self.breadcrumb_root_dir:
+            context["breadcrumb_data"]["root_dir"] = self.breadcrumb_root_dir
+
+        return context

--- a/src/dashboard/apps/consent/templates/consent/forms/widgets/checkbox.html
+++ b/src/dashboard/apps/consent/templates/consent/forms/widgets/checkbox.html
@@ -1,0 +1,7 @@
+{% include "django/forms/widgets/input.html" %}
+
+<label class="fr-label"
+   {% if widget.attrs.id %}for="{{ widget.attrs.id }}"{% endif %}>
+   {{ widget.attrs.label }}
+   <span class="fr-hint-text">{{ widget.attrs.help_text }}</span>  
+</label>

--- a/src/dashboard/apps/consent/templates/consent/manage.html
+++ b/src/dashboard/apps/consent/templates/consent/manage.html
@@ -3,85 +3,87 @@
 {% load i18n static %}
 
 {% block dashboard_content %}
-  <h2>
-    {% trans "Manage consents" %}
-  </h2>
+<h2>{% trans "Manage consents" %}</h2>
 
-  {% if entities %}
-    <form action="" method="post">
-      {% csrf_token %}
-
+{% if entities %}
+  <form action="" method="post">
+    {% csrf_token %}
+    
+    <div class="fr-messages-group" id="error-messages" aria-live="assertive">
+      {% if form.errors %}          
+        <div class="{% if form.consent_agreed.errors %}fr-pl-3v{% endif %} fr-mb-6v">
+        <p class="fr-message fr-message--error" id="message-error">
+          {% trans "The form contains errors" %}
+        </p>          
+        </div>
+      {% endif %}
+    </div>   
+  
       {# toggle button #}
       <div class="fr-fieldset__element">
         <div class="fr-checkbox-group">
-          <input type="checkbox"
-                 id="toggle-all"
-                 name="toggle-all"
-                 aria-describedby="toggle-all-messages"
-                 data-fr-js-checkbox-input="true"
+          <input type="checkbox" id="toggle-all" name="toggle-all" 
+                 aria-describedby="toggle-all-messages" 
+                 data-fr-js-checkbox-input="true" 
                  data-fr-js-checkbox-actionee="true">
-          <label class="fr-label" for="toggle-all">
-            <strong>{% trans "Toggle All" %}</strong>
-          </label>
+          <label class="fr-label" for="toggle-all"><strong>{% trans "Toggle All" %}</strong></label>
         </div>
       </div>
 
       <div class="consent-wrapper fr-py-6v fr-mb-6v">
         <div class="consent-wrapper__inner">
           {% for entity in entities %}
-            <fieldset class="fr-fieldset"
-                      id="checkboxes"
-                      aria-labelledby="checkboxes-legend checkboxes-messages">
-              <legend class="fr-fieldset__legend--regular fr-fieldset__legend"
-                      id="checkboxes-legend">
-                {{ entity.name }}
-              </legend>
+          <fieldset class="fr-fieldset" id="checkboxes" aria-labelledby="checkboxes-legend checkboxes-messages">
+            <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="checkboxes-legend">{{ entity.name }}</legend>
 
-              {% for consent in entity.get_consents %}
-                <div class="fr-fieldset__element">
-                  <div class="fr-checkbox-group">
-                    <input type="checkbox"
-                           name="status"
-                           value="{{ consent.id }}"
-                           id="{{ consent.id }}"
-                           {% if consent.status == 'VALIDATED' %} checked{% endif %}
-                           aria-describedby="{{ consent.id }}-messages"
-                           data-fr-js-checkbox-input="true"
-                           data-fr-js-checkbox-actionee="true" />
-                    <label class="fr-label" for="{{ consent.id }}">
-                      {{ consent.delivery_point.provider_assigned_id }}
-                    </label>
-                    <div class="fr-messages-group"
-                         id="{{ consent.id }}-messages"
-                         aria-live="assertive">
-                    </div>
-                  </div>
-                </div>
-              {% endfor %}
-
-              <div class="fr-messages-group"
-                   id="checkboxes-messages"
-                   aria-live="assertive">
-                {{ field.errors }}
+            {% for consent in entity.get_consents %}
+            <div class="fr-fieldset__element">
+              <div class="fr-checkbox-group">
+                <input type="checkbox"
+                       name="status"
+                       value="{{ consent.id }}"
+                       id="{{ consent.id }}"
+                       {% if consent.status == 'VALIDATED' %} checked{% endif %}
+                       aria-describedby="{{ consent.id }}-messages"
+                       data-fr-js-checkbox-input="true"
+                       data-fr-js-checkbox-actionee="true" />
+                <label class="fr-label" for="{{ consent.id }}">{{ consent.delivery_point.provider_assigned_id }} </label>
+                <div class="fr-messages-group" id="{{ consent.id }}-messages" aria-live="assertive"></div>
               </div>
-            </fieldset>
+            </div>
+            {% endfor %}
+
+          </fieldset>
           {% endfor %}
         </div>
       </div>
-      <button class="fr-btn" type="submit" name="submit">
-        {% trans "submit" %}
-      </button>
-    </form>
 
+      {# checkbox to apply the consent globally #}      
+      <div class="{% if form.consent_agreed.errors %}fr-pl-3v{% endif %} fr-mb-6v">
+        <div class="fr-checkbox-group {% if form.consent_agreed.errors %}fr-checkbox-group--error{% endif %}">
+          {{ form.consent_agreed }}          
+          <div class="fr-messages-group" id="{{ consent.id }}-messages" aria-live="assertive">
+              {% if form.consent_agreed.errors %}
+                {% for error in form.consent_agreed.errors %}
+                <p class="fr-message fr-message--error" id="checkboxes-error-message-error">
+                {{ error }}
+                </p>
+                {% endfor %}
+              {% endif %}
+          </div>          
+        </div>
+      </div>
+
+      <button class="fr-btn" type="submit" name="submit"> {% trans "submit" %} </button>
+  </form>
+  
   {% else %}
-    <p>
-      {% trans "No consents to validate" %}
-    </p>
+    <p>{% trans "No consents to validate" %}</p>
   {% endif %}
 {% endblock dashboard_content %}
 
 {% block dashboard_extra_js %}
   {% if entities %}
-    <script src="{% static 'apps/consent/js/app.js' %}"></script>
+  <script src="{% static 'apps/consent/js/app.js' %}"></script>
   {% endif %}
 {% endblock dashboard_extra_js %}

--- a/src/dashboard/apps/consent/tests/test_views.py
+++ b/src/dashboard/apps/consent/tests/test_views.py
@@ -1,0 +1,358 @@
+"""Dashboard consent views tests."""
+
+from http import HTTPStatus
+
+import pytest
+from django.urls import reverse
+
+from apps.auth.factories import UserFactory
+from apps.consent import AWAITING, VALIDATED
+from apps.consent.factories import ConsentFactory
+from apps.consent.models import Consent
+from apps.consent.views import ConsentFormView
+from apps.core.factories import EntityFactory
+
+
+@pytest.mark.django_db
+def test_bulk_update_consent_status_without_ids(rf):
+    """Test that no status is updated if no id is passed."""
+    request = rf.get(reverse("consent:manage"))
+    request.user = UserFactory()
+
+    view = ConsentFormView()
+    view.setup(request)
+
+    size = 4
+    ConsentFactory.create_batch(size)
+
+    # check data before update
+    assert all(c == AWAITING for c in Consent.objects.values_list("status", flat=True))
+
+    # bulk update to VALIDATED of… nothing, and check 0 record have been updated.
+    assert view._bulk_update_consent([], VALIDATED) == 0
+
+    # and checks that the data has not changed after the update.
+    assert all(c == AWAITING for c in Consent.objects.values_list("status", flat=True))
+
+
+@pytest.mark.django_db
+def test_bulk_update_consent_status(rf):
+    """Test that all consents are correctly updated."""
+    user = UserFactory()
+
+    request = rf.get(reverse("consent:manage"))
+    request.user = user
+
+    view = ConsentFormView()
+    view.setup(request)
+
+    # create entity for the user and consents for the entity
+    size = 3
+    entity = EntityFactory(users=(user,))
+    consents = ConsentFactory.create_batch(size, delivery_point__entity=entity)
+    ids = [c.id for c in consents]
+
+    # check data before update
+    assert all(c == AWAITING for c in Consent.objects.values_list("status", flat=True))
+
+    # bulk update to VALIDATED, and check all records have been updated.
+    assert view._bulk_update_consent(ids, VALIDATED) == size
+
+    # and checks that the data has changed to VALIDATED after the update.
+    assert all(c == VALIDATED for c in Consent.objects.values_list("status", flat=True))
+
+
+@pytest.mark.django_db
+def test_bulk_update_consent_status_with_fake_id(rf):
+    """Test update with wrong ID in list of ids to update."""
+    user = UserFactory()
+
+    request = rf.get(reverse("consent:manage"))
+    request.user = user
+
+    view = ConsentFormView()
+    view.setup(request)
+
+    # create entity for the user and consents for the entity
+    size = 3
+    entity = EntityFactory(users=(user,))
+    consents = ConsentFactory.create_batch(size, delivery_point__entity=entity)
+    ids = [c.id for c in consents]
+
+    # add a fake id to the ids to update
+    ids.append("fa62cf1d-c510-498a-b428-fdf72fa35651")
+
+    # check data before update
+    assert all(c == AWAITING for c in Consent.objects.values_list("status", flat=True))
+
+    # bulk update to VALIDATED,
+    # and check all records have been updated except the fake id.
+    assert view._bulk_update_consent(ids, VALIDATED) == size
+
+    # and checks that the data has changed to VALIDATED after the update.
+    assert all(c == VALIDATED for c in Consent.objects.values_list("status", flat=True))
+
+
+@pytest.mark.django_db
+def test_bulk_update_consent_without_user_perms(rf):
+    """Test the update of consents for which the user does not have the rights."""
+    user = UserFactory()
+
+    request = rf.get(reverse("consent:manage"))
+    request.user = user
+
+    view = ConsentFormView()
+    view.setup(request)
+
+    # create entity for the user and consents for the entity
+    size = 3
+    entity = EntityFactory(users=(user,))
+    consents = ConsentFactory.create_batch(size, delivery_point__entity=entity)
+    ids = [c.id for c in consents]
+
+    # create wrong consent
+    wrong_user = UserFactory()
+    wrong_entity = EntityFactory(users=(wrong_user,))
+    wrong_consent = ConsentFactory(delivery_point__entity=wrong_entity)
+
+    # add wrong_id to ids
+    ids.append(wrong_consent.id)
+    assert len(ids) == size + 1
+    assert wrong_consent.id in ids
+
+    # check data before update
+    assert all(c == AWAITING for c in Consent.objects.values_list("status", flat=True))
+
+    # bulk update to VALIDATED,
+    # and check all records have been updated except the wrong id.
+    assert view._bulk_update_consent(ids, VALIDATED) == size
+
+    # and checks that the data has changed to VALIDATED after the update.
+    assert all(
+        c == VALIDATED
+        for c in Consent.objects.filter(delivery_point__entity=entity).values_list(
+            "status", flat=True
+        )
+    )
+    assert all(
+        c == AWAITING
+        for c in Consent.objects.filter(
+            delivery_point__entity=wrong_entity
+        ).values_list("status", flat=True)
+    )
+
+
+@pytest.mark.django_db
+def test_get_awaiting_ids_with_bad_parameters(rf):
+    """Test get_awaiting_ids() with bad parameters raise exception."""
+    user = UserFactory()
+
+    request = rf.get(reverse("consent:manage"))
+    request.user = user
+
+    view = ConsentFormView()
+    view.setup(request)
+
+    # create entity for the user and consents for the entity
+    size = 3
+    entity = EntityFactory(users=(user,))
+    consents = ConsentFactory.create_batch(size, delivery_point__entity=entity)
+    # create a list of QuerySet instead of str
+    ids = [c.id for c in consents]
+
+    # check _get_awaiting_ids() raise exception
+    # (ids must be a list of string not of QuerySet)
+    with pytest.raises(ValueError):
+        view._get_awaiting_ids(validated_ids=ids)
+
+
+@pytest.mark.django_db
+def test_get_awaiting_ids(rf):
+    """Test getting of awaiting ids inferred from validated consents."""
+    user = UserFactory()
+
+    request = rf.get(reverse("consent:manage"))
+    request.user = user
+
+    view = ConsentFormView()
+    view.setup(request)
+
+    # create entity for the user and consents for the entity
+    size = 3
+    entity = EntityFactory(users=(user,))
+    consents = ConsentFactory.create_batch(size, delivery_point__entity=entity)
+    ids = [str(c.id) for c in consents]
+
+    # removes one `id` from the list `ids`,
+    # this is the one we must find with _get_awaiting_ids()
+    id_not_include = ids.pop()
+    assert len(ids) == size - 1
+
+    # check awaiting id is the expected
+    awaiting_ids = view._get_awaiting_ids(validated_ids=ids)
+    assert len(awaiting_ids) == 1
+    assert id_not_include in awaiting_ids
+
+
+@pytest.mark.django_db
+def test_templates_render_without_entities(rf):
+    """Test the templates are rendered without entities."""
+    user = UserFactory()
+
+    request = rf.get(reverse("consent:manage"))
+    request.user = user
+
+    view = ConsentFormView()
+    view.setup(request)
+
+    # check the context
+    context = view.get_context_data()
+    assert context["entities"] == []
+
+    # Get response object
+    response = view.dispatch(request)
+    assert response.status_code == HTTPStatus.OK
+
+
+@pytest.mark.django_db
+def test_templates_render_html_content_without_entities(rf):
+    """Test the html content of the templates without entities."""
+    user = UserFactory()
+
+    request = rf.get(reverse("consent:manage"))
+    request.user = user
+
+    view = ConsentFormView()
+    view.setup(request)
+
+    # Get response object and force template rendering
+    response = view.dispatch(request)
+    rendered = response.render()
+    html = rendered.content.decode()
+
+    # the id of the global consent checkbox shouldn't be present in HTML
+    not_expected = 'id="id_consent_agreed"'
+    assert (not_expected not in html) is True
+
+    # checkbox with name “status” shouldn't be present in the HTML
+    not_expected = '<input type="checkbox" name="status"'
+    assert (not_expected not in html) is True
+
+
+@pytest.mark.django_db
+def test_templates_render_with_entities(rf):
+    """Test the templates are rendered."""
+    user = UserFactory()
+
+    request = rf.get(reverse("consent:manage"))
+    request.user = user
+
+    view = ConsentFormView()
+    view.setup(request)
+
+    # create entity
+    entity = EntityFactory(users=(user,))
+
+    # check the context
+    context = view.get_context_data()
+    assert context["entities"] == [entity]
+
+    # Get response object
+    response = view.dispatch(request)
+    assert response.status_code == HTTPStatus.OK
+
+
+@pytest.mark.django_db
+def test_templates_render_html_content_with_entities(rf):
+    """Test the html content of the templates with entities but no consents."""
+    user = UserFactory()
+
+    request = rf.get(reverse("consent:manage"))
+    request.user = user
+
+    view = ConsentFormView()
+    view.setup(request)
+
+    # create entity
+    EntityFactory(users=(user,))
+
+    # Get response object and force template rendering
+    response = view.dispatch(request)
+    rendered = response.render()
+    html = rendered.content.decode()
+
+    # the id of the global consent checkbox must be present in HTML
+    expected = 'id="id_consent_agreed"'
+    assert (expected in html) is True
+
+    # no checkbox with name “status” should be present in the HTML
+    not_expected = '<input type="checkbox" name="status"'
+    assert (not_expected not in html) is True
+
+
+@pytest.mark.django_db
+def test_templates_render_with_slug(rf):
+    """Accessing the form with a slug must initialize the entity in the context."""
+    user = UserFactory()
+    # create entity
+    entity_name = "entity-1"
+    entity = EntityFactory(users=(user,), name=entity_name)
+    request = rf.get(reverse("consent:manage", kwargs={"slug": entity_name}))
+    request.user = user
+
+    view = ConsentFormView()
+    view.setup(request)
+
+    # check the context
+    context = view.get_context_data()
+    assert context["entities"] == [entity]
+
+    # Get response object
+    response = view.dispatch(request)
+    assert response.status_code == HTTPStatus.OK
+
+
+@pytest.mark.django_db
+def test_templates_render_html_content_with_consents(rf):
+    """Test the HTML content of the templates with entities and consents."""
+    user = UserFactory()
+
+    request = rf.get(reverse("consent:manage"))
+    request.user = user
+
+    view = ConsentFormView()
+    view.setup(request)
+
+    # create entity
+    size = 3
+    entity = EntityFactory(users=(user,))
+    consents = ConsentFactory.create_batch(size, delivery_point__entity=entity)
+
+    # Get response object and force template rendering
+    response = view.dispatch(request)
+    rendered = response.render()
+    html = rendered.content.decode()
+
+    assert (entity.name in html) is True
+    assert all(str(c.id) in html for c in consents)
+
+
+@pytest.mark.django_db
+def test_form_post_empty(rf):
+    """POST request without required field values will display error."""
+    user = UserFactory()
+    EntityFactory(users=(user,))
+
+    request = rf.post(reverse("consent:manage"), {})
+    request.user = user
+
+    view = ConsentFormView()
+    view.setup(request)
+
+    # Get response object and force template rendering
+    response = view.dispatch(request)
+    rendered = response.render()
+    html = rendered.content.decode()
+
+    expected = 'id="checkboxes-error-message-error"'
+    assert (expected in html) is True

--- a/src/dashboard/apps/consent/urls.py
+++ b/src/dashboard/apps/consent/urls.py
@@ -2,12 +2,12 @@
 
 from django.urls import path
 
-from .views import IndexView, consent_form_view
+from .views import ConsentFormView, IndexView
 
 app_name = "consent"
 
 urlpatterns = [
     path("", IndexView.as_view(), name="index"),
-    path("manage/", consent_form_view, name="manage"),
-    path("manage/<slug:slug>", consent_form_view, name="manage"),
+    path("manage/", ConsentFormView.as_view(), name="manage"),
+    path("manage/<slug:slug>", ConsentFormView.as_view(), name="manage"),
 ]

--- a/src/dashboard/apps/core/factories.py
+++ b/src/dashboard/apps/core/factories.py
@@ -1,5 +1,7 @@
 """Dashboard core factories."""
 
+import uuid
+
 import factory
 
 from .models import DeliveryPoint, Entity
@@ -39,5 +41,5 @@ class DeliveryPointFactory(factory.django.DjangoModelFactory):
     class Meta:  # noqa: D106
         model = DeliveryPoint
 
-    provider_assigned_id = factory.Sequence(lambda n: "dp_%d" % n)
+    provider_assigned_id = factory.LazyFunction(lambda: str(uuid.uuid4()))
     entity = factory.SubFactory(EntityFactory)


### PR DESCRIPTION
## Purpose

Validation of consents must be done via a global checkbox at the end of the form

## Proposal

- [x] Replaced function-based `consent_form_view` with `ConsentFormView` class-based view, 
- [x] Add `ConsentForm` for managing consent input.
- [x] Update templates and URLs. 
- [x] Refactore consent views by splitting and improving helper functions.
- [x] Add tests

## In addition

Add a `BreadcrumbContextMixin` to streamline breadcrumb handling.