### PR TITLE
Feature/dashboard/add futur consents form

### DIFF
--- a/src/dashboard/CHANGELOG.md
+++ b/src/dashboard/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 - add a base view combining mixins for consistency
 - add dashboard homepage
 - add consent form to manage consents of one entity
+- add consent form to manage upcoming consents
 - added a validated consent page allowing consultation of validated consent for the 
   current period.
 - add an email notification to users (via Brevo) after they have validated their consents.

--- a/src/dashboard/apps/consent/templates/consent/includes/_consent_summary_upcoming_card_content.html
+++ b/src/dashboard/apps/consent/templates/consent/includes/_consent_summary_upcoming_card_content.html
@@ -42,9 +42,8 @@
                     </p>
                   </td>
                   <td class="fr-cell--center">
-                    {# todo : add new form url #}
                     <a class="fr-link fr-icon-arrow-right-line fr-link--icon-right"
-                       href=""
+                       href="{% url "consent:manage-upcoming" entity.slug %}"
                        data-fr-js-link-actionee="true">
                       Gérer les autorisations
                     </a>

--- a/src/dashboard/apps/consent/templates/consent/includes/_manage_consents.html
+++ b/src/dashboard/apps/consent/templates/consent/includes/_manage_consents.html
@@ -46,11 +46,14 @@
                 <th scope="col">
                   <div class="fr-cell__title">Identifiant du PDL</div>
                 </th>
+                <th scope="col">
+                  <div class="fr-cell__title">Période d'autorisation</div>
+                </th>
               </tr>
             </thead>
 
             <tbody>
-              {% for consent in entity.get_consents %}
+              {% for consent in consents %}
                 <tr id="table-prm-row-key-{{ forloop.counter }}"
                     data-row-key="{{ forloop.counter }}"
                     aria-labelledby="row-label-{{ forloop.counter }}"
@@ -94,6 +97,7 @@
                   <td> {{ consent.delivery_point.station_name }} </td>
                   <td> {{ consent.delivery_point.id_station_itinerance }}  </td>
                   <td> {{ consent.delivery_point.provider_assigned_id }} </td>
+                  <td> du {{ consent.start|date:'d/m/Y' }} au {{ consent.end|date:'d/m/Y' }} </td>
                 </tr>
               {% endfor %}
             </tbody>

--- a/src/dashboard/apps/consent/templates/consent/validated.html
+++ b/src/dashboard/apps/consent/templates/consent/validated.html
@@ -32,6 +32,9 @@
                   <th scope="col">
                     <div class="fr-cell__title">Identifiant du PDL</div>
                   </th>
+                  <th scope="col">
+                    <div class="fr-cell__title">Période d'autorisation</div>
+                  </th>
                 </tr>
               </thead>
 
@@ -44,6 +47,7 @@
                     <td> {{ consent.delivery_point.station_name }} </td>
                     <td> {{ consent.delivery_point.id_station_itinerance }} </td>
                     <td> {{ consent.delivery_point.provider_assigned_id }} </td>
+                    <td> du {{ consent.start|date:'d/m/Y' }} au {{ consent.end|date:'d/m/Y' }} </td>
                   </tr>
                 {% endfor %}
               </tbody>

--- a/src/dashboard/apps/consent/urls.py
+++ b/src/dashboard/apps/consent/urls.py
@@ -3,7 +3,12 @@
 from django.urls import path
 from django.views.generic.base import RedirectView
 
-from .views import ConsentFormView, IndexView, ValidatedConsentView
+from .views import (
+    ConsentFormView,
+    IndexView,
+    UpcomingConsentFormView,
+    ValidatedConsentView,
+)
 
 app_name = "consent"
 
@@ -17,6 +22,11 @@ urlpatterns = [
         name="manage",
     ),
     path("manage/<slug:slug>", ConsentFormView.as_view(), name="manage"),
+    path(
+        "manage/upcoming/<slug:slug>",
+        UpcomingConsentFormView.as_view(),
+        name="manage-upcoming",
+    ),
     path(
         "validated/",
         RedirectView.as_view(pattern_name="consent:index", permanent=False),


### PR DESCRIPTION
## Purpose

In the dashboard, we need to manage upcoming consents that require validation for future periods.
Future periods are defined as those with a start date between today and up to **x** days ahead.

## Proposal

- [x] update/refactor templates
- [x] add form view to manage upcoming consents
- [x] add urls to the new form view 
- [x] update and add tests
- [x] update changelogs
