### PR TITLE
🔖(api:minor) bump release to 0.18.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.18.0] - 2025-02-10
+
 ### Added
 
 - Integrate `postgresql_audit` for critical database changes versioning
@@ -313,7 +315,8 @@ and this project adheres to
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.17.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.18.0...main
+[0.18.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.14.0...v0.15.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -3,7 +3,7 @@
 #
 [project]
 name = "qualicharge"
-version = "0.17.0"
+version = "0.18.0"
 
 # Third party packages configuration
 [tool.coverage.run]

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.17.0"
+__version__ = "0.18.0"


### PR DESCRIPTION
### Added

- Integrate `postgresql_audit` for critical database changes versioning

### Changed

- Update the list of active operational units
- Upgrade fastapi to `0.115.8`
- Upgrade pydantic to `2.10.6`
- Upgrade pyinstrument to `5.0.1`
