### PR TITLE
🐛(api) Switch the Status table to a TimescaleDB hypertable

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to
 - Docs: update data schema restrictions
 - Docs: add usage section
 
+### Fixed
+
+- Switch `Status` table to a TimescaleDB hypertable
+
 ## [0.21.0] - 2025-04-11
 
 ### Changed

--- a/src/api/qualicharge/migrations/versions/2d5ecaec5672_fix_status_hypertable_creation.py
+++ b/src/api/qualicharge/migrations/versions/2d5ecaec5672_fix_status_hypertable_creation.py
@@ -1,0 +1,45 @@
+"""Fix status hypertable creation
+
+Revision ID: 2d5ecaec5672
+Revises: f0f871ac556d
+Create Date: 2025-04-15 16:56:14.774236
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy.exc import ProgrammingError
+
+
+# revision identifiers, used by Alembic.
+revision: str = "2d5ecaec5672"
+down_revision: Union[str, None] = "f0f871ac556d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create status hypertable and related indexes."""
+    op.drop_constraint("status_pkey", "status")
+    op.drop_index("ix_status_horodatage")
+    op.create_index(
+        "ix_status_id_horodatage", "status", ["id", "horodatage"], unique=True
+    )
+    op.execute(
+        "SELECT create_hypertable('status', by_range('horodatage'), migrate_data => TRUE);"
+    )
+
+
+def downgrade() -> None:
+    """Restore Status to a standard postgres table."""
+    # Duplicate table structure
+    op.execute("CREATE TABLE pg_status (LIKE status INCLUDING ALL)")
+    # Copy all data
+    op.execute("INSERT INTO pg_status (SELECT * FROM status)")
+    # Drop the hypertable
+    op.drop_table("status")
+    # Rename regular table
+    op.rename_table("pg_status", "status")
+    op.create_primary_key("status_pkey", "status", ["id"])
+    op.create_index("ix_status_horodatage", "status", ["horodatage"])

--- a/src/api/qualicharge/schemas/core.py
+++ b/src/api/qualicharge/schemas/core.py
@@ -19,7 +19,7 @@ from pydantic import (
 )
 from pydantic_extra_types.coordinate import Coordinate
 from shapely.geometry import mapping
-from sqlalchemy import Select, event
+from sqlalchemy import PrimaryKeyConstraint, Select, event
 from sqlalchemy import cast as SA_cast
 from sqlalchemy.dialects.postgresql import ENUM as PgEnum
 from sqlalchemy.orm import registry
@@ -446,10 +446,11 @@ class Status(BaseTimestampedSQLModel, StatusBase, table=True):
     """IRVE recharge session."""
 
     __table_args__ = BaseTimestampedSQLModel.__table_args__ + (
+        PrimaryKeyConstraint("id", "horodatage", name="ix_status_id_horodatage"),
         {"timescaledb_hypertable": {"time_column_name": "horodatage"}},
     )
 
-    id: UUID = Field(default_factory=uuid4, primary_key=True)
+    id: UUID = Field(default_factory=uuid4)
     horodatage: PastDatetime = Field(
         sa_type=DateTime(timezone=True),
         description="The timestamp indicating when the status changed.",


### PR DESCRIPTION
## Purpose

As we defined Status.id as the table primary key (with unique constraint), TimescaleDB refused to create our hypertable. This is a well-known, [documented issue](https://docs.timescale.com/use-timescale/latest/hypertables/hypertables-and-unique-indexes/#create-a-hypertable-from-a-table-with-unique-indexes).

## Proposal

We need instead to add a composite unique constraint using both the `id` and `horodatage` fields.
