### PR TITLE
🚸(dashboard) add grouped station in templates

### DIFF
--- a/src/dashboard/apps/consent/templates/consent/includes/_consent_summary_validated_card_content.html
+++ b/src/dashboard/apps/consent/templates/consent/includes/_consent_summary_validated_card_content.html
@@ -37,7 +37,7 @@
                     <td class="fr-cell--center">
                       <p class="fr-badge fr-badge--success">
                         {% with consent_total=entity.get_consents.count consent_count=entity.count_validated_consents pluralize=entity.count_validated_consents|pluralize %}
-                        {{ consent_count }} PDL{{ pluralize }} suivi{{ pluralize }}
+                        {{ consent_count }} PDL{{ pluralize }} suivi{{ pluralize }} sur {{ consent_total }}
                         {% endwith %}
                       </p>
                     </td>

--- a/src/dashboard/apps/consent/templates/consent/includes/_manage_consents.html
+++ b/src/dashboard/apps/consent/templates/consent/includes/_manage_consents.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n consent_filters %}
 
 {% comment %}
     Note: all texts of this page are intended to appear in a contract and must
@@ -38,10 +38,7 @@
                   </div>
                 </th>
                 <th scope="col">
-                  <div class="fr-cell__title">Nom de la station</div>
-                </th>
-                <th scope="col">
-                  <div class="fr-cell__title">Identifiant de la station</div>
+                  <div class="fr-cell__title">Noms et Identifiants de station</div>
                 </th>
                 <th scope="col">
                   <div class="fr-cell__title">Identifiant du PDL</div>
@@ -53,7 +50,7 @@
             </thead>
 
             <tbody>
-              {% for consent in consents %}
+              {% for consent in consents|sort_by_station %}
                 <tr id="table-prm-row-key-{{ forloop.counter }}"
                     data-row-key="{{ forloop.counter }}"
                     aria-labelledby="row-label-{{ forloop.counter }}"
@@ -90,13 +87,17 @@
                         {% elif consent.status == "AWAITING" %}
                           title="Point de livraison en attente de validation."
                         {% endif %}>
-                        Sélectionner le PDL {{ consent.delivery_point.provider_assigned_id }}
+                        Sélectionner le PDL {{ consent.provider_assigned_id }}
                       </label>
                     </div>
                   </th>
-                  <td> {{ consent.delivery_point.station_name }} </td>
-                  <td> {{ consent.delivery_point.id_station_itinerance }}  </td>
-                  <td> {{ consent.delivery_point.provider_assigned_id }} </td>
+                  <td>
+                    {% for station_name, ids in consent.stations_grouped.items %}
+                      {% if forloop.counter0 > 0 %}<br />{% endif %}
+                      {{ station_name }} {% if ids %}({{ ids|join:", " }}){% endif %}
+                    {% endfor %}
+                  </td>
+                  <td> {{ consent.provider_assigned_id }}</td>
                   <td> du {{ consent.start|date:'d/m/Y' }} au {{ consent.end|date:'d/m/Y' }} </td>
                 </tr>
               {% endfor %}
@@ -109,7 +110,7 @@
     <div class="fr-table__footer">
       <div class="fr-table__footer--start">
         <p class="fr-table__detail">
-          <span id="checked-count">0</span> / {{ consents.count }} sélectionné(s)
+          <span id="checked-count">0</span> / {{ consents|length }} sélectionné(s)
         </p>
       </div>
     </div>

--- a/src/dashboard/apps/consent/templates/consent/validated.html
+++ b/src/dashboard/apps/consent/templates/consent/validated.html
@@ -1,8 +1,6 @@
 {% extends "consent/base.html" %}
 
-{% load dsfr_tags %}
-
-{% load i18n static %}
+{% load consent_filters dsfr_tags i18n static %}
 
 {% block dashboard_content %}
   <h2>Stations suivies</h2>
@@ -24,10 +22,7 @@
               <thead>
                 <tr>
                   <th scope="col">
-                    <div class="fr-cell__title">Nom de la station</div>
-                  </th>
-                  <th scope="col">
-                    <div class="fr-cell__title">Identifiant de la station</div>
+                    <div class="fr-cell__title">Noms et Identifiants de station</div>
                   </th>
                   <th scope="col">
                     <div class="fr-cell__title">Identifiant du PDL</div>
@@ -39,14 +34,18 @@
               </thead>
 
               <tbody>
-                {% for consent in consents %}
+                {% for consent in consents|sort_by_station %}
                   <tr id="table-pdl-row-key-{{ forloop.counter }}"
                       data-row-key="{{ forloop.counter }}"
                       aria-labelledby="row-label-{{ forloop.counter }}">
 
-                    <td> {{ consent.delivery_point.station_name }} </td>
-                    <td> {{ consent.delivery_point.id_station_itinerance }} </td>
-                    <td> {{ consent.delivery_point.provider_assigned_id }} </td>
+                    <td>
+                      {% for station_name, ids in consent.stations_grouped.items %}
+                        {% if forloop.counter0 > 0 %}<br />{% endif %}
+                        {{ station_name }} {% if ids %}({{ ids|join:", " }}){% endif %}
+                      {% endfor %}
+                    </td>
+                    <td> {{ consent.provider_assigned_id }} </td>
                     <td>
                       du {{ consent.start|date:'d/m/Y' }} au {{ consent.end|date:'d/m/Y' }} </td>
                   </tr>

--- a/src/dashboard/apps/consent/templatetags/__init__.py
+++ b/src/dashboard/apps/consent/templatetags/__init__.py
@@ -1,0 +1,1 @@
+"""Dashboard consent app template tags."""

--- a/src/dashboard/apps/consent/templatetags/consent_filters.py
+++ b/src/dashboard/apps/consent/templatetags/consent_filters.py
@@ -1,0 +1,42 @@
+"""Dashboard consent app template tags."""
+
+from typing import Any
+
+from django import template
+from django.db.models import QuerySet
+
+register = template.Library()
+
+
+@register.filter
+def sort_by_station(consents: QuerySet) -> list[Any]:
+    """Sorts a queryset of consents by their associated station names.
+
+    This function returns a sorted list of dictionaries with this structured
+    data, ordered by the first station name in a case-insensitive manner.
+
+    Args:
+        consents (QuerySet): A queryset of consent objects.
+
+    Returns:
+        list[Any]: A sorted list of dictionaries, each containing structured data about
+            the consent and its related stations.
+
+    """
+    structured_consents = [
+        {
+            **consent.__dict__,
+            "provider_assigned_id": consent.delivery_point.provider_assigned_id,
+            "stations_grouped": consent.delivery_point.get_linked_stations(),
+        }
+        for consent in consents
+    ]
+
+    return sorted(
+        structured_consents,
+        key=lambda x: (
+            list(x["stations_grouped"].keys())[0].casefold()
+            if x["stations_grouped"]
+            else ""
+        ),
+    )

--- a/src/dashboard/apps/consent/tests/test_templatetags.py
+++ b/src/dashboard/apps/consent/tests/test_templatetags.py
@@ -1,0 +1,57 @@
+"""Dashboard consent templatags tests."""
+
+import pytest
+
+from apps.consent import AWAITING
+from apps.consent.templatetags.consent_filters import sort_by_station
+from apps.core.factories import DeliveryPointFactory, EntityFactory, StationFactory
+
+
+@pytest.mark.django_db
+def test_sort_by_station():
+    """Test `order_consents_by_station` function."""
+    # test order_consents_by_station() without station
+    consents = []
+    results = sort_by_station(consents)
+    assert results == []
+
+    # create entity, delivery points, consents and stations
+    entity1 = EntityFactory()
+    dp_1 = DeliveryPointFactory(entity=entity1)
+    dp_2 = DeliveryPointFactory(entity=entity1)
+    dp_3 = DeliveryPointFactory(entity=entity1)
+
+    # stations are created in a non-alphabetical order
+    StationFactory(
+        delivery_point=dp_1, station_name="B", id_station_itinerance="FRABCP01"
+    )
+    StationFactory(
+        delivery_point=dp_2, station_name="C", id_station_itinerance="FRDEFP05"
+    )
+    StationFactory(
+        delivery_point=dp_2, station_name="y", id_station_itinerance="FRDEFP02"
+    )
+    StationFactory(
+        delivery_point=dp_2, station_name="A", id_station_itinerance="FRDEFP03"
+    )
+    StationFactory(
+        delivery_point=dp_2, station_name="p", id_station_itinerance="FRDEFP04"
+    )
+    StationFactory(
+        delivery_point=dp_3, station_name="d", id_station_itinerance="FRGHIP01"
+    )
+
+    consents = entity1.get_awaiting_consents()
+    results = sort_by_station(consents)
+
+    for result in results:
+        # test retrieving the “standard” information from a consent
+        assert result["delivery_point_id"] in [dp_1.id, dp_2.id, dp_3.id]
+        assert result["provider_assigned_id"] is not None
+        assert result["status"] == AWAITING
+
+    # Extract station names from grouped stations for comparison
+    ordered_station_names = [
+        list(result["stations_grouped"].keys())[0] for result in results
+    ]
+    assert ordered_station_names == sorted(ordered_station_names, key=str.casefold)

--- a/src/dashboard/apps/consent/views.py
+++ b/src/dashboard/apps/consent/views.py
@@ -1,5 +1,7 @@
 """Dashboard consent app views."""
 
+from typing import Any
+
 import sentry_sdk
 from anymail.exceptions import AnymailRequestsAPIError
 from anymail.message import AnymailMessage
@@ -77,7 +79,7 @@ class ConsentFormView(BaseView, FormView):
 
         return initial
 
-    def form_valid(self, form):
+    def form_valid(self, form) -> HttpResponse:
         """Update the consent status.
 
         Bulk update of the consent status:
@@ -105,10 +107,11 @@ class ConsentFormView(BaseView, FormView):
 
     def get_context_data(self, **kwargs):
         """Add context data for the view."""
+        entity = self._get_entity()
         context = super().get_context_data(**kwargs)
         context["control_authority"] = settings.CONSENT_CONTROL_AUTHORITY
-        context["entity"] = self._get_entity()
-        context["consents"] = self._get_entity().get_consents()
+        context["entity"] = entity
+        context["consents"] = entity.get_awaiting_consents()
         context["signature_location"] = settings.CONSENT_SIGNATURE_LOCATION
 
         return context
@@ -319,7 +322,7 @@ class ValidatedConsentView(BaseView, ListView):
     ]
     breadcrumb_current = _("Followed stations")
 
-    def get_queryset(self):
+    def get_queryset(self) -> Any:
         """Filter queryset to only return validated consents for the current user.
 
         Returns:
@@ -350,7 +353,7 @@ class UpcomingConsentFormView(ConsentFormView):
         We need to only retrieve upcoming consents.
         """
         context = super().get_context_data(**kwargs)
-        context["consents"] = self._get_entity().get_upcoming_consents()
+        context["consents"] = context["entity"].get_upcoming_consents()
 
         return context
 

--- a/src/dashboard/apps/core/factories.py
+++ b/src/dashboard/apps/core/factories.py
@@ -66,17 +66,9 @@ class StationFactory(factory.django.DjangoModelFactory):
     @factory.lazy_attribute
     def id_station_itinerance(self):
         """Generate a random ID for the station."""
-        entity_name = self.delivery_point.entity.name
-
-        short_name = (
-            entity_name[:3].upper()
-            if len(entity_name) > 3  # noqa: PLR2004
-            else entity_name.upper()
-        )
-
+        short_name = fake.bothify(text="???", letters="ABCDEFGHIJKLMNOPQRSTUVWXYZ")
         base_id = fake.bothify(
             text=f"FR{short_name}P#####",
-            letters="ABCDEFGHIJKLMNOPQRSTUVWXYZ",
         )
 
         return base_id


### PR DESCRIPTION
## Purpose

- The consent display must not include duplicate `delivery points`.  
- Each `delivery point` row must display the associated `stations` along with a list of `id_station_itinerance` for each `station`.

## Proposal

- [x] add a template_tags to sort a list of consents by `station_name`
- [x] updates Consents views
- [x] update Consents templates
- [x] add tests