### PR TITLE
🐛(prefect) fix offline workers cleanup script

### DIFF
--- a/src/prefect/clean-offline-workers.sh
+++ b/src/prefect/clean-offline-workers.sh
@@ -11,12 +11,13 @@ workers=$(curl -s \
   "${PREFECT_API_URL}work_pools/${work_pool}/workers/filter" \
   --header "Content-Type: application/json"  \
   --data '{"workers": {"status": {"any_": ["OFFLINE"]}}}' |\
-  jq -r .[].id)
+  jq -r .[].name |\
+  sed "s/ /%20/g")
 
 # Delete offline workers
 for worker in ${workers}; do
   echo "Deleting worker ${worker}…"
   curl -s \
     -X DELETE \
-    "${PREFECT_API_URL}work_pools/${work_pool}/workers/ProcessWorker%20${worker}"
+    "${PREFECT_API_URL}work_pools/${work_pool}/workers/${worker}"
 done


### PR DESCRIPTION
## Purpose

The `clean-offline-workers.sh` cronjob does nothing. Old offline workers are never deleted.

## Proposal

Worker id and the UUID in its name are different, we should use its full name in the API.
