### PR TITLE
🔨(prefect) create all deployments once prefect is up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,8 @@ bootstrap: \
   seed-dashboard \
   jupytext--to-ipynb \
   run-api \
-  seed-api
+  seed-api \
+  post-deploy-prefect
 .PHONY: bootstrap
 
 bootstrap-api: ## bootstrap the api service
@@ -315,6 +316,8 @@ post-deploy-prefect:  ## run prefect post-deployment script
 	@$(COMPOSE_UP) --wait prefect
 	@echo "Running postdeploy script for prefect service…"
 	@$(COMPOSE) exec prefect pipenv run honcho start postdeploy
+	@echo "Creating all deployments…"
+	@$(COMPOSE) exec -T prefect pipenv run ./prefect-deploy-all.sh
 .PHONY: post-deploy-prefect
 
 create-api-superuser: ## create api super user


### PR DESCRIPTION
## Purpose

Recent changes in prefect deployment strategy broke local development workflow: deployments are not created locally

## Proposal

- [x] create all deployments in the `post-deploy-prefect` task
- [x] automate post deployment in the `bootstrap` task
