### PR TITLE
🔧(api) set request user in Sentry's context

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - Activate and configure Sentry profiling by setting the
   `SENTRY_PROFILES_SAMPLE_RATE` configuration
+- Set request's user (`username`) in Sentry's context
 
 ### Changed
 

--- a/src/api/qualicharge/auth/oidc.py
+++ b/src/api/qualicharge/auth/oidc.py
@@ -21,6 +21,7 @@ from jwt.exceptions import (
     InvalidTokenError,
 )
 from pydantic import AnyHttpUrl
+from sentry_sdk import set_user
 from sqlalchemy.orm import joinedload
 from sqlmodel import Session as SMSession
 from sqlmodel import select
@@ -199,6 +200,9 @@ def get_user(
     if not user.is_active:
         logger.error(f"User {token.email} tried to login but is not active")
         raise AuthenticationError("User is not active")
+
+    # Add username to sentry's context
+    set_user({"username": user.username})
 
     # We do not check scopes for admin users
     if user.is_superuser:


### PR DESCRIPTION
## Purpose

We need to track how users are using the API and who's raising observed errors.

## Proposal

- [x] add API request user's `username` to Sentry's context
