### PR TITLE
🔖(prefect) adjust level of historicization

### DIFF
--- a/src/prefect/CHANGELOG.md
+++ b/src/prefect/CHANGELOG.md
@@ -33,5 +33,6 @@ and this project adheres to
 ### Changed
 
 - Upgrade API database to PG 15 / TimescaleDB 2.19
+- Adjust level of historicization
 
 [unreleased]: https://github.com/MTES-MCT/qualicharge/

--- a/src/prefect/prefect.yaml
+++ b/src/prefect/prefect.yaml
@@ -16,7 +16,7 @@ deployments:
         active: true
     parameters:
       environment: production
-      levels: [0, 1, 2, 3, 4]
+      levels: [0, 1, 2, 3]
       period: d
       create_artifact: true
       persist: true
@@ -33,7 +33,7 @@ deployments:
         active: true
     parameters:
       environment: production
-      levels: [0, 1, 2, 3, 4]
+      levels: [0, 1, 2, 3]
       period: d
       create_artifact: true
       persist: true
@@ -50,7 +50,7 @@ deployments:
         active: true
     parameters:
       environment: production
-      levels: [0, 1, 2, 3, 4]
+      levels: [0, 1, 2, 3]
       period: d
       create_artifact: true
       persist: true
@@ -67,7 +67,7 @@ deployments:
         active: true
     parameters:
       environment: production
-      levels: [0, 1, 2, 3, 4]
+      levels: [0, 1, 2, 3]
       period: d
       create_artifact: true
       persist: true


### PR DESCRIPTION
## Purpose

The volume of historicization data is high (3,5 millions rows per month).
Performances is degraded and some operations are no longer available (eg the calculation of monthly indicators)

## Proposal

Level 4 (city) represents more than 90 % of the volume and is not a requirement for historicization (ECPI level is sufficient).

We propose to adjust the level of historicization at level 3 (ECPI).

- [x] reduce the volume of historicization (90%)
- [x] improve query performance