### PR TITLE
🐛(api) switch the Session table to a TimescaleDB hypertable

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgresql:
-        image: timescale/timescaledb-ha:pg14-ts2.14-oss
+        image: timescale/timescaledb-ha:pg15-ts2.19-oss
         env:
           POSTGRES_DB: qualicharge-api
           POSTGRES_USER: qualicharge
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgresql:
-        image: timescale/timescaledb-ha:pg14-ts2.14-oss
+        image: timescale/timescaledb-ha:pg15-ts2.19-oss
         env:
           POSTGRES_DB: test-qualicharge-api
           POSTGRES_USER: qualicharge
@@ -352,7 +352,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgresql:
-        image: timescale/timescaledb-ha:pg14-ts2.14-oss
+        image: timescale/timescaledb-ha:pg15-ts2.19-oss
         env:
           POSTGRES_DB: test-qualicharge-api
           POSTGRES_USER: qualicharge

--- a/.github/workflows/prefect.yml
+++ b/.github/workflows/prefect.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgresql:
-        image: timescale/timescaledb-ha:pg14-ts2.14-oss
+        image: timescale/timescaledb-ha:pg15-ts2.19-oss
         env:
           POSTGRES_DB: qualicharge-api
           POSTGRES_USER: qualicharge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgresql:
-    image: timescale/timescaledb-ha:pg14-ts2.14-oss
+    image: timescale/timescaledb-ha:pg15-ts2.19-oss
     env_file:
       - env.d/postgresql
       - env.d/api

--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Switch `Session` table to a TimescaleDB hypertable
+
 ## [0.22.0] - 2025-04-17
 
 ### Added

--- a/src/api/qualicharge/migrations/versions/2d5ecaec5672_fix_status_hypertable_creation.py
+++ b/src/api/qualicharge/migrations/versions/2d5ecaec5672_fix_status_hypertable_creation.py
@@ -9,7 +9,6 @@ Create Date: 2025-04-15 16:56:14.774236
 from typing import Sequence, Union
 
 from alembic import op
-from sqlalchemy.exc import ProgrammingError
 
 
 # revision identifiers, used by Alembic.

--- a/src/api/qualicharge/migrations/versions/d7425ed47afd_fix_session_hypertable_creation.py
+++ b/src/api/qualicharge/migrations/versions/d7425ed47afd_fix_session_hypertable_creation.py
@@ -1,0 +1,43 @@
+"""Fix session hypertable creation
+
+Revision ID: d7425ed47afd
+Revises: 2d5ecaec5672
+Create Date: 2025-04-16 15:34:20.392315
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d7425ed47afd"
+down_revision: Union[str, None] = "2d5ecaec5672"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create session hypertable and related indexes."""
+    op.drop_constraint("session_pkey", "session")
+    op.drop_index("ix_session_start")
+    op.create_index("ix_session_id_start", "session", ["id", "start"], unique=True)
+    op.execute(
+        "SELECT create_hypertable('session', by_range('start'), migrate_data => TRUE);"
+    )
+
+
+def downgrade() -> None:
+    """Restore Session to a standard postgres table."""
+    # Duplicate table structure
+    op.execute("CREATE TABLE pg_session (LIKE session INCLUDING ALL)")
+    # Copy all data
+    op.execute("INSERT INTO pg_session (SELECT * FROM session)")
+    # Drop the hypertable
+    op.drop_table("session")
+    # Rename regular table
+    op.rename_table("pg_session", "session")
+    op.create_primary_key("session_pkey", "session", ["id"])
+    op.create_index("ix_session_start", "session", ["start"])

--- a/src/api/qualicharge/schemas/core.py
+++ b/src/api/qualicharge/schemas/core.py
@@ -422,10 +422,11 @@ class Session(BaseAuditableSQLModel, SessionBase, table=True):
     """IRVE recharge session."""
 
     __table_args__ = BaseAuditableSQLModel.__table_args__ + (
+        PrimaryKeyConstraint("id", "start", name="ix_session_id_start"),
         {"timescaledb_hypertable": {"time_column_name": "start"}},
     )
 
-    id: UUID = Field(default_factory=uuid4, primary_key=True)
+    id: UUID = Field(default_factory=uuid4)
     start: PastDatetime = Field(
         sa_type=DateTime(timezone=True),
         description="The timestamp indicating when the session started.",
@@ -443,7 +444,7 @@ class Session(BaseAuditableSQLModel, SessionBase, table=True):
 
 
 class Status(BaseTimestampedSQLModel, StatusBase, table=True):
-    """IRVE recharge session."""
+    """IRVE recharge status."""
 
     __table_args__ = BaseTimestampedSQLModel.__table_args__ + (
         PrimaryKeyConstraint("id", "horodatage", name="ix_status_id_horodatage"),


### PR DESCRIPTION
## Purpose

As we defined Session.id as the table primary key (with unique constraint), TimescaleDB refused to create our hypertable.

## Proposal

We need instead to add a composite unique constraint using both the ID and start fields. Since `Session` table changes are tracked using database triggers, we need to upgrade TimescaleDB to at least `2.18.0`.

---

We need to wait for our cloud provider to upgrade TimescaleDB from the `2.17.2` to at least `2.18.0`.

---

*Update*: we've upgraded TimescaleDB both in staging and production to `2.19`.
