### PR TITLE
✨(dashboard) add command to generate missing consents

### DIFF
--- a/src/dashboard/apps/consent/management/commands/renewconsents.py
+++ b/src/dashboard/apps/consent/management/commands/renewconsents.py
@@ -1,8 +1,8 @@
-"""Consent management duplicate consents commands."""
+"""Consent management duplicate and generate missing consents commands."""
 
 import sentry_sdk
 
-from apps.consent.helpers import renew_expiring_consents
+from apps.consent.helpers import generate_missing_consents, renew_expiring_consents
 from apps.core.management.commands.base_command import DashboardBaseCommand
 
 
@@ -12,18 +12,29 @@ class Command(DashboardBaseCommand):
     help = __doc__
 
     def handle(self, *args, **options):
-        """Renew expiring consents that are nearing expiration.
+        """Renew expiring consents that are nearing expiration and generate new ones.
 
-        This method attempts to duplicate expiring
-        consents and logs an error message if the operation fails.
+        This method attempts to
+        - duplicate expiring consents and logs an error message if the operation fails.
+        - generate new consents for delivery points that do not have active consents.
 
         Raises:
             Exception: Captures any exception occurring during the consent
             duplication process and logs the error, including the relevant SIRET and
             error details.
         """
+        expiring_consents = consents = []
+
         try:
-            renew_expiring_consents()
+            expiring_consents = renew_expiring_consents()
         except Exception as e:
             sentry_sdk.capture_exception(e)
             self._log_error(f"Failed to duplicate consents. Error: {e}")
+        self._log_notice(f"Duplicate {len(expiring_consents)} consent(s).")
+
+        try:
+            consents = generate_missing_consents()
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+            self._log_error(f"Failed to generating new consents. Error: {e}")
+        self._log_notice(f"Generated {len(consents)} new consent(s).")


### PR DESCRIPTION
## Purpose

Periodically, we need the ability to generate new consents for delivery points that lack active consent.

## Purpose

- [x] add management command 
- [x] add helper function to generate consents for delivery points without active consents. 
- [x] add test.
- [x] update changelog