### PR TITLE
🔖(api:patch) bump release to 0.22.1

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.22.1] - 2025-04-17
+
 ### Fixed
 
 - Switch `Session` table to a TimescaleDB hypertable
@@ -437,7 +439,8 @@ and this project adheres to
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.22.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.22.1...main
+[0.22.1]: https://github.com/MTES-MCT/qualicharge/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.19.1...v0.20.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -3,7 +3,7 @@
 #
 [project]
 name = "qualicharge"
-version = "0.22.0"
+version = "0.22.1"
 
 # Third party packages configuration
 [tool.coverage.run]

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.22.0"
+__version__ = "0.22.1"


### PR DESCRIPTION
### Fixed

- Switch `Session` table to a TimescaleDB hypertable
