### PR TITLE
👔(dashboard) update consent status logic when update from validated to revoked

### DIFF
--- a/src/dashboard/CHANGELOG.md
+++ b/src/dashboard/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to
 - add admin integration for Entity, DeliveryPoint and Consent
 - add mass admin action (make revoked) for consents
 - block the updates of all new data if a consent has the status `VALIDATED`
-- block the deletion of consent if it has the status `VALIDATED`
+- allow selected consent fields update if status changes from `VALIDATED` to  `REVOKED`
+- block the deletion of consent if it has the status `VALIDATED` or `REVOKED` 
 - block consent updates (via the consent form) if the consent status is not `AWAITING`
 - integration of custom 403, 404 and 500 pages 
 - sentry integration

--- a/src/dashboard/apps/consent/exceptions.py
+++ b/src/dashboard/apps/consent/exceptions.py
@@ -1,0 +1,14 @@
+"""Dashboard consent exceptions."""
+
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext as _
+
+
+class ConsentWorkflowError(ValidationError):
+    """Exception for consent workflow validation errors."""
+
+    DEFAULT_MESSAGE = _("Consent workflow error.")
+
+    def __init__(self, custom_message=None):
+        """Initialize the exception with an optional custom message."""
+        super().__init__(custom_message or self.DEFAULT_MESSAGE)

--- a/src/dashboard/apps/consent/tests/test_models.py
+++ b/src/dashboard/apps/consent/tests/test_models.py
@@ -3,12 +3,13 @@
 import datetime
 
 import pytest
-from django.core.exceptions import ValidationError
 from django.db.models import signals
 
 from apps.consent import AWAITING, REVOKED, VALIDATED
+from apps.consent.exceptions import ConsentWorkflowError
 from apps.consent.factories import ConsentFactory
 from apps.consent.signals import handle_new_delivery_point
+from apps.consent.tests.conftest import FAKE_TIME
 from apps.consent.utils import consent_end_date
 from apps.core.factories import DeliveryPointFactory
 from apps.core.models import DeliveryPoint
@@ -101,87 +102,388 @@ def test_create_consent_with_custom_period_date():
 
 
 @pytest.mark.django_db
-def test_update_consent_status():
-    """Tests updating a consent status.
+def test_is_update_allowed():
+    """Tests the `_is_update_allowed` method of a consent.
 
-    Test that consents can no longer be modified once their status is passed to
-    `VALIDATED` (raise ValidationError).
+    - AWAITING to VALIDATED is allowed.
+    - AWAITING to REVOKED is allowed.
+    - VALIDATED to AWAITING is not allowed.
+    - VALIDATED to REVOKED with not-allowed fields is not allowed.
+    - VALIDATED to REVOKED with allowed fields is allowed.
+    - REVOKED to AWAITING is allowed.
+    - REVOKED to VALIDATED is allowed.
+    - Create new consent is allowed.
     """
     from apps.consent.models import Consent
 
-    # create one `delivery_point` and consequently one `consent`
-    assert Consent.objects.count() == 0
-    delivery_point = DeliveryPointFactory()
-    assert Consent.objects.count() == 1
-
-    # get the created consent
-    consent = Consent.objects.get(delivery_point=delivery_point)
-    consent_updated_at = consent.updated_at
-    assert consent.status == AWAITING
-    assert consent.revoked_at is None
-
-    # update status to REVOKED
-    consent.status = REVOKED
-    consent.save()
-    assert consent.status == REVOKED
-    assert consent.updated_at > consent_updated_at
-    assert consent.revoked_at is not None
-    new_updated_at = consent.updated_at
-    # refresh the state in memory
-    consent = Consent.objects.get(delivery_point=delivery_point)
-
-    # Update the consent to AWAITING
-    consent.status = AWAITING
-    consent.revoked_at = None
-    consent.save()
-    assert consent.status == AWAITING
-    assert consent.updated_at > new_updated_at
-    assert consent.revoked_at is None
-    new_updated_at = consent.updated_at
-    # refresh the state in memory
-    consent = Consent.objects.get(delivery_point=delivery_point)
-
-    # update status to VALIDATED
+    # update from AWAITING to VALIDATED
+    consent = ConsentFactory(status=AWAITING)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
     consent.status = VALIDATED
-    consent.revoked_at = None
+    assert consent._is_update_allowed() is True
+
+    # update from AWAITING to REVOKED
+    consent = ConsentFactory(status=AWAITING)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = REVOKED
+    assert consent._is_update_allowed() is True
+
+    # update from VALIDATED to AWAITING, raise exception
+    consent = ConsentFactory(status=VALIDATED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = AWAITING
+    with pytest.raises(
+        ConsentWorkflowError,
+        match='Validated consent can only be changed to the status "revoked".',
+    ):
+        consent._is_update_allowed()
+
+    # update from VALIDATED to REVOKED
+    consent = ConsentFactory(status=VALIDATED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = REVOKED
+    assert consent._is_update_allowed() is True
+
+    # update from VALIDATED to REVOKED with not-allowed fields raise exception
+    consent = ConsentFactory(status=VALIDATED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = REVOKED
+    consent.end = FAKE_TIME
+    with pytest.raises(
+        ConsentWorkflowError,
+        match="['Only the authorized fields (revoked_at, status, updated_at) can be "
+        "modified.']",
+    ):
+        consent._is_update_allowed()
+
+    # update from VALIDATED to REVOKED with allowed fields.
+    consent = ConsentFactory(status=VALIDATED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = REVOKED
+    consent.revoked_at = consent.revoked_at or consent.start
+    assert consent._is_update_allowed() is True
+
+    # update from REVOKED to AWAITING
+    consent = ConsentFactory(status=REVOKED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = AWAITING
+    assert consent._is_update_allowed() is True
+
+    # update from REVOKED to VALIDATED
+    consent = ConsentFactory(status=REVOKED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = VALIDATED
+    assert consent._is_update_allowed() is True
+
+    # create a new consent
+    dl = DeliveryPointFactory()
+    consent = Consent(delivery_point=dl, status=AWAITING)
+    assert consent._state.adding is True
+    assert consent._is_update_allowed() is True
+
+
+@pytest.mark.django_db
+def test_clean_and_update_awaiting_consent_status():
+    """Tests clean and update an awaiting consent status.
+
+    - AWAITING to VALIDATED is authorized.
+    - AWAITING to REVOKED is authorized.
+    - AWAITING with mixed fields is authorized.
+    """
+    from apps.consent.models import Consent
+
+    # update the status from AWAITING to VALIDATED
+    consent = ConsentFactory(status=AWAITING)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = VALIDATED
+    consent.end = FAKE_TIME
+    consent.clean()
     consent.save()
     assert consent.status == VALIDATED
-    assert consent.updated_at > new_updated_at
-    assert consent.revoked_at is None
-    # refresh the state in memory
-    consent = Consent.objects.get(delivery_point=delivery_point)
+    assert consent.end == FAKE_TIME
 
-    # The consent status is `VALIDATED`, so it cannot be changed anymore.
-    with pytest.raises(ValidationError):
-        consent.status = AWAITING
+    # update the status from AWAITING to REVOKED
+    consent = ConsentFactory(status=AWAITING)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = REVOKED
+    consent.end = FAKE_TIME
+    consent.clean()
+    consent.save()
+    assert consent.status == REVOKED
+    assert consent.end == FAKE_TIME
+    assert consent.revoked_at is not None
+
+    # update values
+    consent = ConsentFactory(status=AWAITING)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.end = FAKE_TIME
+    consent.clean()
+    consent.save()
+    assert consent.end == FAKE_TIME
+
+
+@pytest.mark.django_db
+def test_update_validated_consent_status():
+    """Tests updating a validated consent status.
+
+    - VALIDATED to AWAITING is not authorized.
+    - VALIDATED to REVOKED with allowed fields is authorized.
+    - VALIDATED to REVOKED with not-allowed fields is not authorized.
+    - VALIDATED with mixed fields is not authorized.
+    """
+    from apps.consent.models import Consent
+
+    # update the status from VALIDATED to AWAITING raise exception
+    consent = ConsentFactory(status=VALIDATED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = AWAITING
+    with pytest.raises(
+        ConsentWorkflowError,
+        match='Validated consent can only be changed to the status "revoked".',
+    ):
         consent.save()
+
+    # update the status from VALIDATED to REVOKED with allowed fields is authorized.
+    consent = ConsentFactory(status=VALIDATED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = REVOKED
+    consent.revoked_at = FAKE_TIME
+    consent.save()
+    assert consent.status == REVOKED
+    assert consent.revoked_at is not None
+
+    # update status VALIDATED to REVOKED with not-allowed field raise exception
+    consent = ConsentFactory(status=VALIDATED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = REVOKED
+    # update of an unauthorized field
+    consent.end = FAKE_TIME
+    with pytest.raises(
+        ConsentWorkflowError,
+        match="['Only the authorized fields (revoked_at, status, updated_at) can be "
+        "modified.']",
+    ):
+        consent.save()
+
+    # update status with mixed fields raise exception
+    consent = ConsentFactory(status=VALIDATED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    # update of an unauthorized field
+    consent.end = FAKE_TIME
+    with pytest.raises(
+        ConsentWorkflowError,
+        match='Validated consent can only be changed to the status "revoked".',
+    ):
+        consent.save()
+
+
+@pytest.mark.django_db
+def test_update_revoked_consent_status():
+    """Tests updating a revoked consent status.
+
+    - REVOKED to AWAITING is authorized.
+    - REVOKED to VALIDATED is authorized.
+    - REVOKED with mixed fields is authorized.
+    """
+    from apps.consent.models import Consent
+
+    # update the status from REVOKED to AWAITING
+    consent = ConsentFactory(status=REVOKED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = AWAITING
+    consent.save()
+    assert consent.status == AWAITING
+
+    # update the status from REVOKED to VALIDATED
+    consent = ConsentFactory(status=REVOKED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = VALIDATED
+    consent.save()
+    assert consent.status == VALIDATED
+
+    # update status with mixed fields
+    consent = ConsentFactory(status=REVOKED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.end = FAKE_TIME
+    consent.save()
+    assert consent.status == REVOKED
+    assert consent.end == FAKE_TIME
+
+
+@pytest.mark.django_db
+def test_clean_validated_consent_status():
+    """Tests the `clean` method of a validated consent status.
+
+    - VALIDATED to AWAITING is not authorized.
+    - VALIDATED to REVOKED with allowed fields is authorized.
+    - VALIDATED to REVOKED with not-allowed fields is not authorized.
+    - VALIDATED with mixed fields is not authorized.
+    """
+    from apps.consent.models import Consent
+
+    # update the status from VALIDATED to AWAITING raise exception
+    consent = ConsentFactory(status=VALIDATED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = AWAITING
+    with pytest.raises(
+        ConsentWorkflowError,
+        match='Validated consent can only be changed to the status "revoked".',
+    ):
+        consent.clean()
+
+    # update the status from VALIDATED to REVOKED with allowed fields is authorized.
+    consent = ConsentFactory(status=VALIDATED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = REVOKED
+    consent.revoked_at = FAKE_TIME
+    consent.clean()
+    consent.save()
+    assert consent.status == REVOKED
+    assert consent.revoked_at is not None
+
+    # update status VALIDATED to REVOKED with not-allowed field raise exception
+    consent = ConsentFactory(status=VALIDATED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = REVOKED
+    # update of an unauthorized field
+    consent.end = FAKE_TIME
+    with pytest.raises(
+        ConsentWorkflowError,
+        match="['Only the authorized fields (revoked_at, status, updated_at) can be "
+        "modified.']",
+    ):
+        consent.clean()
+
+    # update status with mixed fields raise exception
+    consent = ConsentFactory(status=VALIDATED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    # update of an unauthorized field
+    consent.end = FAKE_TIME
+    with pytest.raises(
+        ConsentWorkflowError,
+        match='Validated consent can only be changed to the status "revoked".',
+    ):
+        consent.clean()
+
+
+@pytest.mark.django_db
+def test_clean_revoked_consent_status():
+    """Tests the `clean` method of a revoked consent status.
+
+    - REVOKED to AWAITING is authorized.
+    - REVOKED to VALIDATED is authorized.
+    - REVOKED with mixed fields is authorized.
+    """
+    from apps.consent.models import Consent
+
+    # update the status from REVOKED to AWAITING
+    consent = ConsentFactory(status=REVOKED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = AWAITING
+    consent.clean()
+    consent.save()
+    assert consent.status == AWAITING
+
+    # update the status from REVOKED to VALIDATED
+    consent = ConsentFactory(status=REVOKED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.status = VALIDATED
+    consent.clean()
+    consent.save()
+    assert consent.status == VALIDATED
+
+    # update status with mixed fields
+    consent = ConsentFactory(status=REVOKED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    consent.end = FAKE_TIME
+    consent.clean()
+    consent.save()
+    assert consent.status == REVOKED
+    assert consent.end == FAKE_TIME
+
+
+@pytest.mark.django_db
+def test_is_deletion_allowed():
+    """Tests the `_is_deletion_allowed` method of a validated consent.
+
+    - AWAITING can be deleted.
+    - VALIDATED cannot be deleted.
+    - REVOKED cannot be deleted.
+    """
+    from apps.consent.models import Consent
+
+    # Delete AWAITING consent
+    consent = ConsentFactory(status=AWAITING)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    assert consent._is_deletion_allowed() is True
+
+    # Delete VALIDATED consent
+    consent = ConsentFactory(status=VALIDATED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+
+    with pytest.raises(
+        ConsentWorkflowError, match="Validated consent cannot be deleted."
+    ):
+        consent._is_deletion_allowed()
+
+    # Delete REVOKED consent
+    consent = ConsentFactory(status=REVOKED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    with pytest.raises(
+        ConsentWorkflowError, match="Revoked consent cannot be deleted."
+    ):
+        consent._is_deletion_allowed()
 
 
 @pytest.mark.django_db
 def test_delete_consent():
     """Tests deleting a consent.
 
-    Consents can no longer be deleted once their status is passed to
-    `VALIDATED` (raise ValidationError).
+    - AWAITING can be deleted.
+    - VALIDATED cannot be deleted.
+    - REVOKED cannot be deleted.
     """
     from apps.consent.models import Consent
 
-    # create one `delivery_point` and consequently one `consent`
-    assert Consent.objects.count() == 0
-    delivery_point = DeliveryPointFactory()
-    assert Consent.objects.count() == 1
+    signals.post_save.disconnect(
+        receiver=handle_new_delivery_point,
+        sender=DeliveryPoint,
+        dispatch_uid="handle_new_delivery_point",
+    )
 
-    # get the created consent and delete it
-    consent = Consent.objects.get(delivery_point=delivery_point)
-    assert consent.status != VALIDATED
+    # delete an AWAITING consent
+    consent = ConsentFactory(status=AWAITING)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    assert Consent.objects.count() == 1
+    assert consent.status == AWAITING
     consent.delete()
     assert Consent.objects.count() == 0
 
-    # create a new content with status VALIDATED
-    ConsentFactory(delivery_point=delivery_point, status=VALIDATED)
-    consent = Consent.objects.get(delivery_point=delivery_point)
+    # delete an VALIDATED consent it is not allowed.
+    consent = ConsentFactory(status=VALIDATED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    assert Consent.objects.count() == 1
     assert consent.status == VALIDATED
-    # the consent status is `VALIDATED`, so it cannot be deleted.
-    with pytest.raises(ValidationError):
+    with pytest.raises(
+        ConsentWorkflowError, match="Validated consent cannot be deleted."
+    ):
         consent.delete()
     assert Consent.objects.count() == 1
+
+    # delete an REVOKED consent it is not allowed.
+    consent = ConsentFactory(status=REVOKED)
+    consent = Consent.objects.get(id=consent.id)  # refresh the state in memory
+    expected_consent_number = 2
+    assert Consent.objects.count() == expected_consent_number
+    assert consent.status == REVOKED
+    with pytest.raises(
+        ConsentWorkflowError, match="Revoked consent cannot be deleted."
+    ):
+        consent.delete()
+    assert Consent.objects.count() == expected_consent_number
+
+    signals.post_save.connect(
+        receiver=handle_new_delivery_point,
+        sender=DeliveryPoint,
+        dispatch_uid="handle_new_delivery_point",
+    )

--- a/src/dashboard/readme.md
+++ b/src/dashboard/readme.md
@@ -72,6 +72,35 @@ There is a signal on the creation of a `delivery point` (`apps.core.models.Deliv
 This signal allows the creation of a `consent` (`apps.consent.models.Consent`) 
 corresponding to the `delivery_point`.
 
+## Business logic
+
+### Consent management
+
+3 different status types exist for consents with different management rules:
+
+#### AWAITING
+
+Consent awaiting validation by the user.  
+- [x] Users can change consent without restriction.
+
+#### VALIDATED: 
+
+Consent validated by the user.   
+It can only be modified under conditions:
+-  [x] users cannot modify validated consents,
+-  [x] administrators can change a validated consent to `REVOKED`,
+-  [x] the updated values are restricted to the `status`, `revoked_date` and 
+   `updated_at` 
+  fields,
+-  [x] validated consent cannot be deleted.
+
+#### REVOKED:
+
+Consent revoked.  
+- [ ] It cannot be modified.
+- [x] It cannot be deleted.
+
 ## License
 
 This work is released under the MIT License (see LICENSE).
+


### PR DESCRIPTION
## Purpose

Validated consent can be changed to revoked. 
Only the `status` and `revoked_at` fields can be modified during this modification.


## Proposal

- [x] add validation on the allowed fields
- [x] add validation when consent status is updated from validated status
- [x] add documentation on business logic of consent in the readme.md file