### PR TITLE
⚡️(api) use background tasks in /dynamique (bulk) create endpoints

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
 ### Changed
 
 - Improve bulk endpoints documentation
+- Improve `/dynamique` (bulk) create endpoint performance by using background
+  tasks
 
 ## [0.18.0] - 2025-02-10
 


### PR DESCRIPTION
## Purpose

Improve query duration for /dynamique creation endpoint by using background tasks as early as possible.

## Proposal

- [x] perform database insertions after the API responds with expected object(s) UUID(s)
