### PR TITLE
🚀(api) inativate temporarily automatic db migrations

### DIFF
--- a/src/api/start.sh
+++ b/src/api/start.sh
@@ -26,8 +26,8 @@ else
   )
 fi
 
-echo "🗃️ Running database migrations..."
-alembic -c qualicharge/alembic.ini upgrade head
+# echo "🗃️ Running database migrations..."
+# alembic -c qualicharge/alembic.ini upgrade head
 
 # shellcheck disable=SC2068
 uvicorn \


### PR DESCRIPTION
## Purpose

Current staging deployment is inconsistent: our database migration state and code version are not synced (database migration is one version ahead). We should deploy only the code to restory consistency.

## Proposal

- [x] temporarily deactivate automatic database migration at application boot
