### PR TITLE
✨(dashboard) add siret sync functionality to DashboardUser admin

### DIFF
--- a/src/dashboard/apps/auth/admin.py
+++ b/src/dashboard/apps/auth/admin.py
@@ -1,9 +1,16 @@
 """Dashboard auth admin."""
 
-from django.contrib import admin
+import sentry_sdk
+from django.contrib import admin, messages
 from django.contrib.auth.admin import UserAdmin
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from django.utils.html import escape, mark_safe  # type: ignore
 from django.utils.translation import gettext_lazy as _
 
+from ..core.helpers import sync_entity_from_siret
+from ..core.models import Entity
+from .forms import DashboardUserForm
 from .models import DashboardUser
 
 
@@ -11,6 +18,7 @@ from .models import DashboardUser
 class DashboardUserAdmin(UserAdmin):
     """Dashboard user admin based on UserAdmin."""
 
+    form = DashboardUserForm
     fieldsets = (
         (None, {"fields": ("username", "password")}),
         (_("Personal info"), {"fields": ("first_name", "last_name", "email")}),
@@ -37,5 +45,43 @@ class DashboardUserAdmin(UserAdmin):
         "last_name",
         "is_staff",
         "is_validated",
+        "is_attached_to_entity",
     )
     list_filter = ("is_staff", "is_superuser", "is_active", "groups", "is_validated")
+
+    def response_change(self, request, obj):
+        """Synchronize the entity.
+
+        Sync the entity with "annuaire des entreprises" API and attaches it to the user.
+        """
+        if "_sync_entity" in request.POST:
+            try:
+                entity: Entity = sync_entity_from_siret(obj.siret, obj)
+            except Exception as e:
+                sentry_sdk.capture_exception(e)
+                messages.error(
+                    request,
+                    _(f"Entity synchronization error ({obj.siret}): {str(e)}"),
+                )
+            else:
+                entity_url = reverse("admin:qcd_core_entity_change", args=[entity.id])
+                self.message_user(
+                    request,
+                    mark_safe(  # noqa: S308
+                        _(
+                            f"Entity with siret {escape(obj.siret)} has been synced. "
+                            f"(Entity: <a href='{escape(entity_url)}' target='_blank'>"
+                            f"{escape(entity)}</a>)."
+                        )
+                    ),
+                    messages.SUCCESS,
+                )
+            return HttpResponseRedirect(".")
+        return super().response_change(request, obj)
+
+    def is_attached_to_entity(self, obj) -> bool:
+        """Return True if the user is attached to an entity."""
+        return obj.get_entities().exists()
+
+    is_attached_to_entity.short_description = _("is attached to an Entity")  # type: ignore
+    is_attached_to_entity.boolean = True  # type: ignore

--- a/src/dashboard/apps/auth/forms.py
+++ b/src/dashboard/apps/auth/forms.py
@@ -1,0 +1,57 @@
+"""Dashboard auth forms."""
+
+from django import forms
+from django.contrib.auth.forms import UserChangeForm
+from django.utils.translation import gettext_lazy as _
+
+from .models import DashboardUser
+
+
+class SiretSyncButtonWidget(forms.Widget):
+    """Custom widget for the siret field.
+
+    The widget adds a button to the form to trigger the entity synchronization.
+    """
+
+    template_name = "auth/widgets/siret_sync_button.html"
+
+    def __init__(self, *args, user_instance=None, **kwargs):
+        """Initialize the widget."""
+        self.user_instance = user_instance
+        super().__init__(*args, **kwargs)
+
+    def get_context(self, name, value, attrs):
+        """Add custom context to the widget template."""
+        context = super().get_context(name, value, attrs)
+        context["entities"] = self.get_user_entities()
+        return context
+
+    def get_user_entities(self):
+        """Returns entities linked to the user instance."""
+        if self.user_instance:
+            return self.user_instance.get_entities()
+        return None
+
+
+class DashboardUserForm(UserChangeForm):
+    """Dashboard user form."""
+
+    class Meta:
+        """Meta for DashboardUserForm."""
+
+        model = DashboardUser
+        fields = "__all__"
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the form and add a custom widget to the 'siret' field."""
+        self.instance = kwargs.get("instance")
+        super().__init__(*args, **kwargs)
+
+        # add a custom widget to the siret field
+        siret = self.fields.get("siret")
+        if siret:
+            siret.widget = SiretSyncButtonWidget(user_instance=self.instance)
+            siret.help_text = _(
+                "Synchronize the entity with the 'Annuaire des Entreprises' "
+                "API and attach the user to it."
+            )

--- a/src/dashboard/apps/auth/templates/auth/widgets/siret_sync_button.html
+++ b/src/dashboard/apps/auth/templates/auth/widgets/siret_sync_button.html
@@ -1,0 +1,22 @@
+{% load i18n %}
+
+<div{% include "django/forms/widgets/attrs.html" %}>
+  <p>
+    <input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}>
+  </p>
+
+  <p>
+    <input type="submit" value="{% trans "Synchronize Entity" %}" name="_sync_entity">
+    {% if entities %}
+      <span>
+        {% trans "The user is already attached to the entity:" %}
+        {% for entity in entities %}
+          <a href="{% url "admin:qcd_core_entity_change" entity.id %}" target="_blank">{{ entity }}</a>{% if not forloop.last %},{% endif %}
+        {% endfor %}
+      </span>
+    {% else %}
+      <span>{% trans "No entity attached to this user" %}</span>
+    {% endif %}
+  </p>
+</div>
+

--- a/src/dashboard/apps/auth/tests/tests_admin.py
+++ b/src/dashboard/apps/auth/tests/tests_admin.py
@@ -1,0 +1,138 @@
+"""Dashboard auth admin tests."""
+
+from http import HTTPStatus
+
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.contrib.messages import get_messages
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.core.exceptions import ValidationError
+from django.http import HttpRequest
+
+from apps.auth.admin import DashboardUserAdmin
+from apps.auth.factories import AdminUserFactory, UserFactory
+from apps.auth.models import DashboardUser
+from apps.core.factories import EntityFactory
+
+
+@pytest.mark.django_db
+def test_response_change_sync_entity_success(monkeypatch):
+    """Test successful entity synchronization in response_change."""
+    entity = EntityFactory()
+    fake_siret = "12345678901234"
+    fake_user = UserFactory(siret=fake_siret)
+    admin_user = AdminUserFactory()
+
+    # mock sync_entity_from_siret()
+    monkeypatch.setattr(
+        "apps.auth.admin.sync_entity_from_siret", lambda siret, user: entity
+    )
+
+    # simulate click on "synchronize entity" button
+    site = AdminSite()
+    admin = DashboardUserAdmin(DashboardUser, site)
+    request = HttpRequest()
+    request.method = "POST"
+    request.POST["_sync_entity"] = "1"
+    request.user = admin_user
+
+    # Add session middleware
+    middleware = SessionMiddleware(lambda req: None)
+    middleware.process_request(request)
+    request.session.save()
+
+    # mock message handler
+    request._messages = FallbackStorage(request)
+
+    # and finally, call the response_change() admin method
+    response = admin.response_change(request, fake_user)
+
+    assert response.status_code == HTTPStatus.FOUND
+    assert response.url == "."
+
+    # check the response message
+    messages = list(get_messages(request))
+    assert len(messages) == 1
+    expected_message = (
+        f"Entity with siret {fake_siret} has been synced. "
+        f"(Entity: <a href='/admin/qcd_core/entity/{entity.id}/change/' "
+        f"target='_blank'>{entity.name}</a>)."
+    )
+    assert messages[0].message == expected_message
+    assert messages[0].level_tag == "success"
+
+
+@pytest.mark.django_db
+def test_response_change_sync_entity_raise_error(monkeypatch):
+    """Test error during entity synchronization in response_change."""
+    fake_siret = "12345678901234"
+    fake_user = UserFactory(siret=fake_siret)
+    admin_user = AdminUserFactory()
+
+    # mock sync_entity_from_siret()
+    def mock_sync_entity_from_siret(siret, user):
+        raise ValidationError("This is a simulated exception.")
+
+    monkeypatch.setattr(
+        "apps.auth.admin.sync_entity_from_siret", mock_sync_entity_from_siret
+    )
+
+    # simulate click on "synchronize entity" button
+    site = AdminSite()
+    admin = DashboardUserAdmin(DashboardUser, site)
+    request = HttpRequest()
+    request.method = "POST"
+    request.POST["_sync_entity"] = "1"
+    request.user = admin_user
+
+    # Add session middleware
+    middleware = SessionMiddleware(lambda req: None)
+    middleware.process_request(request)
+    request.session.save()
+
+    # mock message handler
+    request._messages = FallbackStorage(request)
+
+    # and finally, call the response_change() admin method
+    response = admin.response_change(request, fake_user)
+
+    assert response.status_code == HTTPStatus.FOUND
+    assert response.url == "."
+
+    # check the error message
+    messages = list(get_messages(request))
+    assert len(messages) == 1
+    expected_message = (
+        f"Entity synchronization error ({fake_siret}): "
+        f"['This is a simulated exception.']"
+    )
+    assert messages[0].message == expected_message
+    assert messages[0].level_tag == "error"
+
+
+@pytest.mark.django_db
+def test_response_change_no_sync_entity(rf):
+    """Test response_change behavior without '_sync_entity' in POST data."""
+    fake_user = UserFactory()
+    admin_user = AdminUserFactory()
+
+    # simulate standard save (without '_sync_entity')
+    site = AdminSite()
+    admin = DashboardUserAdmin(DashboardUser, site)
+    request = rf.post(f"/admin/qcd_auth/dashboarduser/{fake_user.id}/change/", data={})
+    request.user = admin_user
+
+    # Add session middleware
+    middleware = SessionMiddleware(lambda req: None)
+    middleware.process_request(request)
+    request.session.save()
+
+    # mock message handler
+    request._messages = FallbackStorage(request)
+
+    # and finally, call the response_change() admin method
+    response = admin.response_change(request, fake_user)
+
+    # Since no '_sync_entity', it should call the parent's response_change
+    assert response.status_code == HTTPStatus.FOUND


### PR DESCRIPTION
## Purpose

in admin, we need to be able to easily trigger the retrieval of information of an Entity from the "Annuaire des Entreprises" API. We also need to link this entity to the user who has the SIRET.
We propose to add a button in a user's admin form to trigger this action.

## Proposal

- [x] enable syncing of entity data via SIRET directly from the admin interface. 
- [x] add a custom form widget and button for triggering sync actions. 
- [x] handle success and error scenarios with appropriate user messaging.
- [x] add indicator to the admin list display
- [x] add test