### PR TITLE
✨(renewable) refactor renewable views and templates to support Entity Mixin

### DIFF
--- a/src/dashboard/apps/consent/views.py
+++ b/src/dashboard/apps/consent/views.py
@@ -1,6 +1,7 @@
 """Dashboard consent app views."""
 
 from typing import Any
+from warnings import warn
 
 import sentry_sdk
 from anymail.exceptions import AnymailRequestsAPIError
@@ -118,6 +119,12 @@ class ConsentFormView(BaseView, FormView):
 
     def _get_entity(self) -> Entity:
         """Return the specific entity with the provided slug."""
+        warn(
+            "This method is deprecated. please use "
+            "core EntityMixin.get_entity() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         slug: str | None = self.kwargs.get("slug", None)
         user: DashboardUser = self.request.user  # type: ignore
 

--- a/src/dashboard/apps/core/mixins.py
+++ b/src/dashboard/apps/core/mixins.py
@@ -1,0 +1,30 @@
+"""Dashboard core mixins."""
+
+from typing import Any
+
+from django.core.exceptions import PermissionDenied
+from django.http import Http404
+from django.shortcuts import get_object_or_404
+
+from apps.auth.models import DashboardUser
+from apps.core.models import Entity
+
+
+class EntityMixin:
+    """Mixin to retrieve a specific entity with permission validation."""
+
+    kwargs: dict[str, Any]
+    request: Any
+
+    def get_entity(self) -> Entity:
+        """Return the specific entity with the provided slug."""
+        slug: str | None = self.kwargs.get("slug", None)
+        user: DashboardUser = self.request.user
+
+        if not slug:
+            raise Http404
+
+        entity: Entity = get_object_or_404(Entity, slug=slug)
+        if not user.can_validate_entity(entity):
+            raise PermissionDenied
+        return entity

--- a/src/dashboard/apps/core/tests/test_mixins.py
+++ b/src/dashboard/apps/core/tests/test_mixins.py
@@ -1,0 +1,71 @@
+"""Dashboard core mixins tests."""
+
+import pytest
+from django.core.exceptions import PermissionDenied
+from django.http import Http404
+
+from apps.auth.factories import UserFactory
+from apps.core.factories import EntityFactory
+from apps.core.mixins import EntityMixin
+
+
+@pytest.mark.django_db
+def test_get_entity_success(rf):
+    """Test get_entity returns the correct entity when permissions are valid."""
+    user = UserFactory()
+    entity = EntityFactory(name="Test Entity", users=[user])
+    request = rf.get("/some-path/")
+    request.user = user
+
+    mixin = EntityMixin()
+    mixin.request = request
+    mixin.kwargs = {"slug": "test-entity"}
+
+    retrieved_entity = mixin.get_entity()
+    assert retrieved_entity == entity
+
+
+@pytest.mark.django_db
+def test_get_entity_missing_slug(rf):
+    """Test get_entity raises Http404 when slug is missing."""
+    user = UserFactory()
+    request = rf.get("/some-path/")
+    request.user = user
+
+    mixin = EntityMixin()
+    mixin.request = request
+    mixin.kwargs = {}
+
+    with pytest.raises(Http404):
+        mixin.get_entity()
+
+
+@pytest.mark.django_db
+def test_get_entity_invalid_slug(rf):
+    """Test get_entity raises 404 when entity with the provided slug doesn't exist."""
+    user = UserFactory()
+    request = rf.get("/some-path/")
+    request.user = user
+
+    mixin = EntityMixin()
+    mixin.request = request
+    mixin.kwargs = {"slug": "non-existent-slug"}
+
+    with pytest.raises(Http404):
+        mixin.get_entity()
+
+
+@pytest.mark.django_db
+def test_get_entity_permission_denied(rf):
+    """Test get_entity raises PermissionDenied when the user lacks permissions."""
+    user = UserFactory()
+    EntityFactory(name="Test Entity")
+    request = rf.get("/some-path/")
+    request.user = user
+
+    mixin = EntityMixin()
+    mixin.request = request
+    mixin.kwargs = {"slug": "test-entity"}
+
+    with pytest.raises(PermissionDenied):
+        mixin.get_entity()

--- a/src/dashboard/apps/renewable/templates/renewable/includes/_manage_meters.html
+++ b/src/dashboard/apps/renewable/templates/renewable/includes/_manage_meters.html
@@ -44,18 +44,22 @@
             </thead>
 
             <tbody>
-              {% for i in '123'|make_list %}
+              {% for renewable_dp in renewable_delivery_points %}
               <tr id="table-prm-row-key-{{ forloop.counter }}"
                   data-row-key="{{ forloop.counter }}"
                   aria-labelledby="row-label-{{ forloop.counter }}">
                 <td> Station {{ forloop.counter }} (FRMIRP17359) </td>
-                <td> 31472430812876 </td>
+                <td> {{ renewable_dp.provider_assigned_id }} </td>
                 <td>
-                  1er trimestre 2025<br />
-                  du 01/01/2025 au 31/03/2025
+                  {# todo: add templatetag to get actual period #}
+                  -
+                  {# 1er trimestre 2025<br />#}
+                  {# du 01/01/2025 au 31/03/2025#}
                 </td>
                 <td>
-                  5698.45 kWh
+                {# todo: add the previous renewable meters and their date #}
+                  -
+                  {# 5698.45 kWh#}
                 </td>
                 <td>
                   <div class="fr-input-group">

--- a/src/dashboard/apps/renewable/templates/renewable/includes/_no_data_card.html
+++ b/src/dashboard/apps/renewable/templates/renewable/includes/_no_data_card.html
@@ -1,4 +1,4 @@
-<div class="fr-card__desc fr-highlight">
+<div class="fr-card__desc fr-highlight" id="no-data-card">
   <p class="fr-card__desc">
     {{ description }}
     <br />

--- a/src/dashboard/apps/renewable/templates/renewable/manage.html
+++ b/src/dashboard/apps/renewable/templates/renewable/manage.html
@@ -14,7 +14,7 @@
         de livraison.
       </p>
 
-      {% if entity %}
+      {% if entity and renewable_delivery_points %}
         <form action="" method="post">
           {% csrf_token %}
 
@@ -22,9 +22,6 @@
             <div class="fr-messages-group" id="error-messages" aria-live="assertive">
               <div class="{% if form.renewable.errors %}fr-pl-3v{% endif %} fr-mb-6v">
                 <ul id="message-non-field-error">
-                  <li class="fr-message fr-message--error" id="message-error">
-                    {% trans "The form contains errors" %}
-                  </li>
                   {% if form.non_field_errors %}
                     {% for error in form.non_field_errors %}
                       <li class="fr-message fr-message--error">{{ error }}</li>
@@ -48,7 +45,7 @@
 
         </form>
       {% else %}
-        <p>{% trans "No production statement to enter." %}</p>
+        {% include "renewable/includes/_no_data_card.html" with description="Aucun relevé en attente." %}
       {% endif %}
     </div>
   </div>

--- a/src/dashboard/apps/renewable/tests/__init__.py
+++ b/src/dashboard/apps/renewable/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Dashboard renewable app tests."""

--- a/src/dashboard/apps/renewable/tests/test_view.py
+++ b/src/dashboard/apps/renewable/tests/test_view.py
@@ -1,0 +1,150 @@
+"""Dashboard renewable views tests."""
+
+from http import HTTPStatus
+
+import pytest
+from django.urls import reverse
+
+from apps.auth.factories import UserFactory
+from apps.auth.mixins import UserValidationMixin
+from apps.core.factories import DeliveryPointFactory, EntityFactory
+from apps.core.mixins import EntityMixin
+from apps.core.models import DeliveryPoint
+from apps.renewable.views import RenewableMetterReadingFormView
+
+
+@pytest.mark.django_db
+def test_view_inherits_entity_mixin():
+    """Test RenewableMetterReadingFormView inherits mixins."""
+    assert issubclass(RenewableMetterReadingFormView, EntityMixin)
+    assert issubclass(RenewableMetterReadingFormView, UserValidationMixin)
+
+
+@pytest.mark.django_db
+def test_manage_views_with_not_logged_user_is_restricted(client):
+    """Test access to renewable:manage with not logged is restricted."""
+    entity_name = "entity-1"
+    EntityFactory(name=entity_name)
+
+    url = reverse("renewable:manage", kwargs={"slug": entity_name})
+    response = client.get(url)
+    assert response.status_code == HTTPStatus.FOUND
+    assert reverse("login") in response.url
+
+
+@pytest.mark.django_db
+def test_manage_views_without_slug_is_redirected(client):
+    """Test direct access to renewable:manage is redirected to index."""
+    user = UserFactory()
+    client.force_login(user)
+
+    response = client.get(reverse("renewable:manage"))
+    assert response.status_code == HTTPStatus.FOUND
+    assert response.url == reverse("renewable:index")
+
+
+@pytest.mark.django_db
+def test_manage_views_with_wrong_slug_raised_404(client):
+    """Test direct access to renewable:manage is redirected to index."""
+    user = UserFactory()
+    client.force_login(user)
+
+    entity_name = "entity-1"
+    wrong_slug = "wrong-slug"
+    EntityFactory(name=entity_name, users=[user])
+
+    url = reverse("renewable:manage", kwargs={"slug": wrong_slug})
+    response = client.get(url)
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_manage_views_rendered_without_data(client):
+    """Test manage view without data."""
+    user = UserFactory()
+    client.force_login(user)
+
+    entity_name = "entity-1"
+    EntityFactory(name=entity_name, users=[user])
+    url = reverse("renewable:manage", kwargs={"slug": entity_name})
+    response = client.get(url)
+    assert response.status_code == HTTPStatus.OK
+
+    # force template rendering
+    rendered = response.render()
+    html = rendered.content.decode()
+
+    expected_html_id = 'id="no-data-card"'
+    assert (expected_html_id in html) is True
+
+
+@pytest.mark.django_db
+def test_manage_views_rendered_with_data(client):
+    """Test manage view without data."""
+    user = UserFactory()
+    client.force_login(user)
+
+    # create entity and associated delivery points
+    assert DeliveryPoint.objects.all().count() == 0
+    entity_name = "entity-1"
+    entity = EntityFactory(name=entity_name, users=[user])
+    size = 4
+    dps = DeliveryPointFactory.create_batch(
+        size=size,
+        entity=entity,
+        has_renewable=True,
+        is_active=True,
+    )
+    assert DeliveryPoint.objects.all().count() == size
+
+    # render manage view
+    url = reverse("renewable:manage", kwargs={"slug": entity_name})
+    response = client.get(url)
+    assert response.status_code == HTTPStatus.OK
+
+    # force template rendering
+    rendered = response.render()
+    html = rendered.content.decode()
+
+    # test all delivery points are listed
+    assert all(str(dp.provider_assigned_id) in html for dp in dps)
+
+
+@pytest.mark.django_db
+def test_manage_views_get_context_data(rf, settings):
+    """Test get_context_data() method of RenewableMetterReadingFormView."""
+    expected_signature_location = "signature location"
+    settings.CONSENT_SIGNATURE_LOCATION = expected_signature_location
+    user = UserFactory()
+
+    # instantiate the view
+    view = RenewableMetterReadingFormView()
+
+    # create delivery points for entity
+    assert DeliveryPoint.objects.all().count() == 0
+    entity_name = "entity-1"
+    entity = EntityFactory(users=(user,), name=entity_name)
+    size = 4
+    DeliveryPointFactory.create_batch(
+        size=size,
+        entity=entity,
+        has_renewable=True,
+        is_active=True,
+    )
+    expected_renewable_dps = entity.get_unsubmitted_quarterly_renewables()
+    assert DeliveryPoint.objects.all().count() == size
+
+    # accessing the view and get context data
+    request = rf.get(reverse("renewable:manage"), kwargs={"slug": entity_name})
+    request.user = user
+    view.setup(request, slug=entity_name)
+    context = view.get_context_data()
+    assert context.get("entity") == entity
+    assert context.get("signature_location") == expected_signature_location
+    renewable_dps = context.get("renewable_delivery_points")
+    assert renewable_dps.count() == size
+    for renewable, expected_renewable in zip(
+        renewable_dps, expected_renewable_dps, strict=True
+    ):
+        assert renewable.id == expected_renewable.id

--- a/src/dashboard/apps/renewable/views.py
+++ b/src/dashboard/apps/renewable/views.py
@@ -1,9 +1,11 @@
 """Dashboard renewable meter app views."""
 
+from django.conf import settings
 from django.urls import reverse_lazy as reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 
+from apps.core.mixins import EntityMixin
 from apps.core.views import BaseView
 
 BREADCRUMB_CURRENT_LABEL = _("Renewable meter")
@@ -27,21 +29,26 @@ class IndexView(BaseView, TemplateView):
         return context
 
 
-class RenewableMetterReadingFormView(BaseView, TemplateView):
+class RenewableMetterReadingFormView(EntityMixin, BaseView, TemplateView):
     """Manage renewable meters."""
 
     template_name = "renewable/manage.html"
     success_url = reverse("renewable:index")
 
+    breadcrumb_current = _("Manage renewable meter reading")
     breadcrumb_links = [
         {"url": reverse("renewable:index"), "title": BREADCRUMB_CURRENT_LABEL},
     ]
-    breadcrumb_current = _("Manage renewable meter reading")
 
     def get_context_data(self, **kwargs):
-        """Add user's entities to the context."""
-        # todo : add logic
+        """Add custom attributes to the context."""
+        entity = self.get_entity()
+
         context = super().get_context_data(**kwargs)
-        context["entity"] = True
+        context["entity"] = entity
+        context["renewable_delivery_points"] = (
+            entity.get_unsubmitted_quarterly_renewables()
+        )
+        context["signature_location"] = settings.CONSENT_SIGNATURE_LOCATION
 
         return context


### PR DESCRIPTION
## Purpose

Update manage view to display delivery points with expected meter readings.

## Proposal

- [x] add EntityMixin for managing renewable meters and ensure proper context handling
- [x] add template logic to support renewable_delivery_points 
- [x] add a reusable "no data" html card
- [x] add deprecation warning in consent views
- [x] add tests for EntityMixin and renewable views