### PR TITLE
🔖(api:minor) bump release to 0.22.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.22.0] - 2025-04-17
+
 ### Added
 
 - Clean database static orphan entries using a SQL script ran as a cronjob task
@@ -431,7 +433,8 @@ and this project adheres to
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.21.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.22.0...main
+[0.22.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.19.1...v0.20.0
 [0.19.1]: https://github.com/MTES-MCT/qualicharge/compare/v0.19.0...v0.19.1

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -3,7 +3,7 @@
 #
 [project]
 name = "qualicharge"
-version = "0.21.0"
+version = "0.22.0"
 
 # Third party packages configuration
 [tool.coverage.run]

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.21.0"
+__version__ = "0.22.0"


### PR DESCRIPTION
### Added

- Clean database static orphan entries using a SQL script ran as a cronjob task

### Changed

- Add time and fk-related missing database indexes for status & session tables
- Docs: update data schema restrictions
- Docs: add usage section

### Fixed

- Switch `Status` table to a TimescaleDB hypertable
