### PR TITLE
👷(dashboard) enforce Black formatting check in CI pipeline

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -74,7 +74,7 @@ jobs:
           cache: "pipenv"
           cache-dependency-path: "src/dashboard/Pipfile.lock"
       - name: Lint with Black
-        run: pipenv run black dashboard apps tests
+        run: pipenv run black --check dashboard apps tests
       - name: Lint with Ruff
         run: pipenv run ruff check dashboard apps tests
       - name: Lint with MyPy


### PR DESCRIPTION
## Purpose

Black should be in check mode.

## Proposal

- [x] Updated the Black linting command in the GitHub Actions workflow to use the `--check` flag.