### PR TITLE
Rollback Git LFS integration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-data/qualicharge-api-data.sql filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/prefect.yml
+++ b/.github/workflows/prefect.yml
@@ -80,8 +80,6 @@ jobs:
       QUALICHARGE_DATABASE_URL_NO_DRIVER: "postgresql://qualicharge:pass@localhost:5432/qualicharge-api"
     steps:
       - uses: actions/checkout@v4
-      - name: Fetch & checkout LFS-managed files
-        run: git lfs pull
       - name: Restore database dump
         run: |
           pg_restore -s -F c -d "${QUALICHARGE_DATABASE_URL_NO_DRIVER}" ../../data/qualicharge-api-schema.sql

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ vous invitons à consulter notre
 Pour travailler sur ce projet, vous aurez besoin d'installer les outils suivants
 sur votre poste de travail :
 
-- [Git-lfs](https://git-lfs.com)
 - [Docker](https://www.docker.com)
 - [Docker compose](https://docs.docker.com/compose/)
 - [GNU Make](https://www.gnu.org/software/make/manual/make.html)
@@ -36,9 +35,6 @@ git clone git@github.com:MTES-MCT/qualicharge.git
 
 # Aller dans le repository local du projet
 cd qualicharge
-
-# Récupérer les fichiers gérés par Git-LFS
-git lfs pull
 ```
 
 Une fois le projet cloné, vous pouvez l'initialiser en utilisant la commande

--- a/src/prefect/pyproject.toml
+++ b/src/prefect/pyproject.toml
@@ -5,6 +5,9 @@
 name = "qualicharge-prefect"
 version = "0.0.1"
 
+# FIXME
+# I'm here so that the Prefect CI is triggered
+
 # Third party packages configuration
 [tool.pytest.ini_options]
 addopts = "-v --cov-report term-missing --cov=indicators"


### PR DESCRIPTION
## Purpose

Git-LFS free quota is relatively low at an organization level. Since its usage is blocking us right now, we think that for a single 48Mb tracked file, it's worth it. So let's switch back to raw Git tracking for database dumps.

## Proposal

- [x] remove Git-LFS integration
- [x] update documentation
