### PR TITLE
🩹(dashboard) set UTC timezone for consent_start_date function

### DIFF
--- a/src/dashboard/apps/consent/tests/test_helpers.py
+++ b/src/dashboard/apps/consent/tests/test_helpers.py
@@ -175,7 +175,9 @@ def test_generate_missing_consents():
     for new_consent in new_consents:
         assert new_consent.delivery_point.id == consent.delivery_point.id
         current_year = datetime.datetime.now().year
-        assert new_consent.start == datetime.datetime(year=current_year, month=1, day=1)
+        assert new_consent.start == datetime.datetime(
+            year=current_year, month=1, day=1, tzinfo=datetime.timezone.utc
+        )
         assert new_consent.end == expected_end_date
 
     assert Consent.objects.all().count() == 6  # noqa: PLR2004

--- a/src/dashboard/apps/consent/tests/test_utils.py
+++ b/src/dashboard/apps/consent/tests/test_utils.py
@@ -12,7 +12,9 @@ def test_consent_start_date_current_year(patch_datetime_now):
     """Test `consent_start_date` returns the start date of the current year."""
     start_date = consent_start_date()
     current_year = datetime.datetime.now().year
-    expected_date = datetime.datetime(year=current_year, month=1, day=1)
+    expected_date = datetime.datetime(
+        year=current_year, month=1, day=1, tzinfo=datetime.timezone.utc
+    )
     assert start_date == expected_date
 
 

--- a/src/dashboard/apps/consent/utils.py
+++ b/src/dashboard/apps/consent/utils.py
@@ -8,7 +8,9 @@ from .settings import CONSENT_NUMBER_DAYS_END_DATE
 def consent_start_date() -> datetime.datetime:
     """Calculate the start date of the consent period."""
     current_year = datetime.datetime.now().year
-    return datetime.datetime(year=current_year, month=1, day=1)
+    return datetime.datetime(
+        year=current_year, month=1, day=1, tzinfo=datetime.timezone.utc
+    )
 
 
 def consent_end_date(


### PR DESCRIPTION
Previously, the start date was timezone-naive, which could cause inconsistencies in environments expecting timezone-aware datetimes.