### PR TITLE
🔧(project) avoid Renovate immortal PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,5 +33,6 @@
   "semanticCommits": "disabled",
   "separateMajorMinor": false,
   "updateNotScheduled": true,
-  "rebaseWhen": "behind-base-branch"
+  "rebaseWhen": "behind-base-branch",
+  "recreateWhen": "never"
 }


### PR DESCRIPTION
## Purpose

Renovate creates immortal PRs (automatically re-open when closed un-merged). This is a real pain when PR are not relevant, e.g. upgrading Python release too early.

## Proposal

- [x] update configuration to avoid immortal PRs

Docs: https://docs.renovatebot.com/key-concepts/pull-requests/#how-to-fix-immortal-prs