### PR TITLE
🚸(dashboard) add submitted renewables view with sorting

### DIFF
--- a/src/dashboard/apps/renewable/templates/renewable/includes/_manage_meters.html
+++ b/src/dashboard/apps/renewable/templates/renewable/includes/_manage_meters.html
@@ -29,7 +29,7 @@
                   <div class="fr-cell__title">Identifiant du PDL</div>
                 </th>
                 <th scope="col">
-                  <div class="fr-cell__title">Période d'autorisation</div>
+                  <div class="fr-cell__title">Période</div>
                 </th>
                 <th scope="col">
                   <div class="fr-cell__title">Relevé précédent (kWh)</div>

--- a/src/dashboard/apps/renewable/templates/renewable/includes/_summary_submitted_card_content.html
+++ b/src/dashboard/apps/renewable/templates/renewable/includes/_summary_submitted_card_content.html
@@ -37,7 +37,7 @@
                     </td>
                     <td class="fr-cell--center">
                         <a class="fr-link fr-icon-arrow-right-line fr-link--icon-right"
-                           href=""
+                           href="{% url "renewable:submitted" entity.slug %}"
                            data-fr-js-link-actionee="true">
                           Consulter la liste
                         </a>

--- a/src/dashboard/apps/renewable/templates/renewable/submitted.html
+++ b/src/dashboard/apps/renewable/templates/renewable/submitted.html
@@ -1,0 +1,77 @@
+{% extends "renewable/base.html" %}
+
+{% load dsfr_tags %}
+
+{% load i18n static dashboard_filters renewable_tags %}
+
+{% block dashboard_content %}
+  <h2>Relevés de production transmis</h2>
+
+  <p>
+    Retrouver ici la liste des relevés de production que vous avez transmis.
+  </p>
+
+  {% if renewables %}
+    <div class="fr-table fr-table--no-caption" id="table-pdl-component">
+      <div class="fr-table__wrapper">
+        <div class="fr-table__container">
+          <div class="fr-table__content">
+
+            <table id="table-pdl" aria-labelledby="table-pdl-caption">
+              <caption id="table-pdl-caption">Relevés de production transmis</caption>
+
+              <thead>
+                <tr>
+                  <th scope="col">
+                    <div class="fr-cell__title">Nom / Identifiant de la station</div>
+                  </th>
+                  <th scope="col">
+                    <div class="fr-cell__title">Identifiant du PDL</div>
+                  </th>
+                  <th scope="col">
+                    <div class="fr-cell__title">Période</div>
+                  </th>
+                  <th scope="col">
+                    <div class="fr-cell__title">Date du relevé</div>
+                  </th>
+                  <th scope="col">
+                    <div class="fr-cell__title">Relevé de production (kWh)</div>
+                  </th>
+                </tr>
+              </thead>
+
+              <tbody>
+                {% for renewable_dp in renewables %}
+                <tr id="table-pdl-row-key-{{ forloop.counter }}"
+                    data-row-key="{{ forloop.counter }}"
+                    aria-labelledby="row-label-{{ forloop.counter }}">
+                  <td>
+                    {% for station_name, ids in renewable_dp.stations_grouped.items %}
+                      {% if forloop.counter0 > 0 %}<br />{% endif %}
+                      {{ station_name }} {% if ids %}({{ ids|join:", " }}){% endif %}
+                    {% endfor %}
+                  </td>
+                  <td> {{ renewable_dp.provider_assigned_id }} </td>
+                  <td>
+                    {% quarter_period renewable_dp.collected_at %}<br />
+                    {% quarter_period_dates renewable_dp.collected_at %}
+                  </td>
+                  <td> {{ renewable_dp.collected_at|date:"d/m/Y" }} </td>
+                  <td> {{ renewable_dp.meter_reading }}</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+
+          </div>
+        </div>
+      </div>
+    </div>
+
+    {% dsfr_pagination page_obj %}
+
+  {% else %}
+    {% include "consent/includes/_no_data_card.html" with description="Aucun relevé de production transmis." %}
+  {% endif %}
+
+{% endblock dashboard_content %}

--- a/src/dashboard/apps/renewable/urls.py
+++ b/src/dashboard/apps/renewable/urls.py
@@ -6,6 +6,7 @@ from django.views.generic.base import RedirectView
 from .views import (
     IndexView,
     RenewableMetterReadingFormView,
+    SubmittedRenewableView,
 )
 
 app_name = "renewable"
@@ -19,4 +20,5 @@ urlpatterns = [
         RedirectView.as_view(pattern_name="renewable:index", permanent=False),
         name="manage",
     ),
+    path("submitted/<slug:slug>", SubmittedRenewableView.as_view(), name="submitted"),
 ]

--- a/src/dashboard/apps/renewable/views.py
+++ b/src/dashboard/apps/renewable/views.py
@@ -1,5 +1,7 @@
 """Dashboard renewable meter app views."""
 
+from typing import Any
+
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import ValidationError
@@ -7,10 +9,11 @@ from django.db.models import QuerySet
 from django.forms import modelformset_factory
 from django.urls import reverse_lazy as reverse
 from django.utils.translation import gettext_lazy as _
-from django.views.generic import FormView, TemplateView
+from django.views.generic import FormView, ListView, TemplateView
 
 from apps.core.mixins import EntityViewMixin
 from apps.core.models import Entity
+from apps.core.utils import get_quarter_number
 from apps.core.views import BaseView
 from apps.renewable.forms import RenewableForm, RenewableFormSet
 from apps.renewable.models import Renewable
@@ -142,3 +145,56 @@ class RenewableMetterReadingFormView(EntityViewMixin, BaseView, FormView):
         """Handle invalid formset."""
         formset.non_form_errors().append(_("The form contains errors."))
         return self.render_to_response(self.get_context_data(formset=formset))
+
+
+class SubmittedRenewableView(EntityViewMixin, BaseView, ListView):
+    """Submitted renewable view."""
+
+    context_object_name = "renewables"
+    template_name = "renewable/submitted.html"
+
+    breadcrumb_current = _("Submitted renewable meter reading")
+    breadcrumb_links = [
+        {"url": reverse("renewable:index"), "title": BREADCRUMB_CURRENT_LABEL},
+    ]
+
+    def get_queryset(self):
+        """Filter queryset to only return submitted renewables for the current user."""
+        return self._order_by_quarter_stations(self.get_entity().get_renewables())
+
+    @staticmethod
+    def _order_by_quarter_stations(renewables: QuerySet) -> list[Any]:
+        """Sort and group stations alphabetically by name and by revert quarter.
+
+        Returns a sorted list of dictionaries with this structured
+        data, ordered by reversed quarter period date and by the first station name in a
+        case-insensitive manner.
+
+        Args:
+            renewables (QuerySet): A queryset of renewables objects.
+
+        Returns:
+            list[Any]: A sorted list of dictionaries, each containing structured data
+            about the renewable and its delivery point and stations.
+        """
+        structured_renewables = [
+            {
+                **renewable.__dict__,
+                "provider_assigned_id": renewable.delivery_point.provider_assigned_id,
+                "stations_grouped": renewable.delivery_point.get_linked_stations(),
+            }
+            for renewable in renewables
+        ]
+
+        return sorted(
+            structured_renewables,
+            key=lambda x: (
+                -x["collected_at"].year,  # reverse year
+                -get_quarter_number(x["collected_at"]),  # reverse quarter
+                (
+                    list(x["stations_grouped"].keys())[0].casefold()
+                    if x["stations_grouped"]
+                    else ""
+                ),
+            ),
+        )


### PR DESCRIPTION
## Purpose

We need a page that displays all submitted energy meter readings. 
The listing should be ordered by:
- Submission date (most recent first)
- Station names (alphabetically)

## Proposal

- [x] add a view with supporting logic for listing sorted submitted renewable meter readings. 
- [x] add template to display submitted renewables
- [x] update URLs
- [x] add tests