### PR TITLE
👔(dashboard) enforce immutability of validated consents

### DIFF
--- a/src/dashboard/CHANGELOG.md
+++ b/src/dashboard/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to
 - add consent form to manage consents of one or many entities 
 - add admin integration for Entity, DeliveryPoint and Consent
 - add mass admin action (make revoked and make awaiting) for consents
+- block the updates of all new data if a consent has the status `VALIDATED`
+- block the deletion of consent if it has the status `VALIDATED`
 - integration of custom 403, 404 and 500 pages 
 - sentry integration
 - added a signal on the creation of a delivery point. This signal allows the creation 


### PR DESCRIPTION
## Purpose

For contractual reasons, the validated consents cannot be modified.
It is therefore necessary to block the updates of all new data and the deletion of consents if a consent has the status "VALIDATED". 

## Proposal

Introduced a validation mechanism to block any changes to consents with a `VALIDATED` status, raising a `ValidationError` if attempted. 

- [x] add the custom method `clean()` to the `Consent model` and raised a `ValidationError`.
- [x] override save() method of the consent model to raised a `ValidationError`.
- [x]  override delete() method  of the consent model a `ValidationError`.
- [x] add tests to confirm this behavior.
- [x] update changelog