### PR TITLE
⚡️(opendata) restrict statuses query to recent statuses

### DIFF
--- a/src/opendata/data7.yaml
+++ b/src/opendata/data7.yaml
@@ -31,7 +31,7 @@ default:
         FROM
           Status
           INNER JOIN recent_statuses ON Status.id = recent_statuses.latest_id
-          INNER JOIN PointDeCharge ON PointDeCharge.id = status.point_de_charge_id
+          RIGHT JOIN PointDeCharge ON PointDeCharge.id = status.point_de_charge_id
         ORDER BY
           Status.horodatage DESC
     - basename: statiques

--- a/src/opendata/data7.yaml
+++ b/src/opendata/data7.yaml
@@ -15,7 +15,7 @@ default:
               PointDeCharge
               INNER JOIN Status ON Status.point_de_charge_id = PointDeCharge.id
             WHERE
-              Status.horodatage > now() - interval '1 day'
+              Status.horodatage > now() - interval '1 week'
             GROUP BY
               PointDeCharge.id_pdc_itinerance
           )

--- a/src/opendata/data7.yaml
+++ b/src/opendata/data7.yaml
@@ -8,12 +8,14 @@ default:
     - basename: statuses
       query: >-
         WITH
-          pdc_status AS (
+          recent_statuses AS (
             SELECT
               LAST (Status.id, Status.horodatage) AS latest_id
             FROM
               PointDeCharge
               INNER JOIN Status ON Status.point_de_charge_id = PointDeCharge.id
+            WHERE
+              Status.horodatage > now() - interval '1 day'
             GROUP BY
               PointDeCharge.id_pdc_itinerance
           )
@@ -28,15 +30,10 @@ default:
           Status.etat_prise_type_ef
         FROM
           Status
-          INNER JOIN PointDeCharge ON Status.point_de_charge_id = PointDeCharge.id
-        WHERE
-          Status.id IN (
-            SELECT
-              latest_id
-            FROM
-              pdc_status
-          )
-        ORDER BY Status.horodatage DESC
+          INNER JOIN recent_statuses ON Status.id = recent_statuses.latest_id
+          INNER JOIN PointDeCharge ON PointDeCharge.id = status.point_de_charge_id
+        ORDER BY
+          Status.horodatage DESC
     - basename: statiques
       query: >-
         SELECT

--- a/src/opendata/data7.yaml
+++ b/src/opendata/data7.yaml
@@ -32,8 +32,6 @@ default:
           Status
           INNER JOIN recent_statuses ON Status.id = recent_statuses.latest_id
           RIGHT JOIN PointDeCharge ON PointDeCharge.id = status.point_de_charge_id
-        ORDER BY
-          Status.horodatage DESC
     - basename: statiques
       query: >-
         SELECT


### PR DESCRIPTION
## Purpose

The statuses database query is quite greedy when trying to get the most recent status for every charging point. We can do better.

## Proposal

If we consider returning an old status is a non-sense, We can drastically improve query performance by restricting the analysis to recent statuses, e.g. that ocurred in the last day (week?).
