### PR TITLE
🚸(renewable) add template tag for quarter period display

### DIFF
--- a/src/dashboard/apps/core/tests/test_utils.py
+++ b/src/dashboard/apps/core/tests/test_utils.py
@@ -26,7 +26,7 @@ PREVIOUS_QUARTER_TEST_CASES = [
     (
         date(2025, 1, 6),  # testing date
         date(2024, 10, 1),  # expected start date
-        date(2024, 12, 31),  # expected end dat
+        date(2024, 12, 31),  # expected end date
     ),
     (date(2025, 3, 6), date(2024, 10, 1), date(2024, 12, 31)),
     (date(2025, 5, 6), date(2025, 1, 1), date(2025, 3, 31)),

--- a/src/dashboard/apps/core/utils.py
+++ b/src/dashboard/apps/core/utils.py
@@ -20,9 +20,9 @@ def siret2siren(siret: str) -> str:
 
 def get_quarter_date_range(reference_date: date) -> DateRange:
     """Get the start and end day of a quarter for a given date."""
-    current_quarter = (reference_date.month - 1) // 3
+    current_quarter = (reference_date.month - 1) // MONTHS_PER_QUARTER
     first_day: date = date(reference_date.year, current_quarter * 3 + 1, 1)
-    last_day: date = first_day + relativedelta(months=3, days=-1)
+    last_day: date = first_day + relativedelta(months=MONTHS_PER_QUARTER, days=-1)
 
     return first_day, last_day
 
@@ -35,3 +35,21 @@ def get_current_quarter_date_range() -> DateRange:
 def get_previous_quarter_date_range(reference_date: date) -> DateRange:
     """Get the start and end day of the previous quarter of a given date."""
     return get_quarter_date_range(reference_date - relativedelta(months=3))
+
+
+def get_quarter_number(reference_date: date) -> int:
+    """Determines the quarter number for a given date.
+
+    Args:
+        reference_date: The date for which to calculate the quarter.
+              If None, uses the current date.
+
+    Returns:
+        int: The quarter number (1-4).
+              Q1: January-March
+              Q2: April-June
+              Q3: July-September
+              Q4: October-December
+    """
+    first_day, _ = get_quarter_date_range(reference_date)
+    return (first_day.month - 1) // MONTHS_PER_QUARTER + 1

--- a/src/dashboard/apps/renewable/templates/renewable/includes/_manage_meters.html
+++ b/src/dashboard/apps/renewable/templates/renewable/includes/_manage_meters.html
@@ -1,4 +1,4 @@
-{% load i18n dashboard_filters %}
+{% load i18n dashboard_filters renewable_tags %}
 
 {# todo: review the useful cols and data to display in the table #}
 {# todo: add real text content #}
@@ -63,10 +63,8 @@
                 </td>
 
                 <td>
-                  {# todo: add templatetag to get actual period #}
-                  -
-                  {# 1er trimestre 2025<br />#}
-                  {# du 01/01/2025 au 31/03/2025#}
+                  {% previous_quarter_period %}<br />
+                  {% previous_quarter_period_dates %}
                 </td>
 
                 <td>

--- a/src/dashboard/apps/renewable/templatetags/__init__.py
+++ b/src/dashboard/apps/renewable/templatetags/__init__.py
@@ -1,0 +1,1 @@
+"""Dashboard renewable app template tags."""

--- a/src/dashboard/apps/renewable/templatetags/renewable_tags.py
+++ b/src/dashboard/apps/renewable/templatetags/renewable_tags.py
@@ -1,0 +1,64 @@
+"""Dashboard renewable app template tags."""
+
+from datetime import date
+
+from django import template
+from django.utils import timezone
+from django.utils.translation import gettext as _
+
+from apps.core.utils import (
+    get_previous_quarter_date_range,
+    get_quarter_date_range,
+    get_quarter_number,
+)
+
+register = template.Library()
+
+
+def _get_reference_date(reference_date: date | None) -> date:
+    """Return the reference date or today if None."""
+    return reference_date or timezone.now()
+
+
+def _format_quarter_period(start_date: date) -> str:
+    """Format quarter period string."""
+    quarter = get_quarter_number(start_date)
+    return _(f"Q{quarter} {start_date.strftime('%Y')}")
+
+
+def _format_date_range(start_date: date, end_date: date) -> str:
+    """Format date range string."""
+    return _(f"{start_date.strftime('%d/%m/%Y')} to {end_date.strftime('%d/%m/%Y')}")
+
+
+@register.simple_tag
+def previous_quarter_period(reference_date: date | None = None) -> str:
+    """Return formatted string for previous quarter period.
+
+    For example, when reference_date is in Q2 2024, returns Q1 2024.
+    """
+    start_date, _ = get_previous_quarter_date_range(_get_reference_date(reference_date))
+    return f"{_format_quarter_period(start_date)}"
+
+
+@register.simple_tag
+def quarter_period(reference_date: date | None = None) -> str:
+    """Return formatted string for current quarter period."""
+    start_date, _ = get_quarter_date_range(_get_reference_date(reference_date))
+    return f"{_format_quarter_period(start_date)}"
+
+
+@register.simple_tag
+def previous_quarter_period_dates(reference_date: date | None = None):
+    """Return formatted date range string for previous quarter."""
+    start_date, end_date = get_previous_quarter_date_range(
+        _get_reference_date(reference_date)
+    )
+    return _format_date_range(start_date, end_date)
+
+
+@register.simple_tag
+def quarter_period_dates(reference_date: date | None = None):
+    """Return formatted date range string for current quarter."""
+    start_date, end_date = get_quarter_date_range(_get_reference_date(reference_date))
+    return _(_format_date_range(start_date, end_date))

--- a/src/dashboard/apps/renewable/tests/test_renewable_tags.py
+++ b/src/dashboard/apps/renewable/tests/test_renewable_tags.py
@@ -1,0 +1,112 @@
+"""Dashboard renewable_tags tests."""
+
+from datetime import date
+
+import pytest
+from django.utils import timezone
+
+from apps.renewable.templatetags.renewable_tags import (
+    _get_reference_date,
+    previous_quarter_period,
+    previous_quarter_period_dates,
+    quarter_period,
+    quarter_period_dates,
+)
+
+
+def test_get_reference_date_with_valid_date(monkeypatch):
+    """Test _get_reference_date."""
+    # with a valid reference date
+    reference_date = date(2025, 1, 1)
+    result = _get_reference_date(reference_date)
+    assert result == reference_date
+
+    # when given a None value
+    expected_date = date(2025, 5, 6)
+    monkeypatch.setattr(timezone, "now", lambda: expected_date)
+    result = _get_reference_date(None)
+    assert result == expected_date
+
+
+@pytest.mark.parametrize(
+    "reference_date, expected_period",
+    [
+        (date(2025, 4, 1), "Q1 2025"),
+        (date(2025, 1, 1), "Q4 2024"),
+        (date(2025, 7, 15), "Q2 2025"),
+    ],
+)
+def test_previous_quarter_period(reference_date, expected_period):
+    """Test previous_quarter_period for various cases of reference_date."""
+    result = previous_quarter_period(reference_date)
+    assert result == expected_period
+
+
+def test_previous_quarter_period_without_reference_date(monkeypatch):
+    """Test previous_quarter_period without reference_date."""
+    monkeypatch.setattr(timezone, "now", lambda: date(2025, 5, 6))
+    result = previous_quarter_period()
+    assert result == "Q1 2025"
+
+
+@pytest.mark.parametrize(
+    "reference_date, expected_period",
+    [
+        (date(2025, 4, 1), "Q2 2025"),
+        (date(2025, 1, 1), "Q1 2025"),
+        (date(2025, 7, 15), "Q3 2025"),
+    ],
+)
+def test_quarter_period(reference_date, expected_period):
+    """Test previous_quarter_period for various cases of reference_date."""
+    result = quarter_period(reference_date)
+    assert result == expected_period
+
+
+def test_quarter_period_without_reference_date(monkeypatch):
+    """Test previous_quarter_period without reference_date."""
+    monkeypatch.setattr(timezone, "now", lambda: date(2025, 5, 6))
+    result = quarter_period()
+    assert result == "Q2 2025"
+
+
+@pytest.mark.parametrize(
+    "reference_date, expected_period",
+    [
+        (date(2025, 4, 1), "01/01/2025 to 31/03/2025"),
+        (date(2025, 1, 1), "01/10/2024 to 31/12/2024"),
+        (date(2025, 7, 15), "01/04/2025 to 30/06/2025"),
+    ],
+)
+def test_previous_quarter_period_dates(reference_date, expected_period):
+    """Test previous_quarter_period for various cases of reference_date."""
+    result = previous_quarter_period_dates(reference_date)
+    assert result == expected_period
+
+
+def test_previous_quarter_period_dates_period_without_reference_date(monkeypatch):
+    """Test previous_quarter_period without reference_date."""
+    monkeypatch.setattr(timezone, "now", lambda: date(2025, 5, 6))
+    result = previous_quarter_period_dates()
+    assert result == "01/01/2025 to 31/03/2025"
+
+
+@pytest.mark.parametrize(
+    "reference_date, expected_period",
+    [
+        (date(2025, 4, 1), "01/04/2025 to 30/06/2025"),
+        (date(2025, 1, 1), "01/01/2025 to 31/03/2025"),
+        (date(2025, 7, 15), "01/07/2025 to 30/09/2025"),
+    ],
+)
+def test_quarter_period_dates(reference_date, expected_period):
+    """Test previous_quarter_period for various cases of reference_date."""
+    result = quarter_period_dates(reference_date)
+    assert result == expected_period
+
+
+def test_quarter_period_dates_period_without_reference_date(monkeypatch):
+    """Test previous_quarter_period without reference_date."""
+    monkeypatch.setattr(timezone, "now", lambda: date(2025, 5, 6))
+    result = quarter_period_dates()
+    assert result == "01/04/2025 to 30/06/2025"


### PR DESCRIPTION
## Purpose

we need to display the quarterly period information in the energy statement management form to help users track and validate statements based on the corresponding quarter.

## Proposal

- [x] add a template tag to display the quarter-period information
- [x] add corresponding tests to validate outputs
- [x] add the tag into the `_manage_meters.html` template.
- [x] add utility functions to support dynamic quarter calculations.