### PR TITLE
✨(renewable) update logic to handle previous quarter data

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -67,6 +67,7 @@ jobs:
       DASHBOARD_QCC_API_LOGIN_USERNAME: admin
       DASHBOARD_QCC_API_LOGIN_PASSWORD: admin
       DASHBOARD_QCC_API_ROOT_URL: http://api:8000/api/v1
+      DASHBOARD_RENEWABLE_MIN_DAYS_FOR_METER_READING: 15
     steps:
       - uses: actions/checkout@v4
       - name: Install pipenv
@@ -153,3 +154,4 @@ jobs:
           DASHBOARD_QCC_API_LOGIN_USERNAME: admin
           DASHBOARD_QCC_API_LOGIN_PASSWORD: admin
           DASHBOARD_QCC_API_ROOT_URL: http://api:8000/api/v1
+          DASHBOARD_RENEWABLE_MIN_DAYS_FOR_METER_READING: 15

--- a/env.d/dashboard
+++ b/env.d/dashboard
@@ -44,6 +44,9 @@ DASHBOARD_CONTROL_AUTHORITY_EMAIL=jdoe@exemple.com
 
 DASHBOARD_CONSENT_SIGNATURE_LOCATION=Paris
 
+# Renewable app
+DASHBOARD_RENEWABLE_MIN_DAYS_FOR_METER_READING=15
+
 # Email to contact the QualiCharge team
 DASHBOARD_CONTACT_EMAIL=contact@exemple.com
 DASHBOARD_DEFAULT_FROM_EMAIL=no-reply@qualicharge.beta.gouv.fr

--- a/src/dashboard/apps/core/templatetags/dashboard_filters.py
+++ b/src/dashboard/apps/core/templatetags/dashboard_filters.py
@@ -39,20 +39,3 @@ def sort_by_station(delivery_points: QuerySet) -> list[Any]:
             else ""
         ),
     )
-
-
-@register.filter
-def get_item(dictionary: dict, key: str | int):
-    """Get an item from a dictionary.
-
-    Allows retrieving the value of a dictionary if its key is a variable.
-    """
-    if not dictionary:
-        return ""
-    return dictionary.get(key, "")
-
-
-@register.filter
-def concatenate(value: str, arg: str | int | float | bool) -> str:
-    """Concatenate two strings."""
-    return str(value) + str(arg)

--- a/src/dashboard/apps/core/templatetags/dashboard_filters.py
+++ b/src/dashboard/apps/core/templatetags/dashboard_filters.py
@@ -39,3 +39,20 @@ def sort_by_station(delivery_points: QuerySet) -> list[Any]:
             else ""
         ),
     )
+
+
+@register.filter
+def get_item(dictionary: dict, key: str | int):
+    """Get an item from a dictionary.
+
+    Allows retrieving the value of a dictionary if its key is a variable.
+    """
+    if not dictionary:
+        return ""
+    return dictionary.get(key, "")
+
+
+@register.filter
+def concatenate(value: str, arg: str | int | float | bool) -> str:
+    """Concatenate two strings."""
+    return str(value) + str(arg)

--- a/src/dashboard/apps/core/tests/test_models.py
+++ b/src/dashboard/apps/core/tests/test_models.py
@@ -621,19 +621,20 @@ def test_get_unsubmitted_quarterly_renewables(monkeypatch):
         INITIAL_SIZE, has_renewable=True, is_active=True, entity=entity_with_renewables
     )
 
-    # create renewables
+    # create renewables for all delivery points
     assert Renewable.objects.count() == 0
     RenewableFactory.create_batch(
         size=len(dps),
         delivery_point=factory.Iterator(dps),
         collected_at="2024-01-01",
     )
-    # create renewables for the current quarter
+    # create submitted renewable for the testing quarter (so, the previous from now)
     RenewableFactory(
         delivery_point=dps[0],
-        collected_at="2025-02-21",
+        collected_at="2024-12-21",
     )
-    assert Renewable.objects.count() == INITIAL_SIZE + 1
+    expected_size = 5
+    assert Renewable.objects.count() == expected_size
 
     # test entity without renewables
     renewable_dps = entity_without_renewables.get_unsubmitted_quarterly_renewables()
@@ -704,7 +705,7 @@ def test_count_unsubmitted_quarterly_renewables(monkeypatch):
         INITIAL_SIZE, has_renewable=True, is_active=True, entity=entity_with_renewables
     )
 
-    # create renewables
+    # create old renewables
     assert Renewable.objects.count() == 0
     RenewableFactory.create_batch(
         size=len(dps),
@@ -714,9 +715,10 @@ def test_count_unsubmitted_quarterly_renewables(monkeypatch):
     # create renewables for the current quarter
     RenewableFactory(
         delivery_point=dps[0],
-        collected_at="2025-02-21",
+        collected_at="2024-12-21",
     )
-    assert Renewable.objects.count() == INITIAL_SIZE + 1
+    expected_size = 5
+    assert Renewable.objects.count() == expected_size
 
     # test entity without renewables
     assert entity_without_renewables.count_unsubmitted_quarterly_renewables() == 0

--- a/src/dashboard/apps/core/tests/test_utils.py
+++ b/src/dashboard/apps/core/tests/test_utils.py
@@ -1,32 +1,69 @@
 """Dashboard core utils tests."""
 
-from datetime import datetime
+from datetime import date
 
 import pytest
 from django.utils import timezone as django_timezone
 
-from apps.core.utils import get_current_quarter_date_range
+from apps.core.utils import (
+    get_current_quarter_date_range,
+    get_previous_quarter_date_range,
+    get_quarter_date_range,
+)
 
 QUARTER_TEST_CASES = [
     (
-        datetime(2025, 1, 6),  # testing date
-        datetime(2025, 1, 1),  # expected start date
-        datetime(2025, 3, 31),  # expected end date
+        date(2025, 1, 6),  # testing date
+        date(2025, 1, 1),  # expected start date
+        date(2025, 3, 31),  # expected end date
     ),
-    (datetime(2025, 3, 6), datetime(2025, 1, 1), datetime(2025, 3, 31)),
-    (datetime(2025, 5, 6), datetime(2025, 4, 1), datetime(2025, 6, 30)),
-    (datetime(2025, 12, 6), datetime(2025, 10, 1), datetime(2025, 12, 31)),
+    (date(2025, 3, 6), date(2025, 1, 1), date(2025, 3, 31)),
+    (date(2025, 5, 6), date(2025, 4, 1), date(2025, 6, 30)),
+    (date(2025, 12, 6), date(2025, 10, 1), date(2025, 12, 31)),
 ]
+
+PREVIOUS_QUARTER_TEST_CASES = [
+    (
+        date(2025, 1, 6),  # testing date
+        date(2024, 10, 1),  # expected start date
+        date(2024, 12, 31),  # expected end dat
+    ),
+    (date(2025, 3, 6), date(2024, 10, 1), date(2024, 12, 31)),
+    (date(2025, 5, 6), date(2025, 1, 1), date(2025, 3, 31)),
+    (date(2025, 12, 6), date(2025, 7, 1), date(2025, 9, 30)),
+]
+
+
+@pytest.mark.parametrize("test_date,expected_start,expected_end", QUARTER_TEST_CASES)
+def test_get_quarter_date_range_start_and_end_dates(
+    monkeypatch, test_date, expected_start, expected_end
+):
+    """Test if range dates of the quarter are calculated correctly."""
+    start_date, end_date = get_quarter_date_range(test_date)
+    assert start_date == expected_start
+    assert end_date == expected_end
 
 
 @pytest.mark.parametrize("test_date,expected_start,expected_end", QUARTER_TEST_CASES)
 def test_get_current_quarter_date_range_start_and_end_dates(
     monkeypatch, test_date, expected_start, expected_end
 ):
-    """Test if the start and end dates of the quarter are calculated correctly."""
+    """Test if range dates of the quarter are calculated correctly."""
+    # test without date parameter
     monkeypatch.setattr(django_timezone, "now", lambda: test_date)
-
     start_date, end_date = get_current_quarter_date_range()
+    assert start_date == expected_start
+    assert end_date == expected_end
 
+
+@pytest.mark.parametrize(
+    "test_date,expected_start,expected_end", PREVIOUS_QUARTER_TEST_CASES
+)
+def test_get_previous_quarter_date_range_start_and_end_dates(
+    monkeypatch, test_date, expected_start, expected_end
+):
+    """Test if previous range dates of the previous quarter are calculated correctly."""
+    # test with date parameter
+    start_date, end_date = get_previous_quarter_date_range(test_date)
     assert start_date == expected_start
     assert end_date == expected_end

--- a/src/dashboard/apps/core/utils.py
+++ b/src/dashboard/apps/core/utils.py
@@ -1,11 +1,15 @@
 """Dashboard core utils."""
 
-import datetime
+from datetime import date
+from typing import Tuple
 
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 
 from apps.core.validators import validate_siret
+
+DateRange = Tuple[date, date]
+MONTHS_PER_QUARTER = 3
 
 
 def siret2siren(siret: str) -> str:
@@ -14,12 +18,20 @@ def siret2siren(siret: str) -> str:
     return siret[:9]
 
 
-def get_current_quarter_date_range() -> tuple[datetime.date, datetime.date]:
-    """Get the start and end day of the current quarter."""
-    now: datetime.date = timezone.now()
-
-    current_quarter = (now.month - 1) // 3
-    first_day: datetime.date = datetime.datetime(now.year, current_quarter * 3 + 1, 1)
-    last_day: datetime.date = first_day + relativedelta(months=3, days=-1)
+def get_quarter_date_range(reference_date: date) -> DateRange:
+    """Get the start and end day of a quarter for a given date."""
+    current_quarter = (reference_date.month - 1) // 3
+    first_day: date = date(reference_date.year, current_quarter * 3 + 1, 1)
+    last_day: date = first_day + relativedelta(months=3, days=-1)
 
     return first_day, last_day
+
+
+def get_current_quarter_date_range() -> DateRange:
+    """Get the start and end day of the current quarter."""
+    return get_quarter_date_range(timezone.now())
+
+
+def get_previous_quarter_date_range(reference_date: date) -> DateRange:
+    """Get the start and end day of the previous quarter of a given date."""
+    return get_quarter_date_range(reference_date - relativedelta(months=3))

--- a/src/dashboard/apps/renewable/tests/test_forms.py
+++ b/src/dashboard/apps/renewable/tests/test_forms.py
@@ -1,7 +1,7 @@
 """Dashboard renewable forms tests."""
 
 import datetime as dt
-from datetime import datetime
+from datetime import date, datetime, timedelta
 
 import pytest
 from django import forms
@@ -14,22 +14,88 @@ from apps.renewable.forms import RenewableForm, RenewableFormSet
 from apps.renewable.models import Renewable
 
 
+def test_get_authorized_date_range(monkeypatch, settings):
+    """Test _get_authorized_date_range()."""
+    settings.RENEWABLE_MIN_DAYS_FOR_METER_READING = 15
+    mock_now = date(2025, 3, 6)
+    monkeypatch.setattr(timezone, "now", lambda: mock_now)
+
+    min_date, end_date = RenewableForm._get_authorized_date_range()
+
+    # expected dates
+    expected_min_date = date(2024, 12, 16)
+    expected_end_date = date(2024, 12, 31)
+    assert min_date == expected_min_date
+    assert end_date == expected_end_date
+
+    # check min_date is before end_date
+    assert min_date < end_date
+
+    # check the gap between min_date and end_date
+    delta = end_date - min_date
+    assert delta.days == settings.RENEWABLE_MIN_DAYS_FOR_METER_READING
+
+
+@pytest.mark.parametrize(
+    "test_date,expected_quarter_end",
+    [
+        (date(2025, 2, 15), date(2024, 12, 31)),
+        (date(2025, 5, 15), date(2025, 3, 31)),
+        (date(2025, 8, 15), date(2025, 6, 30)),
+        (date(2025, 11, 15), date(2025, 9, 30)),
+    ],
+)
+def test_get_authorized_date_range_different_quarters(
+    test_date, expected_quarter_end, monkeypatch, settings
+):
+    """Test _get_authorized_date_range() with different quarters."""
+    monkeypatch.setattr(timezone, "now", lambda: test_date)
+
+    min_date, end_date = RenewableForm._get_authorized_date_range()
+
+    assert end_date == expected_quarter_end
+    assert min_date == end_date - timedelta(
+        days=settings.RENEWABLE_MIN_DAYS_FOR_METER_READING
+    )
+
+
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "collected_at, meter_reading, expected_message",
     [
         (None, 100.5, "Collected date is required if a meter reading is provided"),
-        ("2999-01-01", 100.5, "The date cannot be in the future"),
-        ("2000-01-01", 100.5, "The date cannot be earlier than 10 days"),
+        (
+            "2999-01-01",
+            100.5,
+            "The date cannot be in the future. <br />Collected date should be "
+            "between 16/03/2025 and 31/03/2025.",
+        ),
+        (
+            "2000-01-01",
+            100.5,
+            "The date cannot be earlier than 16/03/2025.<br />Collected date should"
+            " be between 16/03/2025 and 31/03/2025.",
+        ),
+        (
+            "2025-03-15",
+            100.5,
+            "The date cannot be earlier than 16/03/2025.<br />Collected date should"
+            " be between 16/03/2025 and 31/03/2025.",
+        ),
+        (
+            "2025-04-01",
+            100.5,
+            "The date cannot be in the future. <br />Collected date should be "
+            "between 16/03/2025 and 31/03/2025.",
+        ),
     ],
 )
-def test_renewable_form_clean_collected_at(
-    collected_at,
-    meter_reading,
-    expected_message,
-    patch_datetime_now,  # noqa: F811
+def test_renewable_form_clean_collected_at_with_errors(
+    collected_at, meter_reading, expected_message, monkeypatch
 ):
     """Test _clean_collected_at."""
+    now = datetime(2025, 5, 6, tzinfo=dt.timezone.utc)
+    monkeypatch.setattr(timezone, "now", lambda: now)
     form = RenewableForm()
 
     if collected_at:
@@ -38,16 +104,20 @@ def test_renewable_form_clean_collected_at(
     form.cleaned_data = {"collected_at": collected_at, "meter_reading": 100.5}
     with pytest.raises(forms.ValidationError) as e:
         form.clean_collected_at()
-        assert e.value.messages == [expected_message]
+    assert e.value.messages == [expected_message]
 
 
-def test_renewable_form_clean_collected_at_valid(patch_datetime_now):  # noqa: F811
+def test_renewable_form_clean_collected_at_valid(monkeypatch):
     """Test _clean_collected_at with valid data."""
-    form = RenewableForm()
-    expected_date = datetime.strptime("2025-01-03", "%Y-%m-%d").date()
-    form.cleaned_data = {"collected_at": expected_date, "meter_reading": 100.5}
+    now = datetime(2025, 5, 6, tzinfo=dt.timezone.utc)
+    monkeypatch.setattr(timezone, "now", lambda: now)
 
-    assert form.clean_collected_at() == expected_date
+    form = RenewableForm()
+    # collected date should be within x days prior to the previous quarter's end date
+    expected_collected_at = datetime(2025, 3, 28, tzinfo=dt.timezone.utc).date()
+    form.cleaned_data = {"collected_at": expected_collected_at, "meter_reading": 100.5}
+
+    assert form.clean_collected_at() == expected_collected_at
 
 
 def setup_formset_class():
@@ -76,16 +146,16 @@ def test_renewable_formset_clean_has_confirmed_information_accuracy():
     formset = FormsetClass(queryset=Renewable.objects.none(), data=post_data)
     with pytest.raises(forms.ValidationError) as exc_info:
         formset.clean_has_confirmed_information_accuracy()
-        expected_message = "You must confirm the accuracy of the information"
-        assert str(exc_info.value.messages[0]) == expected_message
+    expected_message = "You must confirm the accuracy of the information"
+    assert str(exc_info.value.messages[0]) == expected_message
 
     # has_confirmed_information_accuracy value is None
     post_data["has_confirmed_information_accuracy"] = None
     formset = FormsetClass(queryset=Renewable.objects.none(), data=post_data)
     with pytest.raises(forms.ValidationError) as exc_info:
         formset.clean_has_confirmed_information_accuracy()
-        expected_message = "You must confirm the accuracy of the information"
-        assert str(exc_info.value.messages[0]) == expected_message
+    expected_message = "You must confirm the accuracy of the information"
+    assert str(exc_info.value.messages[0]) == expected_message
 
     # has_confirmed_information_accuracy checkbox is checked
     post_data["has_confirmed_information_accuracy"] = "on"
@@ -111,6 +181,8 @@ def test_renewable_formset_saves_multiple_meter_readings(monkeypatch):
 
     expected_meter_reading_1 = 100.5
     expected_meter_reading_2 = 200.5
+    # collected date should be within x days prior to the previous quarter's end date
+    expected_collected_at = datetime(2025, 3, 28, tzinfo=dt.timezone.utc)
     expected_count = 2
 
     FormsetClass = setup_formset_class()
@@ -122,10 +194,10 @@ def test_renewable_formset_saves_multiple_meter_readings(monkeypatch):
             "form-MAX_NUM_FORMS": "1000",
             "form-0-delivery_point": dp1.id,
             "form-0-meter_reading": expected_meter_reading_1,
-            "form-0-collected_at": now,
+            "form-0-collected_at": expected_collected_at,
             "form-1-delivery_point": dp2.id,
             "form-1-meter_reading": expected_meter_reading_2,
-            "form-1-collected_at": now,
+            "form-1-collected_at": expected_collected_at,
             "has_confirmed_information_accuracy": "on",
         },
     )
@@ -150,6 +222,8 @@ def test_renewable_formset_save_partial_data_submission(monkeypatch):
     dp2 = DeliveryPointFactory(has_renewable=True, is_active=True)
 
     expected_meter_reading = 100.5
+    # collected date should be within x days prior to the previous quarter's end date
+    expected_collected_at = datetime(2025, 3, 28, tzinfo=dt.timezone.utc)
 
     FormsetClass = setup_formset_class()
     formset = FormsetClass(
@@ -160,7 +234,7 @@ def test_renewable_formset_save_partial_data_submission(monkeypatch):
             "form-MAX_NUM_FORMS": "1000",
             "form-0-delivery_point": dp1.id,
             "form-0-meter_reading": expected_meter_reading,
-            "form-0-collected_at": now,
+            "form-0-collected_at": expected_collected_at,
             "form-1-delivery_point": dp2.id,
             "has_confirmed_information_accuracy": "on",
             # form-1 is incomplete (no meter_reading or collected_at)
@@ -184,6 +258,8 @@ def test_renewable_formset_save_without_commit(monkeypatch):
 
     dp1 = DeliveryPointFactory(has_renewable=True, is_active=True)
     expected_meter_reading = 100.5
+    # collected date should be within x days prior to the previous quarter's end date
+    expected_collected_at = datetime(2025, 3, 28, tzinfo=dt.timezone.utc)
 
     FormsetClass = setup_formset_class()
     formset = FormsetClass(
@@ -194,7 +270,7 @@ def test_renewable_formset_save_without_commit(monkeypatch):
             "form-MAX_NUM_FORMS": "1000",
             "form-0-delivery_point": dp1.id,
             "form-0-meter_reading": expected_meter_reading,
-            "form-0-collected_at": now,
+            "form-0-collected_at": expected_collected_at,
             "has_confirmed_information_accuracy": "on",
         },
     )

--- a/src/dashboard/dashboard/settings.py
+++ b/src/dashboard/dashboard/settings.py
@@ -245,6 +245,13 @@ CONSENT_CONTROL_AUTHORITY = {
 CONSENT_SIGNATURE_LOCATION = env.str("CONSENT_SIGNATURE_LOCATION")
 
 
+## Renewable app
+
+# Defines the time window (in days) before the end of the previous quarter
+# during which meter readings are accepted.
+RENEWABLE_MIN_DAYS_FOR_METER_READING = env.int("RENEWABLE_MIN_DAYS_FOR_METER_READING")
+
+
 ## EMAIL
 
 # Email to contact the QualiCharge team


### PR DESCRIPTION
## Purpose

Add validation rule for user-submitted meter readings: entries must fall within a specific timeframe relative to the previous quarter.
Readings must be between [X] days before the previous quarter's end date and the previous quarter's end date.

## Proposal

- [x] add validation to ensure meter readings are within the allowed time window
- [x] add `get_previous_quarter_date_range` utility
- [x] Update functions, methods, and placeholders to retrieve and validate data from the previous quarter instead of the current quarter.
- [x] add tests 
