### PR TITLE
🩹(client) update docstrings in manage.py to reflect correct endpoints

### DIFF
--- a/src/client/CHANGELOG.md
+++ b/src/client/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix copy/pasta in manage endpoint doc strings
+
 ## [0.3.0] - 2025-03-14
 
 ### Added

--- a/src/client/qcc/endpoints/manage.py
+++ b/src/client/qcc/endpoints/manage.py
@@ -19,7 +19,7 @@ class Manage:
     endpoint: str = "/manage"
 
     def __init__(self, client: HTTPClient) -> None:
-        """Set /auth endpoints HTTP client."""
+        """Set /manage endpoints HTTP client."""
         self.client = client
 
     async def read_stations(
@@ -27,7 +27,7 @@ class Manage:
         siren: str,
         after: Optional[datetime] = None,
     ) -> AsyncIterator[dict]:
-        """Query the /dynamique/status endpoint (GET)."""
+        """Query the /station/siren/ endpoint (GET)."""
         # Get ISO string for the `after` parameter
         after_str = after.isoformat() if after else None
 


### PR DESCRIPTION
Corrected docstrings to accurately describe the /manage endpoints and corresponding routes. 
No functional code changes were made.