### PR TITLE
🐛(api) ignore stations without PDL in stations mananagement

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 ### Fixed
 
 - Allow creating a new PDC the day it has been connected
+- Ignore stations without PDL in stations mananagement endpoint
 
 ## [0.19.1] - 2025-03-10
 

--- a/src/api/qualicharge/api/v1/routers/manage.py
+++ b/src/api/qualicharge/api/v1/routers/manage.py
@@ -61,7 +61,9 @@ async def stations_by_siren(
 ) -> List[DashboardStation]:
     """List stations for a given company identified by its SIREN."""
     statement = select(Station).where(
-        cast(SAColumn, Station.amenageur).has(siren_amenageur=siren)
+        (cast(SAColumn, Station.amenageur).has(siren_amenageur=siren))
+        & (Station.num_pdl != None)  # noqa: E711
+        & (Station.num_pdl != "")
     )
     if after is not None:
         statement = statement.where(Station.updated_at >= after)

--- a/src/api/tests/api/v1/routers/test_manage.py
+++ b/src/api/tests/api/v1/routers/test_manage.py
@@ -1,7 +1,10 @@
 """Tests for the QualiCharge API dynamic router."""
 
+from typing import cast
+
 import pytest
 from fastapi import status
+from sqlalchemy.schema import Column as SAColumn
 from sqlmodel import select
 
 from qualicharge.api.v1.routers.manage import DashboardStation
@@ -29,7 +32,7 @@ from qualicharge.schemas.utils import save_statiques
     indirect=True,
 )
 def test_stations_by_siren_with_missing_scopes(client_auth):
-    """Test the /status/ get endpoint scopes."""
+    """Test the /manage/station/siren/ get endpoint scopes."""
     response = client_auth.get("/manage/station/siren/123456789")
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -43,7 +46,7 @@ def test_stations_by_siren_with_missing_scopes(client_auth):
     indirect=True,
 )
 def test_stations_by_siren_for_user(db_session, client_auth):
-    """Test the /status/ get endpoint (superuser case)."""
+    """Test the /manage/station/siren/ get endpoint (superuser case)."""
     # Station not found
     response = client_auth.get("/manage/station/siren/123456789")
     assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -82,3 +85,58 @@ def test_stations_by_siren_for_user(db_session, client_auth):
             assert station.nom_station == db_station.nom_station
             assert station.num_pdl == db_station.num_pdl
             assert station.updated_at == db_station.updated_at
+
+
+def test_stations_by_siren_with_no_pdl_declared(db_session, client_auth):
+    """Test the /manage/station/siren/ when related stations have no PDL."""
+    # Create statique entries using two amenageurs and related stations
+    save_statiques(
+        db_session,
+        StatiqueFactory.batch(
+            3,
+            siren_amenageur="123456789",
+            num_pdl=StatiqueFactory.__faker__.pystr_format("##############"),
+        ),
+    )
+    # One amenageur has stations with missing PDL numbers
+    save_statiques(
+        db_session,
+        [
+            StatiqueFactory.build(
+                siren_amenageur="012345678",
+                num_pdl=StatiqueFactory.__faker__.pystr_format("##############"),
+            ),
+            StatiqueFactory.build(siren_amenageur="012345678", num_pdl=None),
+            StatiqueFactory.build(siren_amenageur="012345678", num_pdl=""),
+        ],
+    )
+    db_stations = db_session.exec(select(Station)).all()
+    expected = 6
+    assert len(db_stations) == expected
+
+    db_stations = db_session.exec(
+        select(Station).where(
+            cast(SAColumn, Station.amenageur).has(siren_amenageur="012345678")
+        )
+    ).all()
+    expected = 3
+    assert len(db_stations) == expected
+
+    db_station = db_session.exec(
+        select(Station).where(
+            (cast(SAColumn, Station.amenageur).has(siren_amenageur="012345678"))
+            & (Station.num_pdl != None)  # noqa: E711
+            & (Station.num_pdl != "")
+        )
+    ).one()
+
+    # API should only return stations without missing num_pdl
+    response = client_auth.get("/manage/station/siren/012345678")
+    assert response.status_code == status.HTTP_200_OK
+    stations = [DashboardStation(**s) for s in response.json()]
+    assert len(stations) == 1
+    station = stations[0]
+    assert station.id_station_itinerance == db_station.id_station_itinerance
+    assert station.nom_station == db_station.nom_station
+    assert station.num_pdl == db_station.num_pdl
+    assert station.updated_at == db_station.updated_at


### PR DESCRIPTION
## Purpose

When listing stations related to a Amenageur SIREN, we should ignore stations without PDL number as it's still not required yet.

## Proposal

- [x] filter stations with empty `num_pdl`
