### PR TITLE
✨(dashboard) add cron job configuration to schedule management tasks

### DIFF
--- a/src/dashboard/CHANGELOG.md
+++ b/src/dashboard/CHANGELOG.md
@@ -56,5 +56,6 @@ to the `REVOKED` status
 - add a command to retrieve company information from its SIRET using the 
 "Annuaire des Entreprises" API (for development only)
 - add a command to seed consents (for development only)
+- add cron job configuration to schedule management tasks
 
 [unreleased]: https://github.com/MTES-MCT/qualicharge/compare/main...bootstrap-dashboard-project

--- a/src/dashboard/cron.json
+++ b/src/dashboard/cron.json
@@ -1,0 +1,13 @@
+{
+  "jobs": [
+    {
+      "command": "12 2 * * * python manage.py syncdeliverypoints"
+    },
+    {
+      "command": "42 * * * * python manage.py renewconsents"
+    },
+    {
+      "command": "51 5 * * 1 python manage.py notifawaitingconsents"
+    }
+  ]
+}

--- a/src/dashboard/readme.md
+++ b/src/dashboard/readme.md
@@ -139,20 +139,22 @@ The third-party service **BREVO** is used to send emails.
 
 ### List of Emails Sent
 
-| **Description**     | **Target**       | **BREVO Template ID** |
-|----------------------|------------------|------------------------|
-| New user creation    | Admins           | 4                      |
-| Admin validation     | Users            | 5                      |
-| Consents awaiting    | Users            | 6                      |
-| Consents validated   | Users            | 3                      |
+| **Description**    | **Target** | **BREVO Template ID** |
+|--------------------|------------|-----------------------|
+| New user creation  | Admins     | 4                     |
+| Admin validation   | Users      | 5                     |
+| Consents awaiting  | Users      | 6                     |
+| Consents validated | Users      | 3                     |
 
 ## Django Commands
 
 ### Commands used with Cron Job
 
-- `syncdeliverypoints`: Synchronize delivery points from the QualiCharge API 
-- `renewconsents`: Renew consents (duplicate expiring consents and generate new consents)
-- `notifawaitingconsents`: Notify users of their pending consents
+| **Task**                | **Description**                                                       | **Execution Frequency**  |
+|-------------------------|-----------------------------------------------------------------------|--------------------------|
+| `syncdeliverypoints`    | Synchronizes delivery points from the QualiCharge API                 | Daily at 02:12 AM        |
+| `renewconsents`         | Renews consents (duplicates expiring consents and generates new ones) | Hourly at 00:42          |
+| `notifawaitingconsents` | Notifies users of their pending consents                              | Every Monday at 05:51 AM |
 
 ### Commands used in development only
 


### PR DESCRIPTION
## Purpose

We need to schedule the execution of `syncdeliverypoints`, `renewconsents`, and `notifawaitingconsents` commands.

## Proposal

- [x] add a `cron.json` file to define scheduled jobs
- [x] update readme.md
- [x] update changelog
