### PR TITLE
🔖(api:minor) bump release to 0.19.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.19.0] - 2025-02-25
+
 ### Added
 
 - Implement a new `/dynamique/session/check` endpoint to check if a target
@@ -332,7 +334,8 @@ and this project adheres to
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.18.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.19.0...main
+[0.19.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.15.0...v0.16.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -3,7 +3,7 @@
 #
 [project]
 name = "qualicharge"
-version = "0.18.0"
+version = "0.19.0"
 
 # Third party packages configuration
 [tool.coverage.run]

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.18.0"
+__version__ = "0.19.0"


### PR DESCRIPTION
### Added

- Implement a new `/dynamique/session/check` endpoint to check if a target session exists or not

### Changed

- Improve bulk endpoints documentation
- Improve `/dynamique` (bulk) create endpoint performance by using background tasks
- Upgrade cachetools to `5.5.2`
- Upgrade geoalchemy2 to `0.17.1`
- Upgrade psycopg to `3.2.5`
- Upgrade pyarrow to `19.0.1`
- Upgrade pydantic-settings to `2.8.0`
- Upgrade sentry-sdk to `2.22.0`
