### PR TITLE
✨(dashboard) add management command to duplicate expiring consents

### DIFF
--- a/src/dashboard/CHANGELOG.md
+++ b/src/dashboard/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to
 - add API connector to the "Annuaire des Entreprises" API
 - add API connector to the QualiCharge API
 - add a command to sync delivery points from qualicharge API  
+- add a command to duplicate expiring consents
 - add a signal on the creation of a delivery point. This signal allows the creation 
 of the consent corresponding to the delivery point
 - retrieve company information from its SIRET using the "Annuaire des Entreprises" API

--- a/src/dashboard/apps/consent/helpers.py
+++ b/src/dashboard/apps/consent/helpers.py
@@ -1,11 +1,20 @@
 """Dashboard consent helpers."""
 
+import datetime
+
 import sentry_sdk
 from anymail.exceptions import AnymailRequestsAPIError
 from anymail.message import AnymailMessage
 from django.conf import settings
+from django.db import transaction
+from django.db.models import OuterRef, Subquery
+from django.utils import timezone
 
+from apps.consent.models import Consent
+from apps.consent.utils import consent_end_date
 from apps.core.models import Entity
+
+from .settings import CONSENT_NUMBER_DAYS_END_DATE, CONSENT_UPCOMING_DAYS_LIMIT
 
 
 def send_notification_for_awaiting_consents(entity: Entity) -> None:
@@ -76,3 +85,86 @@ def send_mail(recipients: list, template_id: int, email_data: dict) -> int | Non
         # fail silently and send a sentry log
         sentry_sdk.capture_exception(e)
         return 0
+
+
+def renew_expiring_consents():
+    """Renew expiring consents to ensure continuity.
+
+    Perform the renewal of expiring consents to ensure continuity for consents that
+    are nearing their expiration date and have not been renewed yet.
+    The function identifies consents that are set to expire shortly and generates
+    new consents starting immediately after the expiry date of the current consent,
+    with an extended validity period.
+
+    - Consents should be renewed if their end date is earlier than or equal to
+    `now + CONSENT_NUMBER_DAYS_END_DATE`.
+    - renewed consent date:
+        - start date of new consent is end date of current consent
+        - end date of new consent is calculate from CONSENT_NUMBER_DAYS_END_DATE
+
+    Returns:
+        List[Consent]: A list of newly created Consent objects that have been renewed
+         from the expiring consents.
+    """
+    # calculate the date from which to check
+    checking_date = _get_checking_date()
+
+    # calculate the end date of renewed consents
+    renewal_end_date = _get_renewal_end_date()
+
+    # Subquery to check if a renewed consent exists for validated consents.
+    # (this subquery only returns the `provider_assigned_id` of the consents found)
+    existing_renewed_consents = Consent.objects.filter(
+        start__gte=OuterRef("end"),
+        delivery_point=OuterRef("delivery_point"),
+        id_station_itinerance=OuterRef("id_station_itinerance"),
+        station_name=OuterRef("station_name"),
+        provider_assigned_id=OuterRef("provider_assigned_id"),
+    ).values("provider_assigned_id")
+
+    # Get expiring consents
+    #  = all validated consents - validated consents with existing consents.
+    # fmt: off
+    expiring_consents = (
+        Consent.validated_objects
+            .exclude(provider_assigned_id__in=Subquery(existing_renewed_consents))
+            .filter(end__lte=checking_date)
+    )
+    # fmt: on
+
+    # create a list of new consents to renewed
+    consents_to_renewed = []
+    for consent in expiring_consents:
+        consents_to_renewed.append(
+            Consent(
+                delivery_point=consent.delivery_point,
+                id_station_itinerance=consent.id_station_itinerance,
+                station_name=consent.station_name,
+                provider_assigned_id=consent.provider_assigned_id,
+                start=consent.end,
+                end=renewal_end_date,
+            )
+        )
+
+    # Create new renewed consents
+    results = []
+    if consents_to_renewed:
+        with transaction.atomic():
+            results = Consent.objects.bulk_create(consents_to_renewed)
+    return results
+
+
+def _get_checking_date():
+    """Calculate the date from which to check."""
+    now = timezone.now()
+    end_of_today = now.replace(hour=23, minute=59, second=59, microsecond=999999)
+    return end_of_today + datetime.timedelta(days=CONSENT_UPCOMING_DAYS_LIMIT)
+
+
+def _get_renewal_end_date():
+    """Calculate the end date of renewed consents."""
+    renewal_end_date = consent_end_date(CONSENT_NUMBER_DAYS_END_DATE)
+    if not CONSENT_NUMBER_DAYS_END_DATE:
+        renewal_end_date = renewal_end_date.replace(year=renewal_end_date.year + 1)
+
+    return renewal_end_date

--- a/src/dashboard/apps/consent/management/commands/renewconsents.py
+++ b/src/dashboard/apps/consent/management/commands/renewconsents.py
@@ -1,0 +1,29 @@
+"""Consent management duplicate consents commands."""
+
+import sentry_sdk
+
+from apps.consent.helpers import renew_expiring_consents
+from apps.core.management.commands.base_command import DashboardBaseCommand
+
+
+class Command(DashboardBaseCommand):
+    """Command for renewing expiring consents."""
+
+    help = __doc__
+
+    def handle(self, *args, **options):
+        """Renew expiring consents that are nearing expiration.
+
+        This method attempts to duplicate expiring
+        consents and logs an error message if the operation fails.
+
+        Raises:
+            Exception: Captures any exception occurring during the consent
+            duplication process and logs the error, including the relevant SIRET and
+            error details.
+        """
+        try:
+            renew_expiring_consents()
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+            self._log_error(f"Failed to duplicate consents. Error: {e}")

--- a/src/dashboard/apps/consent/tests/test_commands_renewconsents.py
+++ b/src/dashboard/apps/consent/tests/test_commands_renewconsents.py
@@ -1,0 +1,165 @@
+"""Dashboard consent command duplicates consents tests."""
+
+import datetime
+
+import pytest
+
+from apps.consent import AWAITING, VALIDATED
+from apps.consent.helpers import renew_expiring_consents
+from apps.consent.models import Consent
+from apps.core.factories import DeliveryPointFactory
+
+
+def _create_consent(
+    start: datetime.datetime, end: datetime.datetime, status: str | None = None
+) -> Consent:
+    """Create a consent for a delivery point."""
+    dp = DeliveryPointFactory.create()
+    consent = Consent.objects.get(delivery_point=dp)
+    consent.start = start
+    consent.end = end
+
+    if status is not None:
+        consent.status = status
+
+    consent.save()
+
+    return consent
+
+
+@pytest.mark.django_db
+def test_renew_expiring_consents_without_consents():
+    """Tests the `renew_expiring_consents` command without consents don't fail."""
+    assert Consent.objects.count() == 0
+    renew_expiring_consents()
+    assert Consent.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_renew_expiring_consents_outside_period(monkeypatch):
+    """Tests the `renew_expiring_consents` command outside the period.
+
+    This consent should not be renewed.
+    """
+    # mock now() to be the 2025-12-28.
+    fake_time = datetime.datetime(2025, 12, 28, tzinfo=datetime.timezone.utc)
+    monkeypatch.setattr("django.utils.timezone.now", lambda: fake_time)
+
+    # create a consent outside the active period
+    start = datetime.datetime(2026, 1, 15, tzinfo=datetime.timezone.utc)
+    end = datetime.datetime(2026, 3, 15, tzinfo=datetime.timezone.utc)
+    assert Consent.objects.count() == 0
+    _create_consent(start, end)
+    assert Consent.objects.count() == 1
+    assert Consent.active_objects.count() == 0
+
+    # test renew_expiring_consents()
+    duplicated_consents = renew_expiring_consents()
+    assert len(duplicated_consents) == 0
+    assert Consent.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_renew_expiring_consents(monkeypatch, settings):  # noqa: PLR0915
+    """Tests the `renew_expiring_consents`."""
+    settings.CONSENT_UPCOMING_DAYS_LIMIT = 30
+
+    # default consent start period
+    start_date = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+
+    # default end period date for the duplicated consents (for the futur period)
+    futur_period_end_date = datetime.datetime(
+        2026, 12, 31, 23, 59, 59, tzinfo=datetime.timezone.utc
+    )
+
+    # create 2 validated consents - period: 2025-01-01 to 2025-12-31
+    consent_size = 2
+    DeliveryPointFactory.create_batch(consent_size)
+    for consent in Consent.objects.all():
+        consent.start = start_date
+        consent.end = datetime.datetime(
+            2025, 12, 31, 23, 59, 59, tzinfo=datetime.timezone.utc
+        )
+        consent.status = VALIDATED
+        consent.save()
+    assert Consent.objects.count() == consent_size
+    assert Consent.active_objects.count() == consent_size
+    assert Consent.validated_objects.count() == consent_size
+
+    # create a validated consent with an end date is in 30 days
+    # period: 2025-01-01 to 2025-11-15.
+    end = datetime.datetime(2025, 12, 15, 1, 5, 55, 0, tzinfo=datetime.timezone.utc)
+    _create_consent(start_date, end, VALIDATED)
+    assert Consent.objects.count() == 3  # noqa: PLR2004
+    assert Consent.active_objects.count() == 3  # noqa: PLR2004
+    assert Consent.validated_objects.count() == 3  # noqa: PLR2004
+
+    # Create an awaiting consent - it should not be renewed.
+    # period: 2025-01-01 to 2025-12-31.
+    end = datetime.datetime(2025, 12, 31, 23, 59, 59, tzinfo=datetime.timezone.utc)
+    _create_consent(start_date, end, AWAITING)
+    assert Consent.objects.count() == 4  # noqa: PLR2004
+    assert Consent.active_objects.count() == 4  # noqa: PLR2004
+    assert Consent.validated_objects.count() == 3  # noqa: PLR2004
+    assert Consent.active_objects.filter(status=AWAITING).count() == 1
+
+    # create 2 consents (a validated consent with its renewed equivalent)
+    end = datetime.datetime(2025, 12, 31, 23, 59, 59, tzinfo=datetime.timezone.utc)
+    consent_with_duplicated = _create_consent(start_date, end, VALIDATED)
+    Consent.objects.create(
+        delivery_point=consent_with_duplicated.delivery_point,
+        id_station_itinerance=consent_with_duplicated.id_station_itinerance,
+        station_name=consent_with_duplicated.station_name,
+        provider_assigned_id=consent_with_duplicated.provider_assigned_id,
+        start=consent_with_duplicated.end,
+        end=futur_period_end_date,
+    )
+    assert Consent.objects.count() == 6  # noqa: PLR2004
+    assert Consent.active_objects.count() == 5  # noqa: PLR2004
+    assert Consent.validated_objects.count() == 4  # noqa: PLR2004
+    assert Consent.active_objects.filter(status=AWAITING).count() == 1
+
+    # test renew_expiring_consents()
+    # 1- mock now() to be before the consents to be duplicated.
+    fake_time = datetime.datetime(2025, 3, 31, tzinfo=datetime.timezone.utc)
+    monkeypatch.setattr("django.utils.timezone.now", lambda: fake_time)
+
+    # no consents should be renewed
+    duplicated_consents = renew_expiring_consents()
+    assert len(duplicated_consents) == 0
+    assert Consent.objects.count() == 6  # noqa: PLR2004
+
+    # 2 -mock now() to be the 2025-12-14
+    fake_time = datetime.datetime(2025, 12, 14, tzinfo=datetime.timezone.utc)
+    monkeypatch.setattr("django.utils.timezone.now", lambda: fake_time)
+
+    # test renew_expiring_consents() - 3 consents should be renewed.
+    duplicated_consents = renew_expiring_consents()
+    assert len(duplicated_consents) == 3  # noqa: PLR2004
+    for duplicated, consent in zip(
+        duplicated_consents,
+        Consent.validated_objects.filter().exclude(id=consent_with_duplicated.id),
+        strict=True,
+    ):
+        assert duplicated.provider_assigned_id == consent.provider_assigned_id
+        assert duplicated.start == consent.end
+        assert duplicated.end == futur_period_end_date
+
+    # 6 active objects + 3 renewed consents
+    assert Consent.objects.count() == 9  # noqa: PLR2004
+
+    # 3 - create a new consent that would have been missed (ie: it was added after
+    # the cron passed). Period: 2025-01-01 to 2025-12-17.
+    end = datetime.datetime(2025, 12, 17, 23, tzinfo=datetime.timezone.utc)
+    consent = _create_consent(start_date, end, VALIDATED)
+    assert Consent.objects.count() == 10  # noqa: PLR2004
+    assert Consent.active_objects.count() == 6  # noqa: PLR2004
+
+    # test renew_expiring_consents() - 1 consent should be renewed.
+    duplicated_consents = renew_expiring_consents()
+
+    assert len(duplicated_consents) == 1
+    assert Consent.objects.count() == 11  # noqa: PLR2004
+    assert duplicated_consents[0].provider_assigned_id == consent.provider_assigned_id
+    assert duplicated_consents[0].start == end
+    assert duplicated_consents[0].end == futur_period_end_date

--- a/src/dashboard/apps/core/models.py
+++ b/src/dashboard/apps/core/models.py
@@ -5,7 +5,7 @@ from django.db.models import QuerySet
 from django.utils.translation import gettext_lazy as _
 from django_extensions.db.fields import AutoSlugField
 
-from apps.consent import AWAITING, VALIDATED
+from apps.consent import AWAITING
 from apps.consent.models import Consent
 
 from .abstract_models import DashboardBase
@@ -140,11 +140,11 @@ class Entity(DashboardBase):
 
     def count_upcoming_consents(self) -> int:
         """Counts the number of upcoming consents associated with a given entity."""
-        return self.get_consents(AWAITING, Consent.upcoming_objects).count()
+        return self.get_consents(obj=Consent.upcoming_objects).count()
 
     def count_validated_consents(self) -> int:
         """Counts the number of validated consents associated with a given entity."""
-        return self.get_consents(VALIDATED, Consent.validated_objects).count()
+        return self.get_consents(obj=Consent.validated_objects).count()
 
     def get_awaiting_consents(self) -> QuerySet:
         """Get all awaiting consents for this entity."""
@@ -152,11 +152,11 @@ class Entity(DashboardBase):
 
     def get_upcoming_consents(self) -> QuerySet:
         """Get all upcoming consents for this entity."""
-        return self.get_consents(AWAITING, Consent.upcoming_objects)
+        return self.get_consents(obj=Consent.upcoming_objects)
 
     def get_validated_consents(self) -> QuerySet:
-        """Get all awaiting consents for this entity."""
-        return self.get_consents(VALIDATED, Consent.validated_objects).order_by(
+        """Get all validated consents for this entity."""
+        return self.get_consents(obj=Consent.validated_objects).order_by(
             "-start",
             "-end",
             "delivery_point__station_name",


### PR DESCRIPTION
## Purpose

We need to perform a daily check to identify consents that are set to expire within _x_ days. 
Any consents approaching their expiration must be duplicated with updated start and end dates.

## Proposal

- [x] add helper to check and duplicate consents
- [x] add manage command to perform a daily check
- [x] add tests
- [x] update changelog
