### PR TITLE
Improve `Statique` model string fields quality

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Changed
 
+- `Statique` model string fields are now stripped
+
 #### Dependencies
 
 - Upgrade `psycopg` to `3.2.7`

--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Changed
 
 - `Statique` model string fields are now stripped
+- `Statique.restriction_gabarit` field should be at least 2 characters long
 
 #### Dependencies
 

--- a/src/api/qualicharge/models/static.py
+++ b/src/api/qualicharge/models/static.py
@@ -216,7 +216,7 @@ class Statique(ModelSchemaMixin, BaseModel):
     ]
     accessibilite_pmr: AccessibilitePMREnum
     restriction_gabarit: Annotated[
-        str, StringConstraints(strip_whitespace=True)
+        str, StringConstraints(min_length=2, strip_whitespace=True)
     ]
     station_deux_roues: bool
     raccordement: Optional[RaccordementEnum] = None

--- a/src/api/qualicharge/models/static.py
+++ b/src/api/qualicharge/models/static.py
@@ -15,6 +15,7 @@ from pydantic import (
     PlainSerializer,
     PositiveFloat,
     PositiveInt,
+    StringConstraints,
     WithJsonSchema,
     model_validator,
 )
@@ -130,41 +131,67 @@ DEFAULT_SIREN_NUMBER: str = "123456789"
 class Statique(ModelSchemaMixin, BaseModel):
     """IRVE static model."""
 
-    nom_amenageur: Optional[str] = DEFAULT_CHAR_VALUE
+    nom_amenageur: Optional[
+        Annotated[str, StringConstraints(strip_whitespace=True)]
+    ] = DEFAULT_CHAR_VALUE
     siren_amenageur: Optional[
         Annotated[
             str,
-            Field(
+            StringConstraints(
                 pattern=r"^\d{9}$",
+            ),
+            Field(
                 examples=[
                     "853300010",
-                ],
+                ]
             ),
         ]
     ] = DEFAULT_SIREN_NUMBER
-    contact_amenageur: Optional[EmailStr] = DEFAULT_EMAIL_ADDRESS
-    nom_operateur: Optional[str] = DEFAULT_CHAR_VALUE
-    contact_operateur: EmailStr
-    telephone_operateur: Optional[FrenchPhoneNumber] = DEFAULT_PHONE_NUMBER
-    nom_enseigne: str
+    contact_amenageur: Optional[
+        Annotated[EmailStr, StringConstraints(strip_whitespace=True)]
+    ] = DEFAULT_EMAIL_ADDRESS
+    nom_operateur: Optional[
+        Annotated[str, StringConstraints(strip_whitespace=True)]
+    ] = DEFAULT_CHAR_VALUE
+    contact_operateur: Annotated[EmailStr, StringConstraints(strip_whitespace=True)]
+    telephone_operateur: Optional[
+        Annotated[FrenchPhoneNumber, StringConstraints(strip_whitespace=True)]
+    ] = DEFAULT_PHONE_NUMBER
+    nom_enseigne: Annotated[str, StringConstraints(strip_whitespace=True)]
     id_station_itinerance: Annotated[
-        str, Field(pattern="(?:(?:^|,)(^[A-Z]{2}[A-Z0-9]{4,33}$|Non concerné))+$")
+        str,
+        StringConstraints(
+            pattern="(?:(?:^|,)(^[A-Z]{2}[A-Z0-9]{4,33}$|Non concerné))+$",
+            strip_whitespace=True,
+        ),
     ]
-    id_station_local: Optional[str] = None
-    nom_station: str
+    id_station_local: Optional[
+        Annotated[str, StringConstraints(strip_whitespace=True)]
+    ] = None
+    nom_station: Annotated[str, StringConstraints(strip_whitespace=True)]
     implantation_station: ImplantationStationEnum
-    adresse_station: str
-    code_insee_commune: Annotated[str, Field(pattern=r"^([013-9]\d|2[AB1-9])\d{3}$")]
+    adresse_station: Annotated[str, StringConstraints(strip_whitespace=True)]
+    code_insee_commune: Annotated[
+        str,
+        StringConstraints(
+            pattern=r"^([013-9]\d|2[AB1-9])\d{3}$", strip_whitespace=True
+        ),
+    ]
     coordonneesXY: DataGouvCoordinate
     nbre_pdc: PositiveInt
     id_pdc_itinerance: Annotated[
         str,
-        Field(
+        StringConstraints(
             pattern="(?:(?:^|,)(^[A-Z]{2}[A-Z0-9]{4,33}$|Non concerné))+$",
+            strip_whitespace=True,
+        ),
+        Field(
             examples=["FR0NXEVSEXB9YG", "FRFASE3300405", "FR073012308585"],
         ),
     ]
-    id_pdc_local: Optional[str] = None
+    id_pdc_local: Optional[Annotated[str, StringConstraints(strip_whitespace=True)]] = (
+        None
+    )
     puissance_nominale: PositiveFloat
     prise_type_ef: bool
     prise_type_2: bool
@@ -175,19 +202,31 @@ class Statique(ModelSchemaMixin, BaseModel):
     paiement_acte: bool
     paiement_cb: Optional[bool] = None
     paiement_autre: Optional[bool] = None
-    tarification: Optional[str] = None
+    tarification: Optional[Annotated[str, StringConstraints(strip_whitespace=True)]] = (
+        None
+    )
     condition_acces: ConditionAccesEnum
     reservation: bool
     horaires: Annotated[
-        str, Field(pattern=r"(.*?)((\d{1,2}:\d{2})-(\d{1,2}:\d{2})|24/7)")
+        str,
+        StringConstraints(
+            pattern=r"(.*?)((\d{1,2}:\d{2})-(\d{1,2}:\d{2})|24/7)",
+            strip_whitespace=True,
+        ),
     ]
     accessibilite_pmr: AccessibilitePMREnum
-    restriction_gabarit: str
+    restriction_gabarit: Annotated[
+        str, StringConstraints(strip_whitespace=True)
+    ]
     station_deux_roues: bool
     raccordement: Optional[RaccordementEnum] = None
-    num_pdl: Optional[Annotated[str, Field(max_length=64)]]
+    num_pdl: Optional[
+        Annotated[str, StringConstraints(strip_whitespace=True, max_length=64)]
+    ]
     date_mise_en_service: Optional[NotFutureDate] = None
-    observations: Optional[str] = None
+    observations: Optional[Annotated[str, StringConstraints(strip_whitespace=True)]] = (
+        None
+    )
     date_maj: NotFutureDate
     cable_t2_attache: Optional[bool] = None
 

--- a/src/api/tests/models/test_static.py
+++ b/src/api/tests/models/test_static.py
@@ -140,6 +140,68 @@ def test_statique_model_date_mise_en_service():
         StatiqueFactory.build(date_mise_en_service=tomorrow)
 
 
+def test_statique_model_str_fields_strip():
+    """Test the Statique model string fields stripping."""
+    nom_amenageur = " Foo Inc.  "
+    contact_amenageur = " contact@foo.org "
+    nom_operateur = " Bar Inc."
+    contact_operateur = "contact@bar.org  "
+    telephone_operateur = " tel:+33-1-44-27-63-50  "
+    nom_enseigne = " Big Company"
+    id_station_itinerance = "FR073P00001  "
+    id_station_local = " id-01  "
+    nom_station = " Station 01  "
+    adresse_station = " 1 baker street 75000 PARIS "
+    code_insee_commune = "74264 "
+    id_pdc_itinerance = "FR073E0042  "
+    id_pdc_local = " pdc-01 "
+    tarification = " It's Free!  "
+    horaires = " Open 24/7  "
+    restriction_gabarit = " None (for now)  "
+    num_pdl = " 12345678901213  "
+    observations = " None (for now)  "
+
+    statique = StatiqueFactory.build(
+        nom_amenageur=nom_amenageur,
+        contact_amenageur=contact_amenageur,
+        nom_operateur=nom_operateur,
+        contact_operateur=contact_operateur,
+        telephone_operateur=telephone_operateur,
+        nom_enseigne=nom_enseigne,
+        id_station_itinerance=id_station_itinerance,
+        id_station_local=id_station_local,
+        nom_station=nom_station,
+        adresse_station=adresse_station,
+        code_insee_commune=code_insee_commune,
+        id_pdc_itinerance=id_pdc_itinerance,
+        id_pdc_local=id_pdc_local,
+        tarification=tarification,
+        horaires=horaires,
+        restriction_gabarit=restriction_gabarit,
+        num_pdl=num_pdl,
+        observations=observations,
+    )
+
+    assert statique.nom_amenageur == nom_amenageur.strip()
+    assert statique.contact_amenageur == contact_amenageur.strip()
+    assert statique.nom_operateur == nom_operateur.strip()
+    assert statique.contact_operateur == contact_operateur.strip()
+    assert statique.telephone_operateur == telephone_operateur.strip()
+    assert statique.nom_enseigne == nom_enseigne.strip()
+    assert statique.id_station_itinerance == id_station_itinerance.strip()
+    assert statique.id_station_local == id_station_local.strip()
+    assert statique.nom_station == nom_station.strip()
+    assert statique.adresse_station == adresse_station.strip()
+    assert statique.code_insee_commune == code_insee_commune.strip()
+    assert statique.id_pdc_itinerance == id_pdc_itinerance.strip()
+    assert statique.id_pdc_local == id_pdc_local.strip()
+    assert statique.tarification == tarification.strip()
+    assert statique.horaires == horaires.strip()
+    assert statique.restriction_gabarit == restriction_gabarit.strip()
+    assert statique.num_pdl == num_pdl.strip()
+    assert statique.observations == observations.strip()
+
+
 def test_statique_model_defaults():
     """Test the Statique model defaut values (when not provided)."""
     example = StatiqueFactory.build()

--- a/src/api/tests/models/test_static.py
+++ b/src/api/tests/models/test_static.py
@@ -140,6 +140,18 @@ def test_statique_model_date_mise_en_service():
         StatiqueFactory.build(date_mise_en_service=tomorrow)
 
 
+def test_statique_model_restriction_gabarit_len():
+    """Test the Statique model `restriction_gabarit` field length."""
+    statique = StatiqueFactory.build(restriction_gabarit="Aucune")
+    assert statique.restriction_gabarit == "Aucune"
+
+    for value in ["", " ", "  ", "N"]:
+        with pytest.raises(
+            ValueError, match="String should have at least 2 characters"
+        ):
+            StatiqueFactory.build(restriction_gabarit=value)
+
+
 def test_statique_model_str_fields_strip():
     """Test the Statique model string fields stripping."""
     nom_amenageur = " Foo Inc.  "


### PR DESCRIPTION
## Purpose

While publishing our static open dataset, we noticed poor quality data in `restriction_gabarit` field and potential issues with unstripped strings.

## Proposal

- [x] strip `Statique` model string fields
- [x] set `Statique.restriction_gabarit` field minimal length
