### PR TITLE
✨(dashboard) add validation and data updates for consent management

### DIFF
--- a/src/dashboard/apps/consent/apps.py
+++ b/src/dashboard/apps/consent/apps.py
@@ -13,5 +13,8 @@ class ConsentConfig(AppConfig):
     verbose_name = _("Consent")
 
     def ready(self):
-        """Register signals."""
+        """Register signals and validate CONSENT_CONTROL_AUTHORITY on ready."""
         from .signals import handle_new_delivery_point  # noqa: F401
+        from .validators import validate_configured_control_authority
+
+        validate_configured_control_authority()

--- a/src/dashboard/apps/consent/forms.py
+++ b/src/dashboard/apps/consent/forms.py
@@ -1,5 +1,7 @@
 """Dashboard consent app forms."""
 
+from datetime import datetime
+
 from django import forms
 from django.forms.widgets import CheckboxInput
 from django.utils.translation import gettext_lazy as _
@@ -20,7 +22,7 @@ class ConsentForm(forms.Form):
     """
 
     # Specific authorisation checkbox
-    is_authorized_signatory = forms.BooleanField(
+    is_authoritative_signatory = forms.BooleanField(
         required=True,
         initial=False,
         widget=ConsentCheckboxInput(
@@ -99,6 +101,12 @@ class ConsentForm(forms.Form):
                 "souscrite...)",
             },
         ),
+    )
+
+    signed_at = forms.DateField(
+        initial=datetime.now().strftime("%d/%m/%Y"),
+        required=True,
+        widget=forms.HiddenInput(attrs={"readonly": "readonly"}),
     )
 
     # Global authorisation checkbox - this field must be in last position.

--- a/src/dashboard/apps/consent/models.py
+++ b/src/dashboard/apps/consent/models.py
@@ -33,20 +33,14 @@ COMPANY_SCHEMA = {
             "maxLength": 5,
             "pattern": r"^\d{4}[A-Z]$",
         },
-        "address": {
-            "type": "object",
-            "properties": {
-                "line_1": {"type": ["string", "null"], "maxLength": 255},
-                "line_2": {"type": ["string", "null"], "maxLength": 255},
-                "zip_code": {
-                    "type": ["string", "null"],
-                    "maxLength": 5,
-                    "pattern": "^[0-9]{1,5}$",
-                },
-                "city": {"type": ["string", "null"], "maxLength": 255},
-            },
-            "required": ["line_1", "zip_code", "city"],
+        "address_1": {"type": ["string", "null"], "maxLength": 255},
+        "address_2": {"type": ["string", "null"], "maxLength": 255},
+        "zip_code": {
+            "type": ["string", "null"],
+            "maxLength": 5,
+            "pattern": "^[0-9]{1,5}$",
         },
+        "city": {"type": ["string", "null"], "maxLength": 255},
     },
     "required": [
         "company_type",
@@ -55,7 +49,9 @@ COMPANY_SCHEMA = {
         "trade_name",
         "siret",
         "naf",
-        "address",
+        "address_1",
+        "zip_code",
+        "city",
     ],
     "additionalProperties": False,
 }
@@ -78,22 +74,16 @@ CONTROL_AUTHORITY_SCHEMA = {
         "name": {"type": ["string", "null"], "maxLength": 255},
         "represented_by": {"type": ["string", "null"], "maxLength": 255},
         "email": {"type": ["string", "null"], "format": "email"},
-        "address": {
-            "type": "object",
-            "properties": {
-                "line_1": {"type": ["string", "null"], "maxLength": 255},
-                "line_2": {"type": ["string", "null"], "maxLength": 255},
-                "zip_code": {
-                    "type": ["string", "null"],
-                    "maxLength": 5,
-                    "pattern": "^[0-9]{1,5}$",
-                },
-                "city": {"type": ["string", "null"], "maxLength": 255},
-            },
-            "required": ["line_1", "zip_code", "city"],
+        "address_1": {"type": ["string", "null"], "maxLength": 255},
+        "address_2": {"type": ["string", "null"], "maxLength": 255},
+        "zip_code": {
+            "type": ["string", "null"],
+            "maxLength": 5,
+            "pattern": "^[0-9]{1,5}$",
         },
+        "city": {"type": ["string", "null"], "maxLength": 255},
     },
-    "required": ["name", "represented_by", "email", "address"],
+    "required": ["name", "represented_by", "email", "address_1", "zip_code", "city"],
     "additionalProperties": False,
 }
 

--- a/src/dashboard/apps/consent/templates/consent/includes/_manage_consents_date_place.html
+++ b/src/dashboard/apps/consent/templates/consent/includes/_manage_consents_date_place.html
@@ -10,10 +10,3 @@
   <br />
   <strong>Le :</strong> {% now "d/m/Y" %}
 </p>
-
-<input class="fr-input"
-       type="hidden"
-       id="text-input-entity-name"
-       name="text-input-entity-name"
-       value="{% now "d/m/Y" %}"
-       readonly="readonly">

--- a/src/dashboard/apps/consent/templates/consent/manage.html
+++ b/src/dashboard/apps/consent/templates/consent/manage.html
@@ -19,15 +19,22 @@
     <form action="" method="post">
       {% csrf_token %}
 
-      <div class="fr-messages-group" id="error-messages" aria-live="assertive">
-        {% if form.errors %}
+      {% if form.errors %}
+        <div class="fr-messages-group" id="error-messages" aria-live="assertive">
           <div class="{% if form.consent_agreed.errors %}fr-pl-3v{% endif %} fr-mb-6v">
-          <p class="fr-message fr-message--error" id="message-error">
-            {% trans "The form contains errors" %}
-          </p>
+            <ul id="message-non-field-error">
+              <li class="fr-message fr-message--error" id="message-error">
+                {% trans "The form contains errors" %}
+              </li>
+              {% if form.non_field_errors %}
+                  {% for error in form.non_field_errors %}
+                  <li class="fr-message fr-message--error">{{ error }}</li>
+                {% endfor %}
+              {% endif %}
+            </ul>
           </div>
-        {% endif %}
       </div>
+      {% endif %}
 
       {% include "consent/includes/_manage_consents.html" %}
       {% include "consent/includes/_manage_company_informations.html" %}

--- a/src/dashboard/apps/consent/validators.py
+++ b/src/dashboard/apps/consent/validators.py
@@ -1,6 +1,7 @@
 """Dashboard consent app validators."""
 
-from django.core.exceptions import ValidationError
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from jsonschema import ValidationError as JSONSchemaValidationError
 from jsonschema import validate
 
@@ -40,3 +41,17 @@ def validate_control_authority_schema(value):
 
     validator = json_schema_validator(CONTROL_AUTHORITY_SCHEMA)
     return validator(value)
+
+
+def validate_configured_control_authority():
+    """Validates the `settings.CONSENT_CONTROL_AUTHORITY`.
+
+    Check if settings.CONSENT_CONTROL_AUTHORITY is valid,
+    raise ImproperlyConfigured otherwise.
+    """
+    try:
+        validate_control_authority_schema(settings.CONSENT_CONTROL_AUTHORITY)
+    except ValidationError as e:
+        raise ImproperlyConfigured(
+            f"settings.CONSENT_CONTROL_AUTHORITY validation error: {e.message}"
+        ) from e


### PR DESCRIPTION
## Purpose

We need to update all consents with the contractual data once they are validated by the user.
The new data to be incorporated are: company information, representative information, control authority information and all information from the form (checkbox, signature date, ...)


## Proposal

- [x] Added company, control authority, and representative data in consent bulk updates.
- [x] Enhanced the `ConsentFormView` to handle form errors.
- [x] Updated consent records with validated fields and related data. 
- [x] Adjusted tests to incorporate mock form data and validated consent updates.
