### PR TITLE
🐛(api) allow creating a new PDC the day it has been connected

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - Add manage router and `station/siren` endpoint for the Dashboard
 
+### Fixed
+
+- Allow creating a new PDC the day it has been connected
+
 ## [0.19.1] - 2025-03-10
 
 ### Changed

--- a/src/api/qualicharge/models/static.py
+++ b/src/api/qualicharge/models/static.py
@@ -18,7 +18,6 @@ from pydantic import (
     WithJsonSchema,
     model_validator,
 )
-from pydantic.types import PastDate
 from pydantic_extra_types.coordinate import Coordinate
 from pydantic_extra_types.phone_numbers import PhoneNumber
 from typing_extensions import Annotated, Self
@@ -185,7 +184,7 @@ class Statique(ModelSchemaMixin, BaseModel):
     station_deux_roues: bool
     raccordement: Optional[RaccordementEnum] = None
     num_pdl: Optional[Annotated[str, Field(max_length=64)]]
-    date_mise_en_service: Optional[PastDate] = None
+    date_mise_en_service: Optional[NotFutureDate] = None
     observations: Optional[str] = None
     date_maj: NotFutureDate
     cable_t2_attache: Optional[bool] = None

--- a/src/api/qualicharge/schemas/core.py
+++ b/src/api/qualicharge/schemas/core.py
@@ -9,7 +9,6 @@ from geoalchemy2.shape import to_shape
 from geoalchemy2.types import Geometry, WKBElement
 from pydantic import (
     EmailStr,
-    PastDate,
     PastDatetime,
     PositiveFloat,
     PositiveInt,
@@ -313,7 +312,7 @@ class Station(BaseAuditableSQLModel, table=True):
     )
     num_pdl: Optional[str] = Field(max_length=64)
     date_maj: NotFutureDate = Field(sa_type=Date)
-    date_mise_en_service: Optional[PastDate] = Field(sa_type=Date)
+    date_mise_en_service: Optional[NotFutureDate] = Field(sa_type=Date)
 
     # Relationships
     amenageur_id: Optional[UUID] = Field(

--- a/src/api/tests/models/test_static.py
+++ b/src/api/tests/models/test_static.py
@@ -125,6 +125,21 @@ def test_statique_model_date_maj():
         StatiqueFactory.build(date_maj=tomorrow)
 
 
+def test_statique_model_date_mise_en_service():
+    """Test statique model accepts only a `date_mise_en_service` not in the future."""
+    today = datetime.now(timezone.utc).date()
+    statique = StatiqueFactory.build(date_mise_en_service=today)
+    assert statique.date_mise_en_service == today
+
+    yesterday = today - timedelta(days=1)
+    statique = StatiqueFactory.build(date_mise_en_service=yesterday)
+    assert statique.date_mise_en_service == yesterday
+
+    tomorrow = today + timedelta(days=1)
+    with pytest.raises(ValueError, match=f"{tomorrow} is in the future"):
+        StatiqueFactory.build(date_mise_en_service=tomorrow)
+
+
 def test_statique_model_defaults():
     """Test the Statique model defaut values (when not provided)."""
     example = StatiqueFactory.build()

--- a/src/api/tests/schemas/test_static.py
+++ b/src/api/tests/schemas/test_static.py
@@ -356,6 +356,23 @@ def test_station_date_maj(db_session):
         StationFactory.create_sync(date_maj=tomorrow)
 
 
+def test_station_date_mise_en_service(db_session):
+    """Test station schema accepts only a `date_mise_en_service` not in the future."""
+    StationFactory.__session__ = db_session
+
+    today = datetime.now(timezone.utc).date()
+    station = StationFactory.create_sync(date_mise_en_service=today)
+    assert station.date_mise_en_service == today
+
+    yesterday = today - timedelta(days=1)
+    station = StationFactory.create_sync(date_mise_en_service=yesterday)
+    assert station.date_mise_en_service == yesterday
+
+    tomorrow = today + timedelta(days=1)
+    with pytest.raises(ValueError, match=f"{tomorrow} is in the future"):
+        StationFactory.create_sync(date_mise_en_service=tomorrow)
+
+
 def test_operational_unit_create_stations_fk_no_station(db_session):
     """Test OperationalUnit.create_stations_fk method with no matching station."""
     OperationalUnitFactory.__session__ = db_session


### PR DESCRIPTION
## Purpose

When a new PDC has been connected to the CPO's infrastructure, the CPO should be able to declare it to QualiCharge.

## Proposal

- [x] update `date_mise_en_service` field type from `PastDatetime` to `NotFutureDate`
