### PR TITLE
🐛(prefect) correct variance historicization error

### DIFF
--- a/src/prefect/indicators/utils.py
+++ b/src/prefect/indicators/utils.py
@@ -110,6 +110,7 @@ def get_targets_for_level(level: Level, environment: Environment) -> pd.DataFram
         return pd.read_sql_table(level.name.lower(), con=session.connection())
 
 
+@task(task_run_name="export-indicators")
 def export_indicators(  # noqa: PLR0913
     indicators: pd.DataFrame,
     environment: Environment,


### PR DESCRIPTION
## Purpose

Historicization fails when Standard deviation is `nan`.

## Analysis

Standard deviation is `nan` when Variance is negative (reason : data variations are small and precision errors appear).

## Proposal

- [x] Add a threshold to 0 to avoid Variance with negative value  
- [x] Add Prefect tasks to improve historicization performance tracking