### PR TITLE
🧑‍💻(dashboard) add bootstrap and reset commands for dashboard setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,12 @@ bootstrap: \
   seed-api
 .PHONY: bootstrap
 
+bootstrap-dashboard: ## bootstrap the dashboard project for development
+bootstrap-dashboard: \
+  build-dashboard \
+  reset-dashboard-db
+.PHONY: bootstrap-dashboard
+
 build: ## build services image
 	$(COMPOSE) build
 .PHONY: build
@@ -221,6 +227,8 @@ create-prefect-db: ## create prefect database
 .PHONY: create-prefect-db
 
 create-dashboard-db: ## create dashboard database
+	@echo "Running dashboard service database engine…"
+	@$(COMPOSE_UP) --wait postgresql
 	@echo "Creating dashboard service database…"
 	@$(COMPOSE) exec postgresql bash -c 'psql "postgresql://$${POSTGRES_USER}:$${POSTGRES_PASSWORD}@$${QUALICHARGE_DB_HOST}:$${QUALICHARGE_DB_PORT}/postgres" -c "create database \"$${DASHBOARD_DB_NAME}\";"' || echo "Duly noted, skipping database creation."
 .PHONY: create-dashboard-db
@@ -328,6 +336,13 @@ reset-db: ## Reset the PostgreSQL database
 	$(MAKE) create-dashboard-superuser
 	$(MAKE) seed-dashboard
 .PHONY: reset-db
+
+reset-dashboard-db: ## Reset the PostgreSQL dashboard database
+	$(MAKE) create-dashboard-db
+	$(MAKE) migrate-dashboard
+	$(MAKE) create-dashboard-superuser
+	$(MAKE) seed-dashboard
+.PHONY: reset-dashboard-db
 
 seed-api: ## seed the API database (static data)
 seed-api: run

--- a/src/dashboard/readme.md
+++ b/src/dashboard/readme.md
@@ -15,13 +15,20 @@ The qualicharge dashboard is available from the url:
 
 ## Useful commands
 
-Perform a Django migration *(manage.py migrate)* :
+Bootstrap dashboard project:
+
+```
+make bootstrap-dashboard
+make run-dashboard
+```
+
+Perform a Django migration *(manage.py migrate)*:
 
 ```
 make migrate-dashboard-db
 ```
 
-Create superuser.
+Create superuser:
 
 You can connect with **username: admin** / **password: admin**.
 *(The credentials are defined in env.d/dashboard.)*
@@ -30,10 +37,17 @@ You can connect with **username: admin** / **password: admin**.
 make create-dashboard-superuser
 ```
 
-Display dashboard logs
+Display dashboard logs:
 
 ```
 make logs-dashboard
+```
+
+Reset dashboard db:
+
+```
+make drop-dashboard-db
+make reset-dashboard-db
 ```
 
 ## Project specific naming convention


### PR DESCRIPTION
## Purpose

The `bootstrap` command in the `makefile` is too general and long to execute for working on the `dashboard` project alone. A specific `bootstrap` command for the `dashboard` project would be welcome.

## Proposal

- [x] Add `bootstrap-dashboard` command in the Makefile to simplify project setup.
- [x] Add `reset-dashboard-db`  command in the Makefile to simplify database resetting. 
- [x] Update the dashboard README.