### PR TITLE
✨(dashboard) add support for upcoming validated consents in dashboard

### DIFF
--- a/src/dashboard/apps/consent/models.py
+++ b/src/dashboard/apps/consent/models.py
@@ -8,7 +8,7 @@ from apps.core.abstract_models import DashboardBase
 
 from . import AWAITING, CONSENT_STATUS_CHOICE, REVOKED, VALIDATED
 from .exceptions import ConsentWorkflowError
-from .managers import ConsentManager, UpcomingConsentManager
+from .managers import ConsentManager, UpcomingConsentManager, ValidatedConsentManager
 from .utils import consent_end_date
 from .validators import (
     validate_company_schema,
@@ -213,6 +213,7 @@ class Consent(DashboardBase):
     objects = models.Manager()
     active_objects = ConsentManager()
     upcoming_objects = UpcomingConsentManager()
+    validated_objects = ValidatedConsentManager()
 
     class Meta:  # noqa: D106
         ordering = ["delivery_point"]

--- a/src/dashboard/apps/consent/templates/consent/validated.html
+++ b/src/dashboard/apps/consent/templates/consent/validated.html
@@ -47,7 +47,8 @@
                     <td> {{ consent.delivery_point.station_name }} </td>
                     <td> {{ consent.delivery_point.id_station_itinerance }} </td>
                     <td> {{ consent.delivery_point.provider_assigned_id }} </td>
-                    <td> du {{ consent.start|date:'d/m/Y' }} au {{ consent.end|date:'d/m/Y' }} </td>
+                    <td>
+                      du {{ consent.start|date:'d/m/Y' }} au {{ consent.end|date:'d/m/Y' }} </td>
                   </tr>
                 {% endfor %}
               </tbody>

--- a/src/dashboard/apps/core/models.py
+++ b/src/dashboard/apps/core/models.py
@@ -135,10 +135,6 @@ class Entity(DashboardBase):
             .order_by("delivery_point__provider_assigned_id", "start")
         )
 
-    def count_validated_consents(self) -> int:
-        """Counts the number of validated consents associated with a given entity."""
-        return self.get_consents(VALIDATED).count()
-
     def count_awaiting_consents(self) -> int:
         """Counts the number of validated consents associated with a given entity."""
         return self.get_consents(AWAITING).count()
@@ -147,17 +143,26 @@ class Entity(DashboardBase):
         """Counts the number of upcoming consents associated with a given entity."""
         return self.get_consents(AWAITING, Consent.upcoming_objects).count()
 
+    def count_validated_consents(self) -> int:
+        """Counts the number of validated consents associated with a given entity."""
+        return self.get_consents(VALIDATED, Consent.validated_objects).count()
+
     def get_awaiting_consents(self) -> QuerySet:
         """Get all awaiting consents for this entity."""
         return self.get_consents(AWAITING)
 
-    def get_validated_consents(self) -> QuerySet:
-        """Get all awaiting consents for this entity."""
-        return self.get_consents(VALIDATED)
-
     def get_upcoming_consents(self) -> QuerySet:
         """Get all upcoming consents for this entity."""
         return self.get_consents(AWAITING, Consent.upcoming_objects)
+
+    def get_validated_consents(self) -> QuerySet:
+        """Get all awaiting consents for this entity."""
+        return self.get_consents(VALIDATED, Consent.validated_objects).order_by(
+            "-start",
+            "-end",
+            "delivery_point__station_name",
+            "delivery_point__provider_assigned_id",
+        )
 
 
 class DeliveryPoint(DashboardBase):


### PR DESCRIPTION
## Purpose

In the dashboard, we need to display validated consents even if they are a period in the future.
Future periods are defined as those with a start date between today and up to **x** days ahead.

## Proposal

- [x] add `ValidatedConsentManager` to the `Consent`  model
- [x] update the `Consent` model
- [x] update the  `Core` model
- [x] add tests

