### PR TITLE
🐛(prefect) allow historicization with None start

### DIFF
--- a/src/prefect/indicators/historicize/up.py
+++ b/src/prefect/indicators/historicize/up.py
@@ -10,6 +10,8 @@ from prefect.task_runners import ThreadPoolTaskRunner
 from sqlalchemy.orm import Session
 
 from indicators.conf import settings
+
+# from indicators.db import get_api_db_engine
 from indicators.db import get_indicators_db_engine
 from indicators.models import IndicatorPeriod, IndicatorTimeSpan, PeriodDuration
 from indicators.strategy import STRATEGY
@@ -163,7 +165,7 @@ def to_historicization_up(
 
 @flow(
     task_runner=ThreadPoolTaskRunner(max_workers=settings.THREAD_POOL_MAX_WORKERS),
-    flow_run_name="meta-up-{to_period.value}-{start:%y-%m-%d}",
+    flow_run_name="meta-up-{to_period.value}{offset}",
 )
 def calculate(  # noqa: PLR0913
     environment: Environment,
@@ -178,9 +180,9 @@ def calculate(  # noqa: PLR0913
     init_period = (
         datetime.now()
         if not offset and start is None
-        else get_period_start_from_pit(start, offset, period)
+        else get_period_start_from_pit(start, offset, to_period)
     )
-    final_timespan = IndicatorTimeSpan(start=init_period, period=to_period)
+    final_timespan = IndicatorTimeSpan(period=to_period.value, start=init_period)
     query_params = {
         "environment": environment,
         "period": period.value,

--- a/src/prefect/indicators/utils.py
+++ b/src/prefect/indicators/utils.py
@@ -31,13 +31,11 @@ POWER_RANGE_CTE: dict = {
 }
 
 
-# @typing.no_type_check
-# type: ignore[arg-type]
-def get_period_start_from_pit(  # type: ignore[arg-type]  # noqa: PLR0911
+def get_period_start_from_pit(  # noqa: PLR0911
     pit: datetime | None = None,
     offset: int = 0,
     period: IndicatorPeriod = IndicatorPeriod.DAY,
-) -> datetime:  # type: ignore[arg-type]
+) -> datetime:
     """Return the starting datetime of a period given a point in time (PIT) definition and an offset."""  # noqa: E501
     first_minute = {"minute": 0, "second": 0, "microsecond": 0}
     first_hour = first_minute | {"hour": 0}

--- a/src/prefect/tests/historicize/test_up.py
+++ b/src/prefect/tests/historicize/test_up.py
@@ -181,7 +181,7 @@ def test_to_historicization_up_extras():
     assert df["value"].equals(df["mean"])
 
 
-def test_flow_up_calculate(db_connection):
+def test_flow_up_calculate():
     """Test the `calculate` flow."""
     indicators = i1.calculate(
         Environment.TEST,
@@ -192,8 +192,8 @@ def test_flow_up_calculate(db_connection):
         persist=True,
     )
     histo_up = up.calculate(
-        Environment.TEST,
-        IndicatorPeriod.MONTH,
+        environment=Environment.TEST,
+        to_period=IndicatorPeriod.MONTH,
         start=TIMESPAN.start,
         offset=0,
         period=IndicatorPeriod.DAY,
@@ -228,8 +228,8 @@ def test_flow_calculate_persistence(indicators_db_engine):
         persist=True,
     )
     up.calculate(
-        Environment.TEST,
-        IndicatorPeriod.MONTH,
+        environment=Environment.TEST,
+        to_period=IndicatorPeriod.MONTH,
         start=TIMESPAN.start,
         offset=0,
         period=IndicatorPeriod.DAY,
@@ -242,3 +242,18 @@ def test_flow_calculate_persistence(indicators_db_engine):
         """
         result = connection.execute(text(query))
         assert result.one()[0] == len(indicators)
+
+
+def test_flow_calculate_up_with_start_none(indicators_db_engine):
+    """Test the `calculate` flow with start=None."""
+    i1.calculate(
+        Environment.TEST,
+        levels=[Level.NATIONAL],
+        start=TIMESPAN.start,
+        period=IndicatorPeriod.DAY,
+        persist=True,
+    )
+    with indicators_db_engine.connect():
+        assert isinstance(
+            up.calculate(Environment.TEST, to_period=IndicatorPeriod.WEEK), pd.DataFrame
+        )

--- a/src/prefect/tests/infrastructure/test_i1.py
+++ b/src/prefect/tests/infrastructure/test_i1.py
@@ -5,6 +5,7 @@ I1: the number of publicly open points of charge.
 
 from datetime import datetime
 
+import pandas as pd
 import pytest  # type: ignore
 from sqlalchemy import text
 
@@ -104,6 +105,11 @@ def test_flow_calculate_persistence(indicators_db_engine):
     with indicators_db_engine.connect() as connection:
         result = connection.execute(text("SELECT COUNT(*) FROM test WHERE code = 'i1'"))
         assert result.one()[0] == len(indicators)
+
+
+def test_flow_calculate_with_start_none():
+    """Test the `calculate` flow with start=None."""
+    assert isinstance(i1.calculate(Environment.TEST, [Level.NATIONAL]), pd.DataFrame)
 
 
 # query used to get N_LEVEL


### PR DESCRIPTION
## Purpose

Historicization (`calculate` function, module `up`) is ineffective when `start` parameter is None .

## Proposal

- [x] allow historicization when `start` is None