### PR TITLE
🔖(api:minor) bump release to 0.20.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.20.0] - 2025-03-19
+
 ### Added
 
 - Add manage router and `station/siren` endpoint for the Dashboard
@@ -358,7 +360,8 @@ and this project adheres to
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.19.1...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.20.0...main
+[0.20.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.19.1...v0.20.0
 [0.19.1]: https://github.com/MTES-MCT/qualicharge/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.17.0...v0.18.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -3,7 +3,7 @@
 #
 [project]
 name = "qualicharge"
-version = "0.19.1"
+version = "0.20.0"
 
 # Third party packages configuration
 [tool.coverage.run]

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.19.1"
+__version__ = "0.20.0"


### PR DESCRIPTION
### Added

- Add manage router and `station/siren` endpoint for the Dashboard

### Fixed

- Allow creating a new PDC the day it has been connected
- Ignore stations without PDL in stations mananagement endpoint
