### PR TITLE
🗃️(api) add 2 months retention policy for statuses and sessions

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Add a 2 months retention policy for `Status` and `Session` data
+
 ### Changed
 
 - Upgrade alembic to `1.15.2`

--- a/src/api/cron.json
+++ b/src/api/cron.json
@@ -2,6 +2,10 @@
   "jobs": [
     {
       "command": "*/10 * * * * python -m qualicharge refresh-static --concurrently"
+    },
+    {
+      "command": "14 4 * * * dbclient-fetcher psql && psql $SCALINGO_POSTGRESQL_URL -f data_retention_procedure.sql",
+      "size": "S"
     }
   ]
 }

--- a/src/api/data_retention_procedure.sql
+++ b/src/api/data_retention_procedure.sql
@@ -1,0 +1,1 @@
+call generic_retention(config => '{"drop_after":"2 month"}');


### PR DESCRIPTION
## Purpose

For performance purpose, we need to organize dynamic data life-cycle. It means moving old statuses and sessions to cold storage and remove them from our postgresql database.

## Proposal

As explain in Scalingo's documentation [1] for TimescaleDB's integration, we set up a 2 months data retention policy for Statuses and sessions.

⚠️ We need to backup sessions first everyday.

1. https://doc.scalingo.com/databases/postgresql/timescaledb#creating-the-data-retention-policy
