### PR TITLE
🐛(api) fix raccordementenum database type

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to
 - Upgrade questionary to `2.1.0`
 - Upgrade sentry-sdk to `2.20.0`
 
+### Fixed
+
+- Renamed database `raccordementemum` to `raccordementenum`
+
 ## [0.16.0] - 2024-12-12
 
 ### Changed

--- a/src/api/qualicharge/migrations/versions/d3d2c20f8efd_update_enum_definitions.py
+++ b/src/api/qualicharge/migrations/versions/d3d2c20f8efd_update_enum_definitions.py
@@ -1,0 +1,63 @@
+"""Update Enum definitions
+
+Revision ID: d3d2c20f8efd
+Revises: c09664a85912
+Create Date: 2025-01-15 16:13:18.986021
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "d3d2c20f8efd"
+down_revision: Union[str, None] = "c09664a85912"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create expected ENUM
+    postgresql.ENUM("DIRECT", "INDIRECT", name="raccordementenum").create(
+        op.get_bind(), checkfirst=True
+    )
+
+    # Update column type
+    op.alter_column(
+        "station",
+        "raccordement",
+        existing_type=postgresql.ENUM("DIRECT", "INDIRECT", name="raccordementemum"),
+        type_=postgresql.ENUM("DIRECT", "INDIRECT", name="raccordementenum"),
+        existing_nullable=True,
+        postgresql_using="raccordement::VARCHAR::raccordementenum",
+    )
+
+    # Delete old enum
+    postgresql.ENUM("DIRECT", "INDIRECT", name="raccordementemum").drop(
+        op.get_bind(), checkfirst=True
+    )
+
+
+def downgrade() -> None:
+    # Create old ENUM
+    postgresql.ENUM("DIRECT", "INDIRECT", name="raccordementemum").create(
+        op.get_bind(), checkfirst=True
+    )
+
+    # Rollback changes
+    op.alter_column(
+        "station",
+        "raccordement",
+        existing_type=postgresql.ENUM("DIRECT", "INDIRECT", name="raccordementenum"),
+        type_=postgresql.ENUM("DIRECT", "INDIRECT", name="raccordementemum"),
+        existing_nullable=True,
+        postgresql_using="raccordement::VARCHAR::raccordementemum",
+    )
+
+    # Delete created enum
+    postgresql.ENUM("DIRECT", "INDIRECT", name="raccordementenum").drop(
+        op.get_bind(), checkfirst=True
+    )


### PR DESCRIPTION
## Purpose

~~Mypy requires a more explict definition for Enum type fields.~~

The `raccordementemum` database type has never been fixed.

## Proposal

- [ ] ~~use SQLModel `Column(sa_type=...)` to explicitly define Enum fields~~
- [x] rename `raccordementemum` field type to `raccordementenum` with an 'N' 😅 in a database migration
