### PR TITLE
🩹(dashboard) fix email data key to use user email instead of username

### DIFF
--- a/src/dashboard/apps/auth/backends.py
+++ b/src/dashboard/apps/auth/backends.py
@@ -126,7 +126,7 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
         )
         email_data = {
             email_to: {
-                "user_username": user.username,  # type: ignore[union-attr]
+                "user_email": user.email,  # type: ignore[union-attr]
                 "link": link,
             },
         }

--- a/src/dashboard/apps/auth/tests/test_backends.py
+++ b/src/dashboard/apps/auth/tests/test_backends.py
@@ -115,7 +115,7 @@ def test_send_admin_notification_populated(rf):
             template_id=expected_email_config.get("template_id"),
             merge_data={
                 expected_email_to: {
-                    "user_username": user.username,
+                    "user_email": user.email,
                     "link": f"http://localhost:8030/admin/qcd_auth/dashboarduser/{user.id}/change/",
                 }
             },


### PR DESCRIPTION
## Purpose

The notification sent when a new user registers on the dashboard must contain the user's email.

## Fix

- [x] Updated the email data dictionary to use `user.email` in place of `user.username` for email notifications.