### PR TITLE
👔(dashboard) disallow modifications to consents with REVOKED status.

### DIFF
--- a/src/dashboard/CHANGELOG.md
+++ b/src/dashboard/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
 - add consent form to manage consents of one or many entities 
 - add admin integration for Entity, DeliveryPoint and Consent
 - add mass admin action (make revoked) for consents
+- block the updates of all new data if a consent has the status `REVOKED`
 - block the updates of all new data if a consent has the status `VALIDATED`
 - allow selected consent fields update if status changes from `VALIDATED` to  `REVOKED`
 - block the deletion of consent if it has the status `VALIDATED` or `REVOKED` 

--- a/src/dashboard/apps/consent/models.py
+++ b/src/dashboard/apps/consent/models.py
@@ -119,7 +119,6 @@ class Consent(DashboardBase):
 
         - REVOKED
             - can be updated without restriction
-            todo: add restriction: REVOKED consent cannot be modified
         """
         ALLOWED_UPDATE_FIELDS = {"status", "revoked_at", "updated_at"}
 
@@ -129,7 +128,10 @@ class Consent(DashboardBase):
         loaded_status = self._loaded_values.get("status")  # type: ignore[attr-defined]
         updated_status = self.status
 
-        if loaded_status == VALIDATED:
+        if loaded_status == REVOKED:
+            raise ConsentWorkflowError(_("Revoked consent cannot be modified."))
+
+        elif loaded_status == VALIDATED:
             if updated_status != REVOKED:
                 raise ConsentWorkflowError(
                     _('Validated consent can only be changed to the status "revoked".')


### PR DESCRIPTION
## Purpose

To ensures compliance with consent workflow rules, consents with `revoked` status should not be updated.

## Proposal

- [x] add restrictions to disallow updates on consents with a REVOKED status
- [x] updated tests to reflect the new behavior
- [x] updated changelogs