### PR TITLE
🧪(api) test `horaires` statique field values

### DIFF
--- a/src/api/qualicharge/models/static.py
+++ b/src/api/qualicharge/models/static.py
@@ -210,7 +210,8 @@ class Statique(ModelSchemaMixin, BaseModel):
     horaires: Annotated[
         str,
         StringConstraints(
-            pattern=r"(.*?)((\d{1,2}:\d{2})-(\d{1,2}:\d{2})|24/7)",
+            # pattern=r"(.*?)((\d{1,2}:\d{2})-(\d{1,2}:\d{2})|24/7)",
+            pattern="(.*?)((\\d{1,2}:\\d{2})-(\\d{1,2}:\\d{2})|24/7)",
             strip_whitespace=True,
         ),
     ]

--- a/src/api/tests/models/test_static.py
+++ b/src/api/tests/models/test_static.py
@@ -214,6 +214,27 @@ def test_statique_model_str_fields_strip():
     assert statique.observations == observations.strip()
 
 
+def test_statique_model_horaires():
+    """Test the Statique model horaires field."""
+    statique = StatiqueFactory.build(horaires="24/7")
+    assert statique.horaires == "24/7"
+
+    for value in [
+        (
+            "Su 07:00:00-20:59:00, "
+            "Sa 07:00:00-20:59:00, "
+            "Fr 07:00:00-20:59:00, "
+            "Th 07:00:00-20:59:00, "
+            "We 07:00:00-20:59:00, "
+            "Tu 07:00:00-20:59:00, "
+            "Mo 07:00:00-20:59:00"
+        ),
+        "08:30-20:30",
+    ]:
+        with pytest.raises(ValueError, match="String should match pattern"):
+            StatiqueFactory.build(horaires=value)
+
+
 def test_statique_model_defaults():
     """Test the Statique model defaut values (when not provided)."""
     example = StatiqueFactory.build()


### PR DESCRIPTION
## Purpose

Validata reports errors in our statique dataset concerning the `horaires` field. It expects values to match the following pattern:

```regex
(.*?)((\d{1,2}:\d{2})-(\d{1,2}:\d{2})|24/7)
```

Problematic value is:

```
Sa 08:00:00-19:00:00, Fr 08:00:00-19:00:00, Th 08:00:00-19:00:00, We 08:00:00-19:00:00, Tu 08:00:00-19:00:00, Mo 08:00:00-19:00:00
```

But this string [matches the recommended pattern](https://regex101.com/r/yI6z36/1)!

## Proposal

- [ ] reproduce the issue in a test
- [ ] fix regex?
