### PR TITLE
✅(api) test the Statique MV refresh consistency

### DIFF
--- a/src/api/cron.json
+++ b/src/api/cron.json
@@ -1,7 +1,7 @@
 {
   "jobs": [
     {
-      "command": "*/10 * * * * python -m qualicharge refresh-static"
+      "command": "*/10 * * * * python -m qualicharge refresh-static --concurrently"
     }
   ]
 }

--- a/src/api/qualicharge/cli.py
+++ b/src/api/qualicharge/cli.py
@@ -467,6 +467,8 @@ def refresh_static(ctx: typer.Context, concurrently: bool = False):
     refresh_materialized_view(
         session, STATIQUE_MV_TABLE_NAME, concurrently=concurrently
     )
+    session.commit()
+    console.log("Statique Materalized View has been refreshed.")
 
 
 @app.callback()


### PR DESCRIPTION
## Purpose

We want to be sure that the Statique MV is always up-to-date.

## Proposal

- [x] test field update
- [x] test new entries update
