### PR TITLE
Add `/dynamique/session/check` endpoint

### DIFF
--- a/bin/metabase-init
+++ b/bin/metabase-init
@@ -27,7 +27,6 @@ fi
 echo "⚙️ Configuring metabase…"
 ${JQ} -n "{ \
   database: null, \
-  invite: null, \
   prefs: { \
     allow_tracking: false, \
     site_locale: \"en\", \

--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Implement a new `/dynamique/session/check` endpoint to check if a target
+  session exists or not
+
 ## [0.18.0] - 2025-02-10
 
 ### Added

--- a/src/api/qualicharge/factories/dynamic.py
+++ b/src/api/qualicharge/factories/dynamic.py
@@ -6,7 +6,7 @@ from polyfactory.factories.pydantic_factory import ModelFactory
 
 from ..fixtures.operational_units import prefixes
 from ..models.dynamic import SessionCreate, StatusCreate
-from ..schemas.core import Status
+from ..schemas.core import Session, Status
 from . import FrenchDataclassFactory, TimestampedSQLModelFactory
 
 
@@ -26,6 +26,10 @@ class StatusCreateFactory(ModelFactory[StatusCreate]):
         lambda: DataclassFactory.__random__.choice(prefixes)
         + FrenchDataclassFactory.__faker__.pystr_format("E######")
     )
+
+
+class SessionFactory(TimestampedSQLModelFactory[Session]):
+    """Session schema factory."""
 
 
 class StatusFactory(TimestampedSQLModelFactory[Status]):

--- a/src/client/qcc/cli/session.py
+++ b/src/client/qcc/cli/session.py
@@ -1,6 +1,7 @@
 """QualiCharge API client CLI: statuc."""
 
 from typing import Annotated, Optional
+from uuid import UUID
 
 import click
 import typer
@@ -57,3 +58,16 @@ def bulk(
     )
 
     print(f"[green]Created {n_created} sessions successfully.[/green]")
+
+
+@app.command()
+def check(
+    ctx: typer.Context,
+    session_id: UUID,
+):
+    """Check if session exists."""
+    client: QCC = ctx.obj
+
+    async_run_api_query(client.session.check, session_id)
+
+    print(f"[green]Session {session_id} exists.[/green]")

--- a/src/client/qcc/endpoints/dynamic.py
+++ b/src/client/qcc/endpoints/dynamic.py
@@ -3,6 +3,7 @@
 import logging
 from datetime import datetime
 from typing import AsyncIterator, List, Optional
+from uuid import UUID
 
 import httpx
 
@@ -69,3 +70,12 @@ class Session(BaseCreateEndpoint):
     """/dynamique/session endpoints."""
 
     endpoint: str = "/dynamique/session"
+
+    async def check(self, id_: UUID) -> None:
+        """Check if the target session exists."""
+        params = {"session_id": str(id_)}
+        response = await self.client.get(f"{self.endpoint}/check", params=params)
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as err:
+            raise APIRequestError("Session not found.") from err

--- a/src/client/tests/cli/test_session.py
+++ b/src/client/tests/cli/test_session.py
@@ -142,3 +142,29 @@ def test_cli_session_bulk_chunks(runner, qcc, httpx_mock, chunk_size):
     )
     assert result.exit_code == QCCExitCodes.OK
     assert "Created 30 sessions successfully" in result.stdout
+
+
+def test_cli_session_check(runner, qcc, httpx_mock):
+    """Test the `session bulk` command with different chunk sizes."""
+    # The session exists
+    httpx_mock.add_response(
+        method="GET",
+        url="http://example.com/api/v1/dynamique/session/check?session_id=feab81dc-4ff9-4aca-8e1b-f364aec2eae5",
+    )
+    result = runner.invoke(
+        app, ["check", "feab81dc-4ff9-4aca-8e1b-f364aec2eae5"], obj=qcc
+    )
+    assert result.exit_code == QCCExitCodes.OK
+    assert "Session feab81dc-4ff9-4aca-8e1b-f364aec2eae5 exists." in result.stdout
+
+    # The session does not exist
+    httpx_mock.add_response(
+        method="GET",
+        url="http://example.com/api/v1/dynamique/session/check?session_id=feab81dc-4ff9-4aca-8e1b-f364aec4eae5",
+        status_code=404,
+    )
+    result = runner.invoke(
+        app, ["check", "feab81dc-4ff9-4aca-8e1b-f364aec4eae5"], obj=qcc
+    )
+    assert result.exit_code == QCCExitCodes.API_EXCEPTION
+    assert "Session not found." in result.stdout


### PR DESCRIPTION
## Purpose

We need a way to check that session have been properly recorded.

## Proposal

Submit a session UUID if it exists, the API returns a HTTP 200 OK code, else 404.

- [x] add new `/dynamique/session/check` API endpoint
- [x] integrate this new endpoint in the `qcc` client
- [x] test the client integration
- [x] test the API endpoint
