### PR TITLE
🐛(api) add default value to models optional fields

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to
 - Upgrade sqlmodel to `0.0.24`
 - Upgrade typer to `0.15.2`
 
+### Fixed
+
+- Add default `None` value to API models optional fields or else they are
+  considered as required
+
 ## [0.19.0] - 2025-02-25
 
 ### Added

--- a/src/api/qualicharge/models/dynamic.py
+++ b/src/api/qualicharge/models/dynamic.py
@@ -39,10 +39,10 @@ class StatusBase(SQLModel):
     etat_pdc: EtatPDCEnum
     occupation_pdc: OccupationPDCEnum
     horodatage: PastDatetime
-    etat_prise_type_2: Optional[EtatPriseEnum]
-    etat_prise_type_combo_ccs: Optional[EtatPriseEnum]
-    etat_prise_type_chademo: Optional[EtatPriseEnum]
-    etat_prise_type_ef: Optional[EtatPriseEnum]
+    etat_prise_type_2: Optional[EtatPriseEnum] = None
+    etat_prise_type_combo_ccs: Optional[EtatPriseEnum] = None
+    etat_prise_type_chademo: Optional[EtatPriseEnum] = None
+    etat_prise_type_ef: Optional[EtatPriseEnum] = None
 
 
 class StatusCreate(StatusBase):

--- a/src/api/qualicharge/models/static.py
+++ b/src/api/qualicharge/models/static.py
@@ -98,8 +98,7 @@ DataGouvCoordinate = Annotated[
             "type": "string",
             "title": "coordonneesXY",
             "description": (
-                "coordonneesXY is supposed to be a "
-                "'[longitude,latitude]' array string"
+                "coordonneesXY is supposed to be a '[longitude,latitude]' array string"
             ),
             "examples": [
                 "[12.3, 41.5]",
@@ -150,7 +149,7 @@ class Statique(ModelSchemaMixin, BaseModel):
     id_station_itinerance: Annotated[
         str, Field(pattern="(?:(?:^|,)(^[A-Z]{2}[A-Z0-9]{4,33}$|Non concerné))+$")
     ]
-    id_station_local: Optional[str]
+    id_station_local: Optional[str] = None
     nom_station: str
     implantation_station: ImplantationStationEnum
     adresse_station: str
@@ -164,18 +163,18 @@ class Statique(ModelSchemaMixin, BaseModel):
             examples=["FR0NXEVSEXB9YG", "FRFASE3300405", "FR073012308585"],
         ),
     ]
-    id_pdc_local: Optional[str]
+    id_pdc_local: Optional[str] = None
     puissance_nominale: PositiveFloat
     prise_type_ef: bool
     prise_type_2: bool
     prise_type_combo_ccs: bool
     prise_type_chademo: bool
     prise_type_autre: bool
-    gratuit: Optional[bool]
+    gratuit: Optional[bool] = None
     paiement_acte: bool
-    paiement_cb: Optional[bool]
-    paiement_autre: Optional[bool]
-    tarification: Optional[str]
+    paiement_cb: Optional[bool] = None
+    paiement_autre: Optional[bool] = None
+    tarification: Optional[str] = None
     condition_acces: ConditionAccesEnum
     reservation: bool
     horaires: Annotated[
@@ -184,12 +183,12 @@ class Statique(ModelSchemaMixin, BaseModel):
     accessibilite_pmr: AccessibilitePMREnum
     restriction_gabarit: str
     station_deux_roues: bool
-    raccordement: Optional[RaccordementEnum]
+    raccordement: Optional[RaccordementEnum] = None
     num_pdl: Optional[Annotated[str, Field(max_length=64)]]
-    date_mise_en_service: Optional[PastDate]
-    observations: Optional[str]
+    date_mise_en_service: Optional[PastDate] = None
+    observations: Optional[str] = None
     date_maj: NotFutureDate
-    cable_t2_attache: Optional[bool]
+    cable_t2_attache: Optional[bool] = None
 
     @model_validator(mode="after")
     def check_afirev_prefix(self) -> Self:

--- a/src/api/tests/api/v1/routers/test_dynamic.py
+++ b/src/api/tests/api/v1/routers/test_dynamic.py
@@ -880,6 +880,26 @@ def test_create_status_number_of_queries(db_session, client_auth):
     assert counter.count == expected
 
 
+def test_create_status_with_required_fields_only(db_session, client_auth):
+    """Test the /status/ create endpoint with only required fields."""
+    id_pdc_itinerance = "FR911E1111ER1"
+
+    # Create point of charge
+    save_statique(
+        db_session, StatiqueFactory.build(id_pdc_itinerance=id_pdc_itinerance)
+    )
+    payload = {
+        "id_pdc_itinerance": id_pdc_itinerance,
+        "etat_pdc": "en_service",
+        "occupation_pdc": "occupe",
+        "horodatage": "2024-10-05T14:48:00.000Z",
+    }
+
+    # Create a new status
+    response = client_auth.post("/dynamique/status/", json=payload)
+    assert response.status_code == status.HTTP_201_CREATED
+
+
 @pytest.mark.parametrize(
     "client_auth",
     (

--- a/src/api/tests/api/v1/routers/test_statique.py
+++ b/src/api/tests/api/v1/routers/test_statique.py
@@ -521,6 +521,45 @@ def test_create_for_unknown_operational_unit(client_auth, db_session):
     assert n_pdc == 0
 
 
+def test_create_with_required_fields_only(client_auth, db_session):
+    """Test the /statique/ create endpoint."""
+    GroupFactory.__session__ = db_session
+
+    # Create statique
+    id_pdc_itinerance = "FR911E1111ER1"
+    data = StatiqueFactory.build(
+        id_pdc_itinerance=id_pdc_itinerance,
+    )
+
+    # Ignore optional fields in the payload
+    optional_fields = {
+        "nom_amenageur",
+        "siren_amenageur",
+        "contact_amenageur",
+        "nom_operateur",
+        "telephone_operateur",
+        "id_station_local",
+        "id_pdc_local",
+        "gratuit",
+        "paiement_cb",
+        "paiement_autre",
+        "tarification",
+        "raccordement",
+        "date_mise_en_service",
+        "observations",
+        "cable_t2_attache",
+    }
+    response = client_auth.post(
+        "/statique/",
+        json=json.loads(data.model_dump_json(exclude=optional_fields)),
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    json_response = response.json()
+    assert json_response["message"] == "Statique items created"
+    assert json_response["size"] == 1
+    assert json_response["items"][0] == id_pdc_itinerance
+
+
 @pytest.mark.parametrize(
     "client_auth",
     (


### PR DESCRIPTION
## Purpose

Some fields seems required in the API payload even if flagged as optional in our models.

## Proposal

Typing optional fields as optional is not sufficient to make them optional, they also need a default value.
