### PR TITLE
♻️(dashboard) refactor to manage a single entity instead of multiple in consent form

### DIFF
--- a/src/dashboard/CHANGELOG.md
+++ b/src/dashboard/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to
 - add `UserValidationMixin` to ensure access restrictions for unvalidated users.
 - add a base view combining mixins for consistency
 - add dashboard homepage
-- add consent form to manage consents of one or many entities
+- add consent form to manage consents of one entity
 - added a validated consent page allowing consultation of validated consent for the 
   current period.
 - add an email notification to users (via Brevo) after they have validated their consents.

--- a/src/dashboard/apps/consent/templates/consent/includes/_manage_company_informations.html
+++ b/src/dashboard/apps/consent/templates/consent/includes/_manage_company_informations.html
@@ -5,91 +5,90 @@
     therefore be in French and non-translatable.
 {% endcomment %}
 
-{% for entity in entities %}
-  <div class="fr-fieldset__element fr-my-4w">
+<div class="fr-fieldset__element fr-my-4w">
 
-    <legend class="fr-fieldset__legend">
-      B. Client raccordé
-    </legend>
+  <legend class="fr-fieldset__legend">
+    B. Client raccordé
+  </legend>
 
-    <p>
-      Merci de vérifier l’exactitude des informations concernant votre structure et le
-      signataire du présent formulaire.
-      <br />
-      En cas d'informations erronées, merci de nous contacter :
-      <a class="fr-link fr-link--icon-left fr-icon-mail-line"
-         href="mailto:{{ contact_email }}?subject=[QualiCharge] Informations erronées dans le formulaire de gestion des autorisations" target="_blank">
-        {{ contact_email }}
-      </a>
-    </p>
+  <p>
+    Merci de vérifier l’exactitude des informations concernant votre structure et le
+    signataire du présent formulaire.
+    <br />
+    En cas d'informations erronées, merci de nous contacter :
+    <a class="fr-link fr-link--icon-left fr-icon-mail-line"
+       href="mailto:{{ contact_email }}?subject=[QualiCharge] Informations erronées dans le formulaire de gestion des autorisations" target="_blank">
+      {{ contact_email }}
+    </a>
+  </p>
 
-    {% with row_number=0 %}
-    <div class="fr-table fr-table--bordered" id="table-company-bordered-component">
-      <div class="fr-table__wrapper">
-        <div class="fr-table__container">
-          <div class="fr-table__content">
-            <table>
-              <caption class="fr-text--md">
-                Informations sur l'entreprise
-              </caption>
-              <thead>
-               <tr>
-                <th scope="col">
-                  Libellé
-                </th>
-                <th scope="col">
-                  Valeur
-                </th>
-              </tr>
-              </thead>
-              <tbody>
-                  {% include "consent/includes/_table_row.html" with label="Dénomination sociale" value=entity.name row_number=row_number|add:"1" %}
-                  {% include "consent/includes/_table_row.html" with label="Type de structure" value=entity.get_company_type_display row_number=row_number|add:"1" %}
-                  {% include "consent/includes/_table_row.html" with label="Forme juridique" value=entity.legal_form row_number=row_number|add:"1" %}
-                  {% include "consent/includes/_table_row.html" with label="Nom commercial" value=entity.trade_name row_number=row_number|add:"1" %}
-                  {% include "consent/includes/_table_row.html" with label="N° d'identification SIRET" value=entity.siret row_number=row_number|add:"1" %}
-                  {% include "consent/includes/_table_row.html" with label="Activité NAF" value=entity.naf row_number=row_number|add:"1" %}
-                  {% include "consent/includes/_table_row.html" with label="Adresse" value=entity.address_1 row_number=row_number|add:"1" %}
-                  {% include "consent/includes/_table_row.html" with label="Complément d'adresse" value=entity.address_2 row_number=row_number|add:"1" %}
-                  {% include "consent/includes/_table_row.html" with label="Code postal" value=entity.address_zip_code row_number=row_number|add:"1" %}
-                  {% include "consent/includes/_table_row.html" with label="Commune" value=entity.address_city row_number=row_number|add:"1" %}
-                  {# todo: add a form field to retrieve this information (+ email and phone) if it doesn't exist #}
-                  {% include "consent/includes/_table_row.html" with label="Nom du titulaire du contrat" value="-" row_number=row_number|add:"1" %}
-                </tbody>
-              </table>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="fr-table fr-table--bordered" id="table-representative-bordered-component">
-      <div class="fr-table__wrapper">
-        <div class="fr-table__container">
-          <div class="fr-table__content">
-            <table>
-              <caption class="fr-text--md">
-                Informations sur le représentant de l'entreprise
-              </caption>
-              <thead>
-               <tr>
-                <th scope="col">
-                  Libellé
-                </th>
-                <th scope="col">
-                  Valeur
-                </th>
-              </tr>
-              </thead>
-              <tbody>
-                  {% include "consent/includes/_table_row.html" with label="Nom" value=request.user.last_name row_number=row_number|add:"1" %}
-                  {% include "consent/includes/_table_row.html" with label="Prénom" value=request.user.first_name row_number=row_number|add:"1" %}
-                  {% include "consent/includes/_table_row.html" with label="E-mail" value=request.user.email row_number=row_number|add:"1" %}
+  {% with row_number=0 %}
+  <div class="fr-table fr-table--bordered" id="table-company-bordered-component">
+    <div class="fr-table__wrapper">
+      <div class="fr-table__container">
+        <div class="fr-table__content">
+          <table>
+            <caption class="fr-text--md">
+              Informations sur l'entreprise
+            </caption>
+            <thead>
+             <tr>
+              <th scope="col">
+                Libellé
+              </th>
+              <th scope="col">
+                Valeur
+              </th>
+            </tr>
+            </thead>
+            <tbody>
+                {% include "consent/includes/_table_row.html" with label="Dénomination sociale" value=entity.name row_number=row_number|add:"1" %}
+                {% include "consent/includes/_table_row.html" with label="Type de structure" value=entity.get_company_type_display row_number=row_number|add:"1" %}
+                {% include "consent/includes/_table_row.html" with label="Forme juridique" value=entity.legal_form row_number=row_number|add:"1" %}
+                {% include "consent/includes/_table_row.html" with label="Nom commercial" value=entity.trade_name row_number=row_number|add:"1" %}
+                {% include "consent/includes/_table_row.html" with label="N° d'identification SIRET" value=entity.siret row_number=row_number|add:"1" %}
+                {% include "consent/includes/_table_row.html" with label="Activité NAF" value=entity.naf row_number=row_number|add:"1" %}
+                {% include "consent/includes/_table_row.html" with label="Adresse" value=entity.address_1 row_number=row_number|add:"1" %}
+                {% include "consent/includes/_table_row.html" with label="Complément d'adresse" value=entity.address_2 row_number=row_number|add:"1" %}
+                {% include "consent/includes/_table_row.html" with label="Code postal" value=entity.address_zip_code row_number=row_number|add:"1" %}
+                {% include "consent/includes/_table_row.html" with label="Commune" value=entity.address_city row_number=row_number|add:"1" %}
+                {# todo: add a form field to retrieve this information (+ email and phone) if it doesn't exist #}
+                {% include "consent/includes/_table_row.html" with label="Nom du titulaire du contrat" value="-" row_number=row_number|add:"1" %}
               </tbody>
             </table>
-          </div>
         </div>
       </div>
     </div>
-    {% endwith %}
   </div>
-{% endfor %}
+
+  <div class="fr-table fr-table--bordered" id="table-representative-bordered-component">
+    <div class="fr-table__wrapper">
+      <div class="fr-table__container">
+        <div class="fr-table__content">
+          <table>
+            <caption class="fr-text--md">
+              Informations sur le représentant de l'entreprise
+            </caption>
+            <thead>
+             <tr>
+              <th scope="col">
+                Libellé
+              </th>
+              <th scope="col">
+                Valeur
+              </th>
+            </tr>
+            </thead>
+            <tbody>
+                {% include "consent/includes/_table_row.html" with label="Nom" value=request.user.last_name row_number=row_number|add:"1" %}
+                {% include "consent/includes/_table_row.html" with label="Prénom" value=request.user.first_name row_number=row_number|add:"1" %}
+                {% include "consent/includes/_table_row.html" with label="E-mail" value=request.user.email row_number=row_number|add:"1" %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endwith %}
+</div>
+

--- a/src/dashboard/apps/consent/templates/consent/includes/_manage_consents.html
+++ b/src/dashboard/apps/consent/templates/consent/includes/_manage_consents.html
@@ -50,54 +50,52 @@
             </thead>
 
             <tbody>
-              {% for entity in entities %}
-                {% for consent in entity.get_consents %}
-                  <tr id="table-prm-row-key-{{ forloop.counter }}"
-                      data-row-key="{{ forloop.counter }}"
-                      aria-labelledby="row-label-{{ forloop.counter }}"
-                      {% if consent.status == "VALIDATED" %}
-                        title="Point de livraison déjà validé."
-                        aria-label="Point de livraison déjà validé."
-                      {% elif consent.status == "AWAITING" %}
-                        title="Point de livraison en attente de validation."
-                        aria-label="Point de livraison en attente de validation."
-                      {% endif %}>
+              {% for consent in entity.get_consents %}
+                <tr id="table-prm-row-key-{{ forloop.counter }}"
+                    data-row-key="{{ forloop.counter }}"
+                    aria-labelledby="row-label-{{ forloop.counter }}"
+                    {% if consent.status == "VALIDATED" %}
+                      title="Point de livraison déjà validé."
+                      aria-label="Point de livraison déjà validé."
+                    {% elif consent.status == "AWAITING" %}
+                      title="Point de livraison en attente de validation."
+                      aria-label="Point de livraison en attente de validation."
+                    {% endif %}>
 
-                    <th class="fr-cell--fixed fr-cell--center" scope="row">
-                      <div class="fr-checkbox-group fr-checkbox-group--sm">
-                        <input type="checkbox"
-                         name="status"
-                         value="{{ consent.id }}"
-                         id="{{ consent.id }}"
-                         {% if consent.status == "VALIDATED" %} checked="checked" disabled="disabled"{% endif %}
-                         aria-describedby="{{ consent.id }}-messages"
-                         data-fr-js-checkbox-input="true"
-                         data-fr-js-checkbox-actionee="true"
-                         {% if consent.status == "VALIDATED" %}
-                            title="Point de livraison déjà validé."
-                            aria-label="Point de livraison validé, case à cocher désactivée."
-                         {% elif consent.status == "AWAITING" %}
-                            title="Point de livraison en attente de validation."
-                            aria-label="Point de livraison en attente de validation."
-                         {% endif %}
-                        />
+                  <th class="fr-cell--fixed fr-cell--center" scope="row">
+                    <div class="fr-checkbox-group fr-checkbox-group--sm">
+                      <input type="checkbox"
+                       name="status"
+                       value="{{ consent.id }}"
+                       id="{{ consent.id }}"
+                       {% if consent.status == "VALIDATED" %} checked="checked" disabled="disabled"{% endif %}
+                       aria-describedby="{{ consent.id }}-messages"
+                       data-fr-js-checkbox-input="true"
+                       data-fr-js-checkbox-actionee="true"
+                       {% if consent.status == "VALIDATED" %}
+                          title="Point de livraison déjà validé."
+                          aria-label="Point de livraison validé, case à cocher désactivée."
+                       {% elif consent.status == "AWAITING" %}
+                          title="Point de livraison en attente de validation."
+                          aria-label="Point de livraison en attente de validation."
+                       {% endif %}
+                      />
 
-                        <label class="fr-label" for="{{ consent.id }}"
-                          {% if consent.status == "VALIDATED" %}
-                            title="Point de livraison déjà validé."
-                          {% elif consent.status == "AWAITING" %}
-                            title="Point de livraison en attente de validation."
-                          {% endif %}>
-                          Sélectionner le PDL {{ consent.delivery_point.provider_assigned_id }}
-                        </label>
-                      </div>
-                    </th>
-                    {# todo : get station_name, station_id, prm_id #}
-                    <td> -- station name -- </td>
-                    <td> -- station id --  </td>
-                    <td> {{ consent.delivery_point.provider_assigned_id }} </td>
-                  </tr>
-                {% endfor %}
+                      <label class="fr-label" for="{{ consent.id }}"
+                        {% if consent.status == "VALIDATED" %}
+                          title="Point de livraison déjà validé."
+                        {% elif consent.status == "AWAITING" %}
+                          title="Point de livraison en attente de validation."
+                        {% endif %}>
+                        Sélectionner le PDL {{ consent.delivery_point.provider_assigned_id }}
+                      </label>
+                    </div>
+                  </th>
+                  {# todo : get station_name, station_id, prm_id #}
+                  <td> -- station name -- </td>
+                  <td> -- station id --  </td>
+                  <td> {{ consent.delivery_point.provider_assigned_id }} </td>
+                </tr>
               {% endfor %}
             </tbody>
           </table>

--- a/src/dashboard/apps/consent/templates/consent/manage.html
+++ b/src/dashboard/apps/consent/templates/consent/manage.html
@@ -15,7 +15,7 @@
     le gestionnaire du réseau de distribution.
   </p>
 
-  {% if entities %}
+  {% if entity %}
     <form action="" method="post">
       {% csrf_token %}
 
@@ -51,7 +51,7 @@
 {% endblock dashboard_content %}
 
 {% block dashboard_extra_js %}
-  {% if entities %}
+  {% if entity %}
     <script src="{% static 'apps/consent/js/app.js' %}"></script>
   {% endif %}
 {% endblock dashboard_extra_js %}


### PR DESCRIPTION
## Purpose

The consent form should only allow the management of a single entity at a time, rather than multiple entities as it currently does.

## Proposal

- [x] update `ConsentFormView` to manage only a single entity
- [x] update tests
- [x] update templates
- [x] update changelogs