### PR TITLE
[API] fix CI bench

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -161,6 +161,7 @@ jobs:
           zcat ../../data/irve-statique.json.gz | \
             head -n 500 | \
             pipenv run qcc static bulk --chunk-size 100
+          pipenv run python -m qualicharge refresh-static
         env:
           QCC_API_LOGIN_USERNAME: admin
           QCC_API_LOGIN_PASSWORD: admin
@@ -193,6 +194,10 @@ jobs:
         # Only when in PR, not when merged to main
         if: ${{ github.event_name == 'pull_request' }}
         run: |
+          pipenv run csvlook -I ../../data/bench.csv
+          echo "===="
+          pipenv run csvlook -I bench_admin_stats_stamped.csv
+          echo "===="
           echo -e "### Current benchmark\n\n" >> bench_admin_stats.md && \
           pipenv run csvlook -I bench_admin_stats_stamped.csv >> bench_admin_stats.md && \
           echo -e "\n### Comparison with the latest previous benchmark\n\n" >> bench_admin_stats.md && \

--- a/src/bench/cli.py
+++ b/src/bench/cli.py
@@ -44,7 +44,8 @@ def diff(database: Path, current: Path, short: bool = True):
     latest_revision = (
         db[["git", "timestamp"]].sort_values(by="timestamp").tail(1)["git"].iloc[0]
     )
-    latest = db.loc[db["git"] == latest_revision]
+    latest = db[db["git"] == latest_revision]
+    latest.reset_index(drop=True, inplace=True)
 
     # Calculate diff
     cols = list(


### PR DESCRIPTION
## Purpose

Benchmark of the API using Locust is broken: it generates errors since we are using the Statique MV and the benchmark diff from latest bench database entry is empty.

## Proposal

- [x] refresh the `Statique` MV once the database has been seeded
- [x] fix benchmark diff
