### PR TITLE
🗃️(api) make location address/coordinates unique together

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
   command
 - Decrease the number of database queries for dynamic endpoints
 - Cache the "get PointDeCharge id from its `id_pdc_itinerance`" database query
+- Updated `Localisation` table constraint: `adresse_station` is no longer
+  unique, but the `adresse_station`/`coordonneesXY` couple should be
 - Upgrade pydantic to `2.10.4`
 - Upgrade pydantic-settings to `2.7.1`
 - Upgrade python-multipart to `0.0.20`

--- a/src/api/qualicharge/migrations/versions/32b3d0e269a2_update_localisation_uniqueness_.py
+++ b/src/api/qualicharge/migrations/versions/32b3d0e269a2_update_localisation_uniqueness_.py
@@ -1,0 +1,37 @@
+"""Update localisation uniqueness criterions
+
+Revision ID: 32b3d0e269a2
+Revises: c09664a85912
+Create Date: 2025-01-09 16:20:52.578289
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "32b3d0e269a2"
+down_revision: Union[str, None] = "c09664a85912"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "localisation_adresse_station_key", "localisation", type_="unique"
+    )
+    op.create_unique_constraint(
+        "localisation_adresse_station_coordonneesXY_key",
+        "localisation",
+        ["adresse_station", "coordonneesXY"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "localisation_adresse_station_coordonneesXY_key", "localisation", type_="unique"
+    )
+    op.create_unique_constraint(
+        "localisation_adresse_station_key", "localisation", ["adresse_station"]
+    )

--- a/src/api/qualicharge/schemas/core.py
+++ b/src/api/qualicharge/schemas/core.py
@@ -117,12 +117,16 @@ class Enseigne(BaseTimestampedSQLModel, table=True):
 class Localisation(BaseTimestampedSQLModel, table=True):
     """Localisation table."""
 
+    __table_args__ = BaseTimestampedSQLModel.__table_args__ + (
+        UniqueConstraint("adresse_station", "coordonneesXY"),
+    )
+
     model_config = SQLModelConfig(
         validate_assignment=True, arbitrary_types_allowed=True
     )
 
     id: UUID = Field(default_factory=uuid4, primary_key=True)
-    adresse_station: str = Field(unique=True)
+    adresse_station: str
     code_insee_commune: str = Field(regex=r"^([013-9]\d|2[AB1-9])\d{3}$")
     coordonneesXY: DataGouvCoordinate = Field(
         sa_type=Geometry(

--- a/src/api/qualicharge/schemas/sql.py
+++ b/src/api/qualicharge/schemas/sql.py
@@ -289,7 +289,7 @@ class StatiqueImporter:
         self._save_schema(
             self.localisation,
             Localisation,
-            constraint="localisation_adresse_station_key",
+            constraint="localisation_adresse_station_coordonneesXY_key",
         )
         self._save_schema(
             self.station,


### PR DESCRIPTION
## Purpose

Instead of having a unique `Localisation.adresse_station` field, let's be less pedantic and allow address to be unique while combined with specific coordinates. This allows to define a sparse address for a station with precise coordinates. Two stations located in the same area with a partial address will have two separated Localisation entries when their coordinates differ.

## Proposal

- [x] add `localisation_adresse_station_coordonneesXY_key` constraint to the `Localisation` table
- [x] add database migration
