### PR TITLE
✨(dashboard) add email notification for user validation

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -38,6 +38,7 @@ jobs:
     env:
       DASHBOARD_DATABASE_URL: psql://qualicharge:pass@postgresql:5432/qualicharge-dashboard
       DASHBOARD_SECRET_KEY: the_secret_key
+      DASHBOARD_DOMAIN: https://dashboard.qualicharge.beta.gouv.fr
       DASHBOARD_CONTROL_AUTHORITY_NAME: QualiCharge
       DASHBOARD_CONTROL_AUTHORITY_ADDRESS_1: 1 rue de test
       DASHBOARD_CONTROL_AUTHORITY_ZIP_CODE: 75000
@@ -49,6 +50,7 @@ jobs:
       DASHBOARD_DEFAULT_FROM_EMAIL: contact@exemple.com
       DASHBOARD_BREVO_API_KEY: the_secret_api_key
       DASHBOARD_CONSENT_VALIDATION_TEMPLATE_ID: 3
+      DASHBOARD_VALIDATED_USER_TEMPLATE_ID: 5
       DASHBOARD_PROCONNECT_CLIENT_ID: the_client_id
       DASHBOARD_PROCONNECT_CLIENT_SECRET: the_secret_key
       DASHBOARD_PROCONNECT_DOMAIN: proconnect_endpoint
@@ -117,6 +119,7 @@ jobs:
           DASHBOARD_DB_NAME: test-qualicharge-dashboard
           DASHBOARD_DATABASE_URL: psql://qualicharge:pass@localhost:5432/test-qualicharge-dashboard
           DASHBOARD_SECRET_KEY: the_secret_key
+          DASHBOARD_DOMAIN: https://dashboard.qualicharge.beta.gouv.fr
           DASHBOARD_CONTROL_AUTHORITY_NAME: QualiCharge
           DASHBOARD_CONTROL_AUTHORITY_ADDRESS_1: 1 rue de test
           DASHBOARD_CONTROL_AUTHORITY_ZIP_CODE: 75000
@@ -128,6 +131,7 @@ jobs:
           DASHBOARD_DEFAULT_FROM_EMAIL: contact@exemple.com
           DASHBOARD_BREVO_API_KEY: the_secret_api_key
           DASHBOARD_CONSENT_VALIDATION_TEMPLATE_ID: 3
+          DASHBOARD_VALIDATED_USER_TEMPLATE_ID: 5
           DASHBOARD_PROCONNECT_CLIENT_ID: the_client_id
           DASHBOARD_PROCONNECT_CLIENT_SECRET: the_secret_key
           DASHBOARD_PROCONNECT_DOMAIN: proconnect_endpoint

--- a/env.d/dashboard
+++ b/env.d/dashboard
@@ -9,6 +9,9 @@ DASHBOARD_SECRET_KEY=the_secret_key
 DASHBOARD_DB_NAME=qualicharge-dashboard
 DASHBOARD_DATABASE_URL=psql://qualicharge:pass@postgresql:5432/qualicharge-dashboard
 
+# dashboard
+DASHBOARD_DOMAIN="https://beta.gouv.fr/startups/qualicharge.html"
+
 # Third-party integrations
 DASHBOARD_SENTRY_DSN=
 DASHBOARD_SENTRY_TRACES_SAMPLE_RATE=1.0
@@ -48,6 +51,7 @@ DASHBOARD_DEFAULT_FROM_EMAIL=no-reply@qualicharge.beta.gouv.fr
 # Brevo Emailing
 DASHBOARD_BREVO_API_KEY=
 DASHBOARD_CONSENT_VALIDATION_TEMPLATE_ID=3
+DASHBOARD_VALIDATED_USER_TEMPLATE_ID=5
 
 # Annuaire des Entreprises API
 DASHBOARD_ANNUAIRE_ENTREPRISE_API_ROOT_URL="https://staging.entreprise.api.gouv.fr/v3/"

--- a/src/dashboard/apps/auth/models.py
+++ b/src/dashboard/apps/auth/models.py
@@ -1,5 +1,9 @@
 """Dashboard auth models."""
 
+import sentry_sdk
+from anymail.exceptions import AnymailRequestsAPIError
+from anymail.message import AnymailMessage
+from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 from django.db.models import Q, QuerySet
@@ -25,6 +29,16 @@ class DashboardUser(AbstractUser):
         ),
     )
 
+    def save(self, *args, **kwargs):
+        """Override the save method to send a validation email."""
+        # Check if `is_validated` changes to True
+        if self.pk:
+            previous = DashboardUser.objects.filter(pk=self.pk).first()
+            if not previous.is_validated and self.is_validated:
+                self.send_validation_email()
+
+        super().save(*args, **kwargs)
+
     def get_entities(self) -> QuerySet[Entity]:
         """Get a list of entities, and their proxies associated."""
         return Entity.objects.filter(Q(users=self) | Q(proxies__users=self)).distinct()
@@ -32,3 +46,30 @@ class DashboardUser(AbstractUser):
     def can_validate_entity(self, entity: Entity) -> bool:
         """Determines if the provided entity can be validated."""
         return entity in self.get_entities()
+
+    def send_validation_email(self) -> None:
+        """Send a validation email to the user."""
+        email_to = self.email
+        email_config = settings.DASHBOARD_EMAIL_CONFIGS["validated_user"]
+        email_data = {
+            email_to: {
+                "last_name": self.last_name,  # type: ignore[union-attr]
+                "first_name": self.first_name,  # type: ignore[union-attr]
+                "link": email_config.get("link"),
+                "support_email": settings.CONTACT_EMAIL,
+            },
+        }
+
+        email = AnymailMessage(
+            to=[
+                email_to,
+            ],
+            template_id=email_config.get("template_id"),
+            merge_data=email_data,
+        )
+
+        try:
+            email.send()
+        except AnymailRequestsAPIError as e:
+            # fail silently and send a sentry log
+            sentry_sdk.capture_exception(e)

--- a/src/dashboard/apps/auth/tests/test_models.py
+++ b/src/dashboard/apps/auth/tests/test_models.py
@@ -1,9 +1,14 @@
 """Dashboard auth models tests."""
 
+from unittest.mock import patch
+
 import pytest
+from anymail.exceptions import AnymailRequestsAPIError
+from django.conf import settings
 from pytest_django.asserts import assertQuerySetEqual
 
 from apps.auth.factories import AdminUserFactory, UserFactory
+from apps.auth.models import DashboardUser
 from apps.core.factories import EntityFactory
 
 
@@ -78,3 +83,64 @@ def test_can_validate_entity():
     assert user4.can_validate_entity(entity4) is True
     assert user4.can_validate_entity(entity5) is True
     assert user4.can_validate_entity(entity2) is True
+
+
+@pytest.mark.django_db
+def test_save_triggers_validation_email():
+    """Test the `save` method triggers a validation email."""
+    user = UserFactory(is_validated=False)
+
+    # `is_validated` doesn't change to True: an email should NOT be sent.
+    with patch.object(DashboardUser, "send_validation_email") as mock_send_email:
+        user.save()
+        mock_send_email.assert_not_called()
+
+    # `is_validated` changes to True: an email should be sent.
+    with patch.object(DashboardUser, "send_validation_email") as mock_send_email:
+        user.is_validated = True
+        user.save()
+        mock_send_email.assert_called_once_with()
+
+    # `is_validated` remains to True: an email should NOT be sent.
+    user.refresh_from_db()
+    with patch.object(DashboardUser, "send_validation_email") as mock_send_email:
+        user.is_validated = True
+        user.save()
+        mock_send_email.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_send_validation_email_success():
+    """Test `send_validation_email` successfully sends an email."""
+    user = UserFactory(email="testuser@example.com")
+
+    with patch("apps.auth.models.AnymailMessage") as mock_message:
+        email_send_mock = mock_message.return_value.send
+        user.send_validation_email()
+
+        expected_email_config = settings.DASHBOARD_EMAIL_CONFIGS["validated_user"]
+        mock_message.assert_called_once_with(
+            to=["testuser@example.com"],
+            template_id=expected_email_config.get("template_id"),
+            merge_data={
+                "testuser@example.com": {
+                    "last_name": user.last_name,
+                    "first_name": user.first_name,
+                    "link": expected_email_config.get("link"),
+                    "support_email": settings.CONTACT_EMAIL,
+                },
+            },
+        )
+        email_send_mock.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_send_validation_email_handles_exception():
+    """Test `send_validation_email` handles email sending exception."""
+    user = UserFactory(email="testuser@example.com")
+
+    with patch("apps.auth.models.AnymailMessage") as mock_message:
+        mock_message.return_value.send.side_effect = AnymailRequestsAPIError()
+        with patch("apps.auth.models.sentry_sdk.capture_exception") as mock_sentry:
+            user.send_validation_email()
+            mock_sentry.assert_called_once()

--- a/src/dashboard/dashboard/settings.py
+++ b/src/dashboard/dashboard/settings.py
@@ -254,8 +254,14 @@ DASHBOARD_EMAIL_CONFIGS = {
     # they validate their consents.
     "consent_validation": {
         "template_id": env.int("CONSENT_VALIDATION_TEMPLATE_ID"),
-        "link": "https://beta.gouv.fr/startups/qualicharge.html",
-    }
+        "link": env.str("DOMAIN"),
+    },
+    # Configuration for the notification email sent to the user when
+    # the user has been validated by an admin.
+    "validated_user": {
+        "template_id": env.int("VALIDATED_USER_TEMPLATE_ID"),
+        "link": env.str("DOMAIN"),
+    },
 }
 
 # API Annuaire des Entreprises


### PR DESCRIPTION
## Purpose

When an admin validates a new user, we need to notify the user by sending a notification.

## Proposal

- [x] add the email notification when a user's `is_validated` status changes to True. 
- [x] add environment configuration
- [x] add test coverage
- [x] add Brevo template
