### PR TITLE
🐛(opendata) fix `statiques` dataset SQL query

### DIFF
--- a/src/opendata/data7.yaml
+++ b/src/opendata/data7.yaml
@@ -53,7 +53,7 @@ default:
           implantation_station,
           adresse_station,
           code_insee_commune,
-          ST_AsGeoJSON ("coordonneesXY")::json -> 'coordinates' AS "coordonneesXY",
+          ST_AsGeoJSON ("coordonneesXY"::geometry)::json -> 'coordinates' AS "coordonneesXY",
           nbre_pdc,
           id_pdc_itinerance,
           id_pdc_local,


### PR DESCRIPTION
## Purpose

The `statiques` dataset query of the opendata service is broken, preventing the container to boot.

## Proposal

As the coordonneesXY field is stored with a generic bytea type, we need to cast it first as a Geometry field before performing actions/queries on it.
