### PR TITLE
👔(dashboard) disabled updates to non-AWAITING consents in front app

### DIFF
--- a/src/dashboard/CHANGELOG.md
+++ b/src/dashboard/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 - add mass admin action (make revoked and make awaiting) for consents
 - block the updates of all new data if a consent has the status `VALIDATED`
 - block the deletion of consent if it has the status `VALIDATED`
+- block consent updates (via the consent form) if the consent status is not `AWAITING`
 - integration of custom 403, 404 and 500 pages 
 - sentry integration
 - added a signal on the creation of a delivery point. This signal allows the creation 

--- a/src/dashboard/apps/consent/templates/consent/manage.html
+++ b/src/dashboard/apps/consent/templates/consent/manage.html
@@ -43,11 +43,18 @@
                        name="status"
                        value="{{ consent.id }}"
                        id="{{ consent.id }}"
-                       {% if consent.status == 'VALIDATED' %} checked{% endif %}
+                       {% if consent.status == 'VALIDATED' %} checked="checked" disabled="disabled"{% endif %}
                        aria-describedby="{{ consent.id }}-messages"
                        data-fr-js-checkbox-input="true"
                        data-fr-js-checkbox-actionee="true" />
-                <label class="fr-label" for="{{ consent.id }}">{{ consent.delivery_point.provider_assigned_id }} </label>
+                <label class="fr-label" for="{{ consent.id }}"
+                       {% if consent.status == 'VALIDATED' %}
+                         title="{% trans "Delivery point is already validated" %}"
+                       {% elif consent.status == 'AWAITING' %}
+                         title="{% trans "Delivery point awaiting consent" %}"
+                       {% endif %}>
+                  {{ consent.delivery_point.provider_assigned_id }}
+                </label>
                 <div class="fr-messages-group" id="{{ consent.id }}-messages" aria-live="assertive"></div>
               </div>
             </div>

--- a/src/dashboard/apps/consent/tests/test_views.py
+++ b/src/dashboard/apps/consent/tests/test_views.py
@@ -7,7 +7,7 @@ import pytest
 from django.urls import reverse
 
 from apps.auth.factories import UserFactory
-from apps.consent import AWAITING, VALIDATED
+from apps.consent import AWAITING, REVOKED, VALIDATED
 from apps.consent.factories import ConsentFactory
 from apps.consent.models import Consent
 from apps.consent.views import ConsentFormView
@@ -60,6 +60,16 @@ def test_bulk_update_consent_status(rf):
     assert view._bulk_update_consent(ids, VALIDATED) == size
 
     # and checks that the data has changed to VALIDATED after the update.
+    assert all(c == VALIDATED for c in Consent.objects.values_list("status", flat=True))
+
+    # bulk update from VALIDATED to AWAITING: no data must be updated
+    assert view._bulk_update_consent(ids, AWAITING) == 0
+    # and checks that the status has not changed after the update.
+    assert all(c == VALIDATED for c in Consent.objects.values_list("status", flat=True))
+
+    # bulk update from VALIDATED to REVOKED: no data must be updated
+    assert view._bulk_update_consent(ids, REVOKED) == 0
+    # and checks that the status has not changed after the update.
     assert all(c == VALIDATED for c in Consent.objects.values_list("status", flat=True))
 
 

--- a/src/dashboard/apps/consent/views.py
+++ b/src/dashboard/apps/consent/views.py
@@ -84,9 +84,12 @@ class ConsentFormView(BreadcrumbContextMixin, FormView):
             return list(user.get_entities())
 
     def _bulk_update_consent(self, ids: list[str], status: str) -> int:
-        """Bulk update of the consent status for a given status and list of entities."""
+        """Bulk update of the consent status for a given status and list of entities.
+
+        Only `AWAITING` consents can be updated by users.
+        """
         return (
-            Consent.objects.filter(id__in=ids)
+            Consent.objects.filter(id__in=ids, status=AWAITING)
             .filter(
                 Q(delivery_point__entity__users=self.request.user)
                 | Q(delivery_point__entity__proxies__users=self.request.user)

--- a/src/dashboard/templates/blocks/main_menu.html
+++ b/src/dashboard/templates/blocks/main_menu.html
@@ -18,7 +18,7 @@
       <ul class="fr-nav__list">
         {% if request.user.is_authenticated %}
           <li class="fr-nav__item">
-            {% url 'index' as home_url %}
+            {% url 'home:index' as home_url %}
             <a class="fr-nav__link"
                href="{{ home_url }}"
                target="_self"


### PR DESCRIPTION
## Purpose

Consents with a status other than “AWAITING” cannot be changed by users.
The consent form uses the update() method and therefore cannot take advantage of the clean() method of the model.
The update() present in the view must be modified accordingly.
The user must be able to simply understand that he cannot update delivery points with a status "VALIDATED".

## Proposal

- [x] Disabled updates to non-AWAITING consents and enhanced the bulk update logic to enforce the restriction. 
- [x] Disabled checkbox if status is VALIDATED.
- [x] Added tooltips to consent labels in the UI for better context. 
- [x]  Added test.
- [x] Added changelog.

## Extra

Fix the home URL in the navigation menu.