### PR TITLE
✨(dashboard) add admin notification for new user registration

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -38,7 +38,7 @@ jobs:
     env:
       DASHBOARD_DATABASE_URL: psql://qualicharge:pass@postgresql:5432/qualicharge-dashboard
       DASHBOARD_SECRET_KEY: the_secret_key
-      DASHBOARD_DOMAIN: https://dashboard.qualicharge.beta.gouv.fr
+      DASHBOARD_DOMAIN: http://localhost:8030/
       DASHBOARD_CONTROL_AUTHORITY_NAME: QualiCharge
       DASHBOARD_CONTROL_AUTHORITY_ADDRESS_1: 1 rue de test
       DASHBOARD_CONTROL_AUTHORITY_ZIP_CODE: 75000
@@ -50,6 +50,7 @@ jobs:
       DASHBOARD_DEFAULT_FROM_EMAIL: contact@exemple.com
       DASHBOARD_BREVO_API_KEY: the_secret_api_key
       DASHBOARD_CONSENT_VALIDATION_TEMPLATE_ID: 3
+      DASHBOARD_NEW_SUBSCRIPTION_TEMPLATE_ID: 4
       DASHBOARD_VALIDATED_USER_TEMPLATE_ID: 5
       DASHBOARD_PROCONNECT_CLIENT_ID: the_client_id
       DASHBOARD_PROCONNECT_CLIENT_SECRET: the_secret_key
@@ -119,7 +120,7 @@ jobs:
           DASHBOARD_DB_NAME: test-qualicharge-dashboard
           DASHBOARD_DATABASE_URL: psql://qualicharge:pass@localhost:5432/test-qualicharge-dashboard
           DASHBOARD_SECRET_KEY: the_secret_key
-          DASHBOARD_DOMAIN: https://dashboard.qualicharge.beta.gouv.fr
+          DASHBOARD_DOMAIN: http://localhost:8030/
           DASHBOARD_CONTROL_AUTHORITY_NAME: QualiCharge
           DASHBOARD_CONTROL_AUTHORITY_ADDRESS_1: 1 rue de test
           DASHBOARD_CONTROL_AUTHORITY_ZIP_CODE: 75000
@@ -131,6 +132,7 @@ jobs:
           DASHBOARD_DEFAULT_FROM_EMAIL: contact@exemple.com
           DASHBOARD_BREVO_API_KEY: the_secret_api_key
           DASHBOARD_CONSENT_VALIDATION_TEMPLATE_ID: 3
+          DASHBOARD_NEW_SUBSCRIPTION_TEMPLATE_ID: 4
           DASHBOARD_VALIDATED_USER_TEMPLATE_ID: 5
           DASHBOARD_PROCONNECT_CLIENT_ID: the_client_id
           DASHBOARD_PROCONNECT_CLIENT_SECRET: the_secret_key

--- a/env.d/dashboard
+++ b/env.d/dashboard
@@ -10,7 +10,7 @@ DASHBOARD_DB_NAME=qualicharge-dashboard
 DASHBOARD_DATABASE_URL=psql://qualicharge:pass@postgresql:5432/qualicharge-dashboard
 
 # dashboard
-DASHBOARD_DOMAIN="https://beta.gouv.fr/startups/qualicharge.html"
+DASHBOARD_DOMAIN="http://localhost:8030/"
 
 # Third-party integrations
 DASHBOARD_SENTRY_DSN=
@@ -51,6 +51,7 @@ DASHBOARD_DEFAULT_FROM_EMAIL=no-reply@qualicharge.beta.gouv.fr
 # Brevo Emailing
 DASHBOARD_BREVO_API_KEY=
 DASHBOARD_CONSENT_VALIDATION_TEMPLATE_ID=3
+DASHBOARD_NEW_SUBSCRIPTION_TEMPLATE_ID=4
 DASHBOARD_VALIDATED_USER_TEMPLATE_ID=5
 
 # Annuaire des Entreprises API

--- a/src/dashboard/dashboard/settings.py
+++ b/src/dashboard/dashboard/settings.py
@@ -210,6 +210,8 @@ sentry_sdk.init(
     send_default_pii=True,
 )
 
+## Dashboard
+DASHBOARD_DOMAIN = env.str("DOMAIN")
 
 ## Consent app
 
@@ -259,6 +261,11 @@ DASHBOARD_EMAIL_CONFIGS = {
     "consent_validation": {
         "template_id": env.int("CONSENT_VALIDATION_TEMPLATE_ID"),
         "link": env.str("DOMAIN"),
+    },
+    # Configuration for the notification email sent to the QualiCharge Team when
+    # a new user registers on the Dashboard.
+    "new_subscription": {
+        "template_id": env.int("NEW_SUBSCRIPTION_TEMPLATE_ID"),
     },
     # Configuration for the notification email sent to the user when
     # the user has been validated by an admin.


### PR DESCRIPTION
## Purpose

When a new user registers on the dashboard, we must notify the QualiCharge team by sending a notification.

## Proposal

- [x] add the email notification. 
- [x] add environment configuration
- [x] add test coverage
- [x] add Brevo template