### PR TITLE
✨(dashboard) add validated consent view

### DIFF
--- a/src/dashboard/CHANGELOG.md
+++ b/src/dashboard/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 - add ProConnect authentication system
 - add dashboard homepage
 - add consent form to manage consents of one or many entities
+- added a validated consent page allowing consultation of validated consent for the 
+  current period.
 - add an email notification to users (via Brevo) after they have validated their consents.
 - add admin integration for Entity, DeliveryPoint and Consent
 - add mass admin action (make revoked) for consents

--- a/src/dashboard/apps/consent/templates/consent/includes/_consent_summary_card.html
+++ b/src/dashboard/apps/consent/templates/consent/includes/_consent_summary_card.html
@@ -16,32 +16,12 @@
 
       {# awaiting consent - no items #}
       {% if resume_awaiting and not has_awaiting_consent %}
-        <div class="fr-card__desc fr-highlight">
-          <p class="fr-card__desc">
-            Aucune autorisation en attente.
-            <br />
-            Si vous pensez qu'il s'agit d'une erreur, merci de contacter l'équipe QualiCharge.
-            <a class="fr-link fr-card__desc"
-              href="mailto:{{ contact_email }}?subject=[QualiCharge] Aucune autorisation en attente dans le Dashboard." target="_blank">
-              {{ contact_email }}
-            </a>
-          </p>
-        </div>
+        {% include "consent/includes/_no_data_card.html" with description="Aucune autorisation en attente." %}
       {% endif %}
 
       {# validated consent - no items #}
       {% if resume_validated and not has_validated_consent %}
-        <div class="fr-card__desc fr-highlight">
-          <p class="fr-card__desc">
-            Aucune station suivie.
-            <br />
-            Si vous pensez qu'il s'agit d'une erreur, merci de contacter l'équipe QualiCharge.
-            <a class="fr-link fr-card__desc"
-              href="mailto:{{ contact_email }}?subject=[QualiCharge] Aucune station suivie dans le Dashboard." target="_blank">
-              {{ contact_email }}
-            </a>
-          </p>
-        </div>
+        {% include "consent/includes/_no_data_card.html" with description="Aucune station suivie." %}
       {% endif %}
     </div>
 

--- a/src/dashboard/apps/consent/templates/consent/includes/_consent_summary_validated.html
+++ b/src/dashboard/apps/consent/templates/consent/includes/_consent_summary_validated.html
@@ -44,7 +44,7 @@
                     </td>
                     <td class="fr-cell--center">
                         <a class="fr-link fr-icon-arrow-right-line fr-link--icon-right"
-                           href="{% url "consent:manage" entity.slug %}"
+                           href="{% url "consent:validated" entity.slug %}"
                            data-fr-js-link-actionee="true">
                           Consulter la liste
                         </a>

--- a/src/dashboard/apps/consent/templates/consent/includes/_no_data_card.html
+++ b/src/dashboard/apps/consent/templates/consent/includes/_no_data_card.html
@@ -1,0 +1,11 @@
+<div class="fr-card__desc fr-highlight">
+  <p class="fr-card__desc">
+    {{ description }}
+    <br />
+    Si vous pensez qu'il s'agit d'une erreur, merci de contacter l'équipe QualiCharge.
+    <a class="fr-link fr-card__desc"
+      href="mailto:{{ contact_email }}?subject=[QualiCharge] Dashboard - {{ description }}." target="_blank">
+      {{ contact_email }}
+    </a>
+  </p>
+</div>

--- a/src/dashboard/apps/consent/templates/consent/validated.html
+++ b/src/dashboard/apps/consent/templates/consent/validated.html
@@ -1,0 +1,64 @@
+{% extends "consent/base.html" %}
+
+{% load dsfr_tags %}
+
+{% load i18n static %}
+
+{% block dashboard_content %}
+  <h2>Stations suivies</h2>
+
+  <p>
+    Retrouver ici la liste des stations pour lesquelles la DGEC consulte le gestionnaire
+    de réseau et émet des certificats.
+  </p>
+
+  {% if consents %}
+    <div class="fr-table fr-table--no-caption" id="table-pdl-component">
+      <div class="fr-table__wrapper">
+        <div class="fr-table__container">
+          <div class="fr-table__content">
+
+            <table id="table-pdl" aria-labelledby="table-pdl-caption">
+              <caption id="table-pdl-caption"> Points de livraison suivis </caption>
+
+              <thead>
+                <tr>
+                  <th scope="col">
+                    <div class="fr-cell__title">Nom de la station</div>
+                  </th>
+                  <th scope="col">
+                    <div class="fr-cell__title">Identifiant de la station</div>
+                  </th>
+                  <th scope="col">
+                    <div class="fr-cell__title">Identifiant du PDL</div>
+                  </th>
+                </tr>
+              </thead>
+
+              <tbody>
+                {% for consent in consents %}
+                  <tr id="table-pdl-row-key-{{ forloop.counter }}"
+                      data-row-key="{{ forloop.counter }}"
+                      aria-labelledby="row-label-{{ forloop.counter }}">
+
+                    {# todo : get station_name, station_id, prm_id #}
+                    <td> -- station name -- </td>
+                    <td> -- station id --  </td>
+                    <td> {{ consent.delivery_point.provider_assigned_id }} </td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+
+          </div>
+        </div>
+      </div>
+    </div>
+
+    {% dsfr_pagination page_obj %}
+
+  {% else %}
+    {% include "consent/includes/_no_data_card.html" with description="Aucune station suivie." %}
+  {% endif %}
+
+{% endblock dashboard_content %}

--- a/src/dashboard/apps/consent/urls.py
+++ b/src/dashboard/apps/consent/urls.py
@@ -3,7 +3,7 @@
 from django.urls import path
 from django.views.generic.base import RedirectView
 
-from .views import ConsentFormView, IndexView
+from .views import ConsentFormView, IndexView, ValidatedConsentView
 
 app_name = "consent"
 
@@ -17,4 +17,10 @@ urlpatterns = [
         name="manage",
     ),
     path("manage/<slug:slug>", ConsentFormView.as_view(), name="manage"),
+    path(
+        "validated/",
+        RedirectView.as_view(pattern_name="consent:index", permanent=False),
+        name="validated",
+    ),
+    path("validated/<slug:slug>", ValidatedConsentView.as_view(), name="validated"),
 ]

--- a/src/dashboard/apps/core/models.py
+++ b/src/dashboard/apps/core/models.py
@@ -134,6 +134,10 @@ class Entity(DashboardBase):
         """Get all awaiting consents for this entity."""
         return self.get_consents(AWAITING)
 
+    def get_validated_consents(self) -> QuerySet:
+        """Get all awaiting consents for this entity."""
+        return self.get_consents(VALIDATED)
+
 
 class DeliveryPoint(DashboardBase):
     """Represents a delivery point for electric vehicles.


### PR DESCRIPTION
## Purpose

Users must be able to view validated consents for the current period

## Proposal

- [x] Implemented a view to display validated consents with appropriate permissions. 
- [x] Added tests to ensure proper behavior of the validated consent view and permissions.
- [x] Updated the changelog

## In addition

- [x] Modularized the no-data card template to reduce duplication across consent summary templates.