### PR TITLE
🔖(api:minor) bump release to 0.21.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.21.0] - 2025-04-11
+
 ### Changed
 
 - Update the list of active operational units
@@ -376,7 +378,8 @@ and this project adheres to
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.20.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.21.0...main
+[0.21.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.19.1...v0.20.0
 [0.19.1]: https://github.com/MTES-MCT/qualicharge/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.18.0...v0.19.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -3,7 +3,7 @@
 #
 [project]
 name = "qualicharge"
-version = "0.20.0"
+version = "0.21.0"
 
 # Third party packages configuration
 [tool.coverage.run]

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.20.0"
+__version__ = "0.21.0"


### PR DESCRIPTION
### Changed

- Update the list of active operational units
- Upgrade alembic to `1.15.2`
- Upgrade fastapi to `0.115.12`
- Upgrade psycopg to `3.2.6`
- Upgrade pydantic to `2.11.1`
- Upgrade pydantic-extra-types to `2.10.3`
- Upgrade sentry-sdk to `2.25.0`
- Upgrade setuptools to `78.1.0`

### Fixed

- Update `Localisation` discriminating field to `coordonneesXY` for statique-related helpers
