### PR TITLE
👔(dashboard) disallow delete action for consents in admin.

### DIFF
--- a/src/dashboard/CHANGELOG.md
+++ b/src/dashboard/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
 - add consent form to manage consents of one or many entities 
 - add admin integration for Entity, DeliveryPoint and Consent
 - add mass admin action (make revoked) for consents
+- disallow mass action "delete" for consents in admin
 - block the updates of all new data if a consent has the status `REVOKED`
 - block the updates of all new data if a consent has the status `VALIDATED`
 - allow selected consent fields update if status changes from `VALIDATED` to  `REVOKED`

--- a/src/dashboard/apps/consent/admin.py
+++ b/src/dashboard/apps/consent/admin.py
@@ -28,6 +28,10 @@ class ConsentAdmin(admin.ModelAdmin):
     date_hierarchy = "start"
     actions = ["make_revoked"]
 
+    def has_delete_permission(self, request, obj=None):
+        """Disable delete action permission for all users."""
+        return False
+
     @admin.action(description=_("Mark selected consents as revoked"))
     def make_revoked(self, request, queryset):
         """Mark selected consents as revoked."""

--- a/src/dashboard/apps/consent/tests/test_admin.py
+++ b/src/dashboard/apps/consent/tests/test_admin.py
@@ -62,3 +62,28 @@ def test_make_revoked_action(client, patch_timezone_now):
     assert consent.status == REVOKED
     assert consent.revoked_at == FAKE_TIME
     assert consent.updated_at == FAKE_TIME
+
+
+@pytest.mark.django_db
+def test_has_delete_permission_false_for_existing_object(rf):
+    """Test that the has_delete_permission disallows deletion of an existing object."""
+    # Initialize admin
+    admin = ConsentAdmin(Consent, AdminSite())
+    request = rf.get(reverse("admin:qcd_consent_consent_changelist"))
+
+    # create a consent
+    assert Consent.objects.count() == 0
+    DeliveryPointFactory()
+    assert Consent.objects.count() == 1
+
+    consent = Consent.objects.first()
+    assert admin.has_delete_permission(request, obj=consent) is False
+
+
+@pytest.mark.django_db
+def test_has_delete_permission_false_for_none_object(rf):
+    """Test has_delete_permission disallows deletion when no object is passed (None)."""
+    # Initialize admin
+    admin = ConsentAdmin(Consent, AdminSite())
+    request = rf.get(reverse("admin:qcd_consent_consent_changelist"))
+    assert admin.has_delete_permission(request, obj=None) is False


### PR DESCRIPTION
## Purpose

In admin, the deletion of `validated` and `revoked` consents must not be allowed.

## Proposal

- [x] add `has_delete_permission` method to disable the delete action for all users in the Consent admin
- [x] add tests to ensure deletion is disallowed 
- [x] update the changelog 