### PR TITLE
🔖(client:minor) bump release to 0.3.0

### DIFF
--- a/src/client/CHANGELOG.md
+++ b/src/client/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-03-14
+
 ### Added
 
 - Add support for new `/manage` API endpoints
@@ -37,6 +39,7 @@ and this project adheres to
 - Add `QCC` QualiCharge API client
 - Add `qcc` CLI
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.2.0-cli...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.3.0-cli...main
+[0.3.0]: https://github.com/MTES-MCT/qualicharge/releases/tag/v0.2.0-cli...v0.3.0-cli
 [0.2.0]: https://github.com/MTES-MCT/qualicharge/releases/tag/v0.1.0-cli...v0.2.0-cli
 [0.1.0]: https://github.com/MTES-MCT/qualicharge/releases/tag/v0.1.0-cli

--- a/src/client/pyproject.toml
+++ b/src/client/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qualicharge-client"
-version = "0.2.0"
+version = "0.3.0"
 description = "A python client and CLI for the QualiCharge API"
 authors = ["Julien Maupetit <julien@maupetit.net>"]
 license = "MIT"


### PR DESCRIPTION
### Added

- Add support for new `/manage` API endpoints

### Changed

- Upgrade anyio to `4.6.1`
- Upgrade httpx to `0.28.0`
- Upgrade Pydantic to `2.9.1`
- Upgrade pydantic-settings to `2.8.1`
- Upgrade typer to `0.15.2`
