### PR TITLE
🗑️(dashboard) remove "make awaiting" action from ConsentAdmin.

### DIFF
--- a/src/dashboard/CHANGELOG.md
+++ b/src/dashboard/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to
 - add dashboard homepage
 - add consent form to manage consents of one or many entities 
 - add admin integration for Entity, DeliveryPoint and Consent
-- add mass admin action (make revoked and make awaiting) for consents
+- add mass admin action (make revoked) for consents
 - block the updates of all new data if a consent has the status `VALIDATED`
 - block the deletion of consent if it has the status `VALIDATED`
 - block consent updates (via the consent form) if the consent status is not `AWAITING`

--- a/src/dashboard/apps/consent/admin.py
+++ b/src/dashboard/apps/consent/admin.py
@@ -4,7 +4,7 @@ from django.contrib import admin, messages
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from . import AWAITING, REVOKED
+from . import REVOKED
 from .models import Consent
 
 
@@ -26,7 +26,7 @@ class ConsentAdmin(admin.ModelAdmin):
     ]
     list_filter = ["status"]
     date_hierarchy = "start"
-    actions = ["make_revoked", "make_awaiting"]
+    actions = ["make_revoked"]
 
     @admin.action(description=_("Mark selected consents as revoked"))
     def make_revoked(self, request, queryset):
@@ -36,15 +36,5 @@ class ConsentAdmin(admin.ModelAdmin):
         self.message_user(
             request,
             _("Selected consents have been marked as revoked."),
-            messages.SUCCESS,
-        )
-
-    @admin.action(description=_("Mark selected consents as awaiting"))
-    def make_awaiting(self, request, queryset):
-        """Mark selected consents as awaiting."""
-        queryset.update(status=AWAITING, updated_at=timezone.now(), revoked_at=None)
-        self.message_user(
-            request,
-            _("Selected consents have been marked as awaiting."),
             messages.SUCCESS,
         )

--- a/src/dashboard/apps/consent/tests/test_admin.py
+++ b/src/dashboard/apps/consent/tests/test_admin.py
@@ -5,7 +5,7 @@ from django.contrib.admin.sites import AdminSite
 from django.urls import reverse
 
 from apps.auth.factories import AdminUserFactory
-from apps.consent import AWAITING, REVOKED, VALIDATED
+from apps.consent import AWAITING, REVOKED
 from apps.consent.admin import ConsentAdmin
 from apps.consent.models import Consent
 from apps.consent.tests.conftest import FAKE_TIME
@@ -61,37 +61,4 @@ def test_make_revoked_action(client, patch_timezone_now):
     consent.refresh_from_db()
     assert consent.status == REVOKED
     assert consent.revoked_at == FAKE_TIME
-    assert consent.updated_at == FAKE_TIME
-
-
-@pytest.mark.django_db
-def test_make_awaiting_action(client, patch_timezone_now):
-    """Tests the 'make_awaiting' action for ConsentAdmin."""
-    # Initialize admin user
-    admin_user = AdminUserFactory()
-
-    # create a consent
-    assert Consent.objects.count() == 0
-    DeliveryPointFactory()
-    assert Consent.objects.count() == 1
-
-    # Select and update consent status to AWAITING
-    consent = Consent.objects.first()
-    consent.status = VALIDATED
-    consent.save()
-    assert consent.status == VALIDATED
-
-    # Post action with selected consent
-    data = {
-        "action": "make_awaiting",
-        "_selected_action": [
-            consent.id,
-        ],
-    }
-    client.force_login(admin_user)
-    client.post(reverse("admin:qcd_consent_consent_changelist"), data)
-
-    consent.refresh_from_db()
-    assert consent.status == AWAITING
-    assert consent.revoked_at is None
     assert consent.updated_at == FAKE_TIME


### PR DESCRIPTION

## Purpose

According to the business rules, consents with status `VALIDATED` and `REVOKED`cannot be changed.
Therefore, the action `make awaiting`  has no interest and must be deleted.

## Proposal

- [x] remove the "make awaiting" admin action 
- [x] remove  related test
- [x] update the changelog to reflect this change.