### PR TITLE
🐛(api) update localisation using the coordonneesXY field

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to
 - Upgrade sentry-sdk to `2.25.0`
 - Upgrade setuptools to `78.1.0`
 
+### Fixed
+
+- Update `Localisation` discriminating field to `coordonneesXY` for
+  statique-related helpers
+
 ## [0.20.0] - 2025-03-19
 
 ### Added

--- a/src/api/qualicharge/models/static.py
+++ b/src/api/qualicharge/models/static.py
@@ -67,18 +67,20 @@ class FrenchPhoneNumber(PhoneNumber):
 def to_coordinates_tuple(value):
     """Convert input string to a Coordinate tuple.
 
-    Two string formats are supported:
+    Three string formats are supported:
 
     1. "[longitude: float, latitude: float]"
     2. "POINT(longitude latitude)"
+    3. "SRID=0000;POINT(longitude latitude)"
 
-    In both cases, the input string is converted to a reversed tuple
+    In all cases, the input string is converted to a reversed tuple
     (latitude: float, longitude: float) that will be used as Coordinate input.
     """
     if not isinstance(value, str):
         return value
     if m := re.match(
-        r"POINT\((?P<longitude>-?\d+\.\d+) (?P<latitude>-?\d+\.\d+)\)", value
+        r"(?:SRID=\d{4};)?POINT\((?P<longitude>-?\d+\.\d+) (?P<latitude>-?\d+\.\d+)\)",
+        value,
     ):
         return (m["latitude"], m["longitude"])
     return tuple(reversed(json.loads(value)))

--- a/src/api/qualicharge/schemas/core.py
+++ b/src/api/qualicharge/schemas/core.py
@@ -59,6 +59,8 @@ mapper_registry = registry()
 
 STATIQUE_MV_TABLE_NAME: str = "statique"
 
+DEFAULT_SRID: int = 4326
+
 
 class OperationalUnitTypeEnum(IntEnum):
     """Operational unit types."""
@@ -194,7 +196,7 @@ class Localisation(BaseAuditableSQLModel, table=True):
         sa_type=Geometry(
             geometry_type="POINT",
             # WGS84 coordinates system
-            srid=4326,
+            srid=DEFAULT_SRID,
             spatial_index=True,
         ),
         unique=True,
@@ -211,7 +213,7 @@ class Localisation(BaseAuditableSQLModel, table=True):
     @staticmethod
     def _coordinates_to_geometry_point(value: Coordinate):
         """Convert coordinate to Geometry point."""
-        return f"POINT({value.longitude} {value.latitude})"
+        return f"SRID={DEFAULT_SRID};POINT({value.longitude} {value.latitude})"
 
     @staticmethod
     def _wkb_to_coordinates(value: WKBElement):

--- a/src/api/qualicharge/schemas/utils.py
+++ b/src/api/qualicharge/schemas/utils.py
@@ -198,7 +198,7 @@ def save_statique(
         Localisation,
         statique,
         fields={
-            "adresse_station",
+            "coordonneesXY",
         },
         update=update,
         author=author,

--- a/src/api/tests/schemas/test_static.py
+++ b/src/api/tests/schemas/test_static.py
@@ -87,7 +87,7 @@ def test_localisation_schema_coordonneesXY_serializer(db_session):
         coordonneesXY=Coordinate(longitude=-3.129447, latitude=45.700327),
     )
     assert loc.model_dump(include={"coordonneesXY"}) == {
-        "coordonneesXY": "POINT(-3.129447 45.700327)",
+        "coordonneesXY": "SRID=4326;POINT(-3.129447 45.700327)",
     }
 
     db_session.add(loc)
@@ -106,7 +106,7 @@ def test_localisation_schema_coordonneesXY_serializer(db_session):
     # Test update case
     db_loc.coordonneesXY = Coordinate(longitude=-3.129447, latitude=-55.700327)
     assert db_loc.model_dump(include={"coordonneesXY"}) == {
-        "coordonneesXY": "POINT(-3.129447 -55.700327)",
+        "coordonneesXY": "SRID=4326;POINT(-3.129447 -55.700327)",
     }
 
     db_session.add(loc)
@@ -126,7 +126,9 @@ def test_localisation_factory():
     localisation = LocalisationFactory.build()
     assert localisation.coordonneesXY is not None
     assert (
-        re.match(r"^POINT\(-?\d+\.\d+ -?\d+\.\d+\)$", localisation.coordonneesXY)
+        re.match(
+            r"^SRID=4326;POINT\(-?\d+\.\d+ -?\d+\.\d+\)$", localisation.coordonneesXY
+        )
         is not None
     )
 


### PR DESCRIPTION
## Purpose

When a user tries to update a Localisation that as many entries with the same address but an already referenced set of coordinates (which is perfectly acceptable), the API returns an error (for statique creation or update).

## Proposal

Since the `coordonneesXY` field is the only unique field for the `Localisation` model, it should be used to discriminate existing objects from those that need to be created.
