### PR TITLE
🔇(api) remove access logs in production

### DIFF
--- a/src/api/logging-config.prod.yaml
+++ b/src/api/logging-config.prod.yaml
@@ -4,19 +4,11 @@ disable_existing_loggers: false
 formatters:
   default:
     "()": uvicorn.logging.DefaultFormatter
-    fmt: "%(levelprefix)s %(message)s"
-    use_colors: true
-  access:
-    "()": uvicorn.logging.AccessFormatter
-    fmt: '%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s'
-    use_colors: true
+    fmt: "level=%(levelname)s msg=\"%(message)s\""
+    use_colors: false
 handlers:
   default:
     formatter: default
-    class: logging.StreamHandler
-    stream: ext://sys.stdout
-  access:
-    formatter: access
     class: logging.StreamHandler
     stream: ext://sys.stdout
 loggers:
@@ -27,11 +19,6 @@ loggers:
     propagate: false
   uvicorn.error:
     level: INFO
-  uvicorn.access:
-    handlers:
-      - access
-    level: INFO
-    propagate: false
   qualicharge:
     handlers:
       - default

--- a/src/api/start.sh
+++ b/src/api/start.sh
@@ -22,7 +22,8 @@ if [ ${debug} == 1 ]; then
 else
   extra_opts=(
     "--workers ${workers}" \
-    "--log-config logging-config.prod.yaml"
+    "--log-config logging-config.prod.yaml" \
+    "--no-access-log"
   )
 fi
 


### PR DESCRIPTION
## Purpose

API instances running on Scalingo already have activated router logs, hence uvicorn access logs seems useless duplicates.

## Proposal

- [x] remove uvicorn access logging
