### PR TITLE
🚸(renewable) add `sort_by_station` filter and integrate it into template

### DIFF
--- a/src/dashboard/apps/core/templatetags/__init__.py
+++ b/src/dashboard/apps/core/templatetags/__init__.py
@@ -1,0 +1,1 @@
+"""Dashboard core app template tags."""

--- a/src/dashboard/apps/core/templatetags/dashboard_filters.py
+++ b/src/dashboard/apps/core/templatetags/dashboard_filters.py
@@ -1,0 +1,41 @@
+"""Dashboard core app template tags."""
+
+from typing import Any
+
+from django import template
+from django.db.models import QuerySet
+
+register = template.Library()
+
+
+@register.filter
+def sort_by_station(delivery_points: QuerySet) -> list[Any]:
+    """Sorts a queryset of delivery points by their associated station names.
+
+    This function returns a sorted list of dictionaries with this structured
+    data, ordered by the first station name in a case-insensitive manner.
+
+    Args:
+        delivery_points (QuerySet): A queryset of delivery points objects.
+
+    Returns:
+        list[Any]: A sorted list of dictionaries, each containing structured data about
+            the delivery point and its related stations.
+
+    """
+    structured_delivery_points = [
+        {
+            **dp.__dict__,
+            "stations_grouped": dp.get_linked_stations(),
+        }
+        for dp in delivery_points
+    ]
+
+    return sorted(
+        structured_delivery_points,
+        key=lambda x: (
+            list(x["stations_grouped"].keys())[0].casefold()
+            if x["stations_grouped"]
+            else ""
+        ),
+    )

--- a/src/dashboard/apps/core/tests/test_dashboard_filters.py
+++ b/src/dashboard/apps/core/tests/test_dashboard_filters.py
@@ -1,18 +1,19 @@
-"""Dashboard consent templatags tests."""
+"""Dashboard core mixins tests."""
 
 import pytest
 
-from apps.consent import AWAITING
-from apps.consent.templatetags.consent_filters import sort_by_station
 from apps.core.factories import DeliveryPointFactory, EntityFactory, StationFactory
+from apps.core.models import DeliveryPoint
+from apps.core.templatetags.dashboard_filters import sort_by_station
 
 
 @pytest.mark.django_db
 def test_sort_by_station():
     """Test `order_consents_by_station` function."""
     # test order_consents_by_station() without station
-    consents = []
-    results = sort_by_station(consents)
+    assert DeliveryPoint.objects.all().count() == 0
+    delivery_points = DeliveryPoint.objects.all()
+    results = sort_by_station(delivery_points)
     assert results == []
 
     # create entity, delivery points, consents and stations
@@ -41,28 +42,27 @@ def test_sort_by_station():
         delivery_point=dp_3, station_name="d", id_station_itinerance="FRGHIP01"
     )
 
-    consents = entity1.get_awaiting_consents()
-    results = sort_by_station(consents)
+    delivery_points = DeliveryPoint.objects.all()
+    results = sort_by_station(delivery_points)
 
     for result in results:
         # test retrieving the “standard” information from a consent
-        assert result["delivery_point_id"] in [dp_1.id, dp_2.id, dp_3.id]
+        assert result["id"] in [dp_1.id, dp_2.id, dp_3.id]
         assert result["provider_assigned_id"] is not None
-        assert result["status"] == AWAITING
 
-    # Extract provider_assigned_id, station_name and id_station_itinerance
-    # from grouped stations for comparison.
+    # Extract id, station_name and id_station_itinerance from grouped stations
+    # for comparison.
     delivery_point_stations = {
-        result["provider_assigned_id"]: result["stations_grouped"] for result in results
+        result["id"]: result["stations_grouped"] for result in results
     }
 
     assert delivery_point_stations == {
-        dp_2.provider_assigned_id: {
+        dp_2.id: {
             "A": ["FRDEFP03"],
             "C": ["FRDEFP05"],
             "p": ["FRDEFP04"],
             "y": ["FRDEFP02"],
         },
-        dp_1.provider_assigned_id: {"B": ["FRABCP01"]},
-        dp_3.provider_assigned_id: {"d": ["FRGHIP01"]},
+        dp_1.id: {"B": ["FRABCP01"]},
+        dp_3.id: {"d": ["FRGHIP01"]},
     }

--- a/src/dashboard/apps/renewable/templates/renewable/includes/_manage_meters.html
+++ b/src/dashboard/apps/renewable/templates/renewable/includes/_manage_meters.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n dashboard_filters %}
 
 {# todo: review the useful cols and data to display in the table #}
 {# todo: add real text content #}
@@ -44,11 +44,16 @@
             </thead>
 
             <tbody>
-              {% for renewable_dp in renewable_delivery_points %}
+              {% for renewable_dp in renewable_delivery_points|sort_by_station %}
               <tr id="table-prm-row-key-{{ forloop.counter }}"
                   data-row-key="{{ forloop.counter }}"
                   aria-labelledby="row-label-{{ forloop.counter }}">
-                <td> Station {{ forloop.counter }} (FRMIRP17359) </td>
+                <td>
+                  {% for station_name, ids in renewable_dp.stations_grouped.items %}
+                    {% if forloop.counter0 > 0 %}<br />{% endif %}
+                    {{ station_name }} {% if ids %}({{ ids|join:", " }}){% endif %}
+                  {% endfor %}
+                </td>
                 <td> {{ renewable_dp.provider_assigned_id }} </td>
                 <td>
                   {# todo: add templatetag to get actual period #}


### PR DESCRIPTION
## Purpose

We need a templatetag to sor delivery points by station.

## Proposal

- [x] add templatetags `sort_by_station`
- [x] integrate the `sort_by_station` templatetag into template
- [x] add tests
