### PR TITLE
Set Statiques optional values to a default

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to
 - Decrease the number of database queries for dynamic endpoints
 - Cache the "get PointDeCharge id from its `id_pdc_itinerance`" database query
 - Improve JSON string parsing using pyarrow engine
+- Add default values for optional Statique model fields
 - Upgrade pydantic to `2.10.4`
 - Upgrade pydantic-settings to `2.7.1`
 - Upgrade python-multipart to `0.0.20`

--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to
   command
 - Decrease the number of database queries for dynamic endpoints
 - Cache the "get PointDeCharge id from its `id_pdc_itinerance`" database query
+- Improve JSON string parsing using pyarrow engine
 - Upgrade pydantic to `2.10.4`
 - Upgrade pydantic-settings to `2.7.1`
 - Upgrade python-multipart to `0.0.20`

--- a/src/api/qualicharge/api/v1/routers/static.py
+++ b/src/api/qualicharge/api/v1/routers/static.py
@@ -1,7 +1,7 @@
 """QualiCharge API v1 statique router."""
 
 import logging
-from io import StringIO
+from io import BytesIO
 from typing import Annotated, List, Optional, cast
 
 import pandas as pd
@@ -285,8 +285,12 @@ async def bulk(
 
     # Convert statiques to a Pandas DataFrame
     df = pd.read_json(
-        StringIO(f"{'\n'.join([s.model_dump_json() for s in statiques])}"),
+        BytesIO(
+            bytes(f"{'\n'.join([s.model_dump_json() for s in statiques])}", "utf-8")
+        ),
         lines=True,
+        orient="records",
+        engine="pyarrow",
         dtype_backend="pyarrow",
     )
 

--- a/src/api/qualicharge/models/static.py
+++ b/src/api/qualicharge/models/static.py
@@ -120,11 +120,17 @@ def not_future(value: date):
 # A date not in the future (today or in the past)
 NotFutureDate = Annotated[date, AfterValidator(not_future)]
 
+# Default values (if not provided)
+DEFAULT_CHAR_VALUE: str = "NA"
+DEFAULT_EMAIL_ADDRESS: str = "na@example.org"
+DEFAULT_PHONE_NUMBER: FrenchPhoneNumber = FrenchPhoneNumber("+33.123456789")
+DEFAULT_SIREN_NUMBER: str = "123456789"
+
 
 class Statique(ModelSchemaMixin, BaseModel):
     """IRVE static model."""
 
-    nom_amenageur: Optional[str]
+    nom_amenageur: Optional[str] = DEFAULT_CHAR_VALUE
     siren_amenageur: Optional[
         Annotated[
             str,
@@ -135,11 +141,11 @@ class Statique(ModelSchemaMixin, BaseModel):
                 ],
             ),
         ]
-    ]
-    contact_amenageur: Optional[EmailStr]
-    nom_operateur: Optional[str]
+    ] = DEFAULT_SIREN_NUMBER
+    contact_amenageur: Optional[EmailStr] = DEFAULT_EMAIL_ADDRESS
+    nom_operateur: Optional[str] = DEFAULT_CHAR_VALUE
     contact_operateur: EmailStr
-    telephone_operateur: Optional[FrenchPhoneNumber]
+    telephone_operateur: Optional[FrenchPhoneNumber] = DEFAULT_PHONE_NUMBER
     nom_enseigne: str
     id_station_itinerance: Annotated[
         str, Field(pattern="(?:(?:^|,)(^[A-Z]{2}[A-Z0-9]{4,33}$|Non concerné))+$")

--- a/src/api/qualicharge/schemas/utils.py
+++ b/src/api/qualicharge/schemas/utils.py
@@ -2,7 +2,7 @@
 
 import logging
 from enum import IntEnum
-from io import StringIO
+from io import BytesIO
 from typing import Generator, List, Optional, Set, Tuple, Type, cast
 
 import pandas as pd
@@ -215,8 +215,12 @@ def update_statique(
 def save_statiques(db_session: Session, statiques: List[Statique]):
     """Save input statiques to database."""
     df = pd.read_json(
-        StringIO(f"{'\n'.join([s.model_dump_json() for s in statiques])}"),
+        BytesIO(
+            bytes(f"{'\n'.join([s.model_dump_json() for s in statiques])}", "utf-8")
+        ),
         lines=True,
+        orient="records",
+        engine="pyarrow",
         dtype_backend="pyarrow",
     )
     importer = StatiqueImporter(df, db_session.connection())

--- a/src/api/tests/models/test_static.py
+++ b/src/api/tests/models/test_static.py
@@ -123,3 +123,25 @@ def test_statique_model_date_maj():
     tomorrow = today + timedelta(days=1)
     with pytest.raises(ValueError, match=f"{tomorrow} is in the future"):
         StatiqueFactory.build(date_maj=tomorrow)
+
+
+def test_statique_model_defaults():
+    """Test the Statique model defaut values (when not provided)."""
+    example = StatiqueFactory.build()
+    statique = Statique(
+        **example.model_dump(
+            exclude={
+                "nom_amenageur",
+                "siren_amenageur",
+                "contact_amenageur",
+                "nom_operateur",
+                "telephone_operateur",
+            }
+        )
+    )
+
+    assert statique.nom_amenageur == "NA"
+    assert statique.siren_amenageur == "123456789"
+    assert statique.contact_amenageur == "na@example.org"
+    assert statique.nom_operateur == "NA"
+    assert statique.telephone_operateur == "+33.123456789"


### PR DESCRIPTION
## Purpose

The importation process may create many duplicates as the upsert technique we use does not compare rows with missing fields. Two tables are mostly concerned: Operateur and Amenageur. Hence we decided to fill optional (non filled) fields with default generic strings (e.g. "NA").

## Proposal

- [x] set defaults to problematic optional values in the `Statique` model
- [x] test `Statique` model defaults
- [x] bonus: improve json parsing performances using the pyarrow engine
