### PR TITLE
🐛(dashboard) adjust manager order in Consent model

### DIFF
--- a/src/dashboard/apps/consent/models.py
+++ b/src/dashboard/apps/consent/models.py
@@ -46,8 +46,9 @@ class Consent(DashboardBase):
     end = models.DateTimeField(_("end date"))
     revoked_at = models.DateTimeField(_("revoked at"), null=True, blank=True)
 
-    active_objects = ConsentManager()
+    # models.Manager() must be in first place to ensure django admin expectations.
     objects = models.Manager()
+    active_objects = ConsentManager()
 
     class Meta:  # noqa: D106
         ordering = ["delivery_point"]

--- a/src/dashboard/apps/consent/tests/test_admin.py
+++ b/src/dashboard/apps/consent/tests/test_admin.py
@@ -1,0 +1,31 @@
+"""Dashboard consent admin tests."""
+
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.urls import reverse
+
+from apps.consent.admin import ConsentAdmin
+from apps.consent.models import Consent
+
+
+@pytest.mark.django_db
+def test_admin_manager_name(rf):
+    """Tests the name of the manager used by the Django admin to retrieve objects.
+
+    For the Django admin, the manager used must be the default django manager
+    (`objects`) and not a custom manager, which could lead to an unwanted loss of
+    display of data.
+    """
+    # Initialize admin
+    site = AdminSite()
+    admin = ConsentAdmin(Consent, site)
+
+    # Request admin consent
+    request = rf.get(reverse("admin:qcd_consent_consent_changelist"))
+
+    # Get the queryset used by admin
+    queryset = admin.get_queryset(request)
+
+    # The manager name must be the default Django manager: `objects`.
+    manager_name = queryset.model._default_manager.name
+    assert manager_name == "objects"


### PR DESCRIPTION
## Purpose

`Django admin` is sensitive to the order of `model manager` declarations. 
In order to display all data in the admin, it is important to use django's default model manager.

## Proposal

- [x] Reordered `objects` and `active_objects` in the Consent model to ensure compatibility with Django admin expectations. 
- [x] Introduce a test to ensure the default Django manager is used in the admin setup, avoiding issues with custom managers.