### PR TITLE
🚸(dashboard) add fallback for meter readings and refactor hidden inputs

### DIFF
--- a/src/dashboard/apps/renewable/templates/renewable/includes/_manage_delivery_points.html
+++ b/src/dashboard/apps/renewable/templates/renewable/includes/_manage_delivery_points.html
@@ -36,10 +36,10 @@
 
             <tbody>
               {% for form in formset|sort_formset_by_station %}
-                  {{ form.id }}
-                  <input type="hidden" name="form-{{ forloop.counter0 }}-entity_id" value="{{ form.delivery_point_obj.entity.id }}">
                   <tr>
                       <td>
+                        {{ form.id }}
+
                         {% for station_name, ids in form.stations_grouped.items %}
                           {% if forloop.counter0 > 0 %}<br />{% endif %}
                           {{ station_name }} {% if ids %}({{ ids|join:", " }}){% endif %}

--- a/src/dashboard/apps/renewable/templates/renewable/includes/_manage_meters.html
+++ b/src/dashboard/apps/renewable/templates/renewable/includes/_manage_meters.html
@@ -45,12 +45,12 @@
 
             <tbody>
               {% for form in formset %}
-              <input type="hidden" name="form-{{ forloop.counter0 }}-delivery_point" value="{{ form.delivery_point_obj.id }}">
               <tr id="table-prm-row-key-{{ forloop.counter0 }}"
                   data-row-key="{{ forloop.counter0 }}"
                   aria-labelledby="row-label-{{ forloop.counter0 }}">
 
                 <td>
+                  <input type="hidden" name="form-{{ forloop.counter0 }}-delivery_point" value="{{ form.delivery_point_obj.id }}">
                   {% for station_name, ids in form.stations_grouped.items %}
                     {% if forloop.counter0 > 0 %}<br />{% endif %}
                     {{ station_name }} {% if ids %}({{ ids|join:", " }}){% endif %}
@@ -69,19 +69,23 @@
 
                 <td>
                   {% with last_renewable=form.delivery_point_obj.last_renewable.0 %}
-                    {{ last_renewable.meter_reading }} kWh
-                    <button class="fr-btn--tooltip fr-btn"
-                            type="button"
-                            id="button-{{ form.delivery_point_obj.provider_assigned_id }}"
-                            aria-describedby="tooltip-{{ form.delivery_point_obj.provider_assigned_id }}">
-                        date du relevé précèdent
-                    </button>
-                    <span class="fr-tooltip fr-placement"
-                          id="tooltip-{{ form.delivery_point_obj.provider_assigned_id }}"
-                          role="tooltip"
-                          aria-hidden="true">
-                      relevé du {{ last_renewable.collected_at|date:"d/m/Y" }}
-                    </span>
+                    {% if last_renewable.meter_reading %}
+                      {{ last_renewable.meter_reading }} kWh
+                      <button class="fr-btn--tooltip fr-btn"
+                              type="button"
+                              id="button-{{ form.delivery_point_obj.provider_assigned_id }}"
+                              aria-describedby="tooltip-{{ form.delivery_point_obj.provider_assigned_id }}">
+                          date du relevé précèdent
+                      </button>
+                      <span class="fr-tooltip fr-placement"
+                            id="tooltip-{{ form.delivery_point_obj.provider_assigned_id }}"
+                            role="tooltip"
+                            aria-hidden="true">
+                        relevé du {{ last_renewable.collected_at|date:"d/m/Y" }}
+                      </span>
+                    {% else %}
+                      -
+                    {% endif %}
                   {% endwith %}
                 </td>
 


### PR DESCRIPTION
## Purpose

In the energy meter submission form, add a default value, if there are no previous meter readings

## Proposal

- [x]  add a fallback display ("-") for meter readings when no data is available, improving UI clarity.

## In addition

Repositions hidden input fields for consistency across templates.