### PR TITLE
Add statique materialized view

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 
 # -- Docker
 COMPOSE                    	 = bin/compose
-COMPOSE_UP                 	 = $(COMPOSE) up -d
+COMPOSE_UP                 	 = $(COMPOSE) up -d --remove-orphans
 COMPOSE_RUN                	 = $(COMPOSE) run --rm --no-deps
 COMPOSE_RUN_API            	 = $(COMPOSE_RUN) api
 COMPOSE_RUN_API_PIPENV     	 = $(COMPOSE_RUN_API) pipenv run
@@ -332,6 +332,10 @@ reset-db: \
   migrate-prefect \
   reset-dashboard-db
 .PHONY: reset-db
+
+refresh-api-static: ## Refresh the API Statique Materialized View
+	$(COMPOSE) exec api pipenv run python -m qualicharge refresh-static
+.PHONY: refresh-api-static
 
 reset-api-db: ## Reset the PostgreSQL API database
 	$(COMPOSE) stop

--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
   `SENTRY_PROFILES_SAMPLE_RATE` configuration
 - Set request's user (`username`) in Sentry's context
 - Add `Localisation.coordonneesXY` unique contraint [BC] 💥
+- Implement `Statique` materialized view
 
 ### Changed
 

--- a/src/api/Pipfile
+++ b/src/api/Pipfile
@@ -26,6 +26,7 @@ questionary = "==2.1.0"
 sentry-sdk = {extras = ["fastapi"], version = "==2.20.0"}
 setuptools = "==75.8.0"
 sqlalchemy-timescaledb = "==0.4.1"
+sqlalchemy-utils = "==0.41.2"
 sqlmodel = "==0.0.22"
 typer = "==0.15.1"
 uvicorn = {extras = ["standard"] }

--- a/src/api/Pipfile.lock
+++ b/src/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6c812bc177a6f0da310185aa53a02103338be8ddc24295c1aa061820f9a30352"
+            "sha256": "8dda9b1e97aa4c777e193b31fa0da4b39e75107360a5a73d5b167170d1b744af"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1353,6 +1353,15 @@
             "index": "pypi",
             "version": "==0.4.1"
         },
+        "sqlalchemy-utils": {
+            "hashes": [
+                "sha256:85cf3842da2bf060760f955f8467b87983fb2e30f1764fd0e24a48307dc8ec6e",
+                "sha256:bc599c8c3b3319e53ce6c5c3c471120bd325d0071fb6f38a10e924e3d07b9990"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==0.41.2"
+        },
         "sqlmodel": {
             "hashes": [
                 "sha256:7d37c882a30c43464d143e35e9ecaf945d88035e20117bf5ec2834a23cbe505e",
@@ -2109,11 +2118,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:49dde3b06a5602177bc2ad013149b6f60a290b7154539180d37b6f876ae79b20",
-                "sha256:ac4cf2f967ce02c898efa50651c43180bd658a7707cfd676fcc5410ad1482c03"
+                "sha256:42f2da8cf561e38c72b25e9891168b1e25fec42b6b0b5b0b6cd6041da54af885",
+                "sha256:926d2301787220e0554c2e39afc4dc535ce4b0a8d0a089657137999f66334ef4"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==33.3.1"
+            "version": "==35.0.0"
         },
         "flask": {
             "hashes": [

--- a/src/api/cron.json
+++ b/src/api/cron.json
@@ -1,0 +1,7 @@
+{
+  "jobs": [
+    {
+      "command": "*/10 * * * * python -m qualicharge refresh-static"
+    }
+  ]
+}

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -74,5 +74,6 @@ exclude = [
 [[tool.mypy.overrides]]
 module = [
   "shapely.*",
+  "sqlalchemy_utils.*"
 ]
 ignore_missing_imports = true

--- a/src/api/qualicharge/migrations/env.py
+++ b/src/api/qualicharge/migrations/env.py
@@ -3,8 +3,10 @@
 from logging.config import fileConfig
 
 from alembic import context
+from geoalchemy2.alembic_helpers import create_geospatial_index
 from sqlalchemy import engine_from_config, pool
 from sqlmodel import SQLModel
+
 
 from qualicharge.conf import settings
 

--- a/src/api/qualicharge/migrations/versions/4b99d15436b0_add_statique_materialized_view.py
+++ b/src/api/qualicharge/migrations/versions/4b99d15436b0_add_statique_materialized_view.py
@@ -1,0 +1,47 @@
+"""Add statique materialized view
+
+Revision ID: 4b99d15436b0
+Revises: 9ae109e209c9
+Create Date: 2025-01-16 15:02:04.004411
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from geoalchemy2.functions import ST_GeomFromEWKB
+from sqlalchemy_utils.view import CreateView, DropView
+
+from qualicharge.schemas.core import StatiqueMV, _StatiqueMV
+
+# revision identifiers, used by Alembic.
+revision: str = "4b99d15436b0"
+down_revision: Union[str, None] = "9ae109e209c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create the Statique Materialized view and related indexes."""
+    op.execute(
+        CreateView(
+            _StatiqueMV.__table__.fullname, _StatiqueMV.selectable, materialized=True
+        )
+    )
+    op.create_geospatial_index(
+        "idx_statique_coordonneesXY",
+        _StatiqueMV.__table__.fullname,
+        [ST_GeomFromEWKB(StatiqueMV.coordonneesXY)],
+        unique=False,
+        postgresql_using="gist",
+    )
+    for idx in _StatiqueMV.__table__.indexes:
+        idx.create(op.get_bind())
+
+
+def downgrade() -> None:
+    """Delete the Statique Materialized View."""
+
+    op.execute(
+        DropView(_StatiqueMV.__table__.fullname, materialized=True, cascade=True)
+    )


### PR DESCRIPTION
## Purpose

Having a SQL materialized view for "statique" data would ease recurrent database queries joining the same tables frequently. Moreover this should speed up database queries and response time for API endpoints using them.

## Proposal

- [x] add `sqlalchemy_utils` dependency to ease materialized view management
- [x] add `statique` materialized view
- [x] test the materialized view
- [x] integrate a refresh strategy
