### PR TITLE
✨(dashboard) add user-entity attachment logic on ProConnect user creation

### DIFF
--- a/src/dashboard/apps/auth/admin.py
+++ b/src/dashboard/apps/auth/admin.py
@@ -37,5 +37,13 @@ class DashboardUserAdmin(UserAdmin):
         "last_name",
         "is_staff",
         "is_validated",
+        "is_attached_to_entity",
     )
     list_filter = ("is_staff", "is_superuser", "is_active", "groups", "is_validated")
+
+    def is_attached_to_entity(self, obj) -> bool:
+        """Return True if the user is attached to an entity."""
+        return obj.get_entities().exists()
+
+    is_attached_to_entity.short_description = _("is attached to an Entity")  # type: ignore
+    is_attached_to_entity.boolean = True  # type: ignore

--- a/src/dashboard/apps/auth/tests/test_backends.py
+++ b/src/dashboard/apps/auth/tests/test_backends.py
@@ -1,6 +1,12 @@
 """Dashboard auth backends tests."""
 
+from unittest.mock import patch
+
+import pytest
+
 from apps.auth.backends import OIDCAuthenticationBackend
+from apps.auth.factories import UserFactory
+from apps.core.factories import EntityFactory
 
 
 def test_clean_siret_valid():
@@ -27,3 +33,62 @@ def test_clean_siret_invalid():
     # Test with missing SIRET in claims.
     siret = backend.clean_siret(None)
     assert siret is None
+
+
+@pytest.mark.django_db
+@patch("apps.auth.backends.sync_entity_from_siret")
+def test_create_entity_with_valid_siret(mocked):
+    """Test create_entity with a valid SIRET and no user to attach."""
+    backend = OIDCAuthenticationBackend()
+
+    # create user
+    user = UserFactory(siret="12345678901234")
+
+    # mock sync_entity_from_siret()
+    mocked.return_value = EntityFactory()
+
+    # and finally test create_entity()
+    backend.create_entity("12345678901234", user)
+
+    # by default settings.PROCONNECT_ATTACH_USER_ON_CREATION = True,
+    # so user must not be not attached to entity and so user=None
+    mocked.assert_called_once_with("12345678901234", None)
+
+
+@pytest.mark.django_db
+@patch("apps.auth.backends.sync_entity_from_siret")
+def test_create_entity_with_valid_siretand_attach_user(mocked, settings):
+    """Test create_entity with a valid SIRET and user to attach."""
+    backend = OIDCAuthenticationBackend()
+
+    # user must be attached to entity
+    settings.PROCONNECT_ATTACH_USER_ON_CREATION = True
+
+    # create user
+    user = UserFactory(siret="12345678901234")
+
+    # mock sync_entity_from_siret()
+    mocked.return_value = EntityFactory()
+
+    # and finally test create_entity()
+    backend.create_entity("12345678901234", user)
+    mocked.assert_called_once_with("12345678901234", user)
+
+
+@pytest.mark.django_db
+@patch("apps.auth.backends.sync_entity_from_siret")
+def test_create_entity_with_siret_exception(mocked):
+    """Test create_entity when sync_entity_from_siret raises an exception."""
+    backend = OIDCAuthenticationBackend()
+
+    # create user
+    user = UserFactory(siret="12345678901234")
+
+    # sync_entity_from_siret raise an exception
+    mocked.side_effect = Exception("Sync error")
+
+    # and finally test create_entity()
+    with patch("sentry_sdk.capture_exception") as mock_capture_exception:
+        backend.create_entity("12345678901234", user)
+        mocked.assert_called_once_with("12345678901234", None)
+        mock_capture_exception.assert_called_once()

--- a/src/dashboard/apps/home/views.py
+++ b/src/dashboard/apps/home/views.py
@@ -13,7 +13,7 @@ class IndexView(TemplateView):
         context = super().get_context_data(**kwargs)
 
         entities = self.request.user.get_entities()
-        has_awaiting_consent = any(entity.get_consents for entity in entities)
+        has_awaiting_consent = any(entity.get_consents() for entity in entities)
 
         if has_awaiting_consent:
             context["top_detail"] = {

--- a/src/dashboard/dashboard/settings.py
+++ b/src/dashboard/dashboard/settings.py
@@ -188,6 +188,10 @@ OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS = 60 * 60
 OIDC_STORE_ID_TOKEN = True
 ALLOW_LOGOUT_GET_METHOD = True
 
+# if True, a new user created via ProConnect will be automatically attached to
+# the entity corresponding to their SIRET.
+PROCONNECT_ATTACH_USER_ON_CREATION = False
+
 # Sentry
 sentry_sdk.init(
     dsn=env.str("SENTRY_DSN"),


### PR DESCRIPTION
## Purpose

in admin, we need to be able to easily trigger the retrieval of information of an Entity from the "Annuaire des Entreprises" API. We also need to link this entity to the user who has the SIRET.

## Proposal

- [x] Implement functionality to create and sync entity from 'Annuaire des Entreprises' when user is created with ProConnect. 
- [x] Optionally attach users to entities based on settings. 
- [x] Add an indicator for user-entity linkage in the user admin list 
- [x] Add tests

## Fix

- [x] Minor fixes `home.views.py`.