### PR TITLE
🐛(dashboard) fix access to the delivery points management in renewable app

### DIFF
--- a/src/dashboard/apps/core/models.py
+++ b/src/dashboard/apps/core/models.py
@@ -115,6 +115,16 @@ class Entity(DashboardBase):
         verbose_name_plural = "entities"
         ordering = ["name"]
 
+    def __init__(self, *args, **kwargs):
+        """Sets up the initial state for count_active_delivery_points.
+
+        Attributes:
+            _count_active_delivery_points (Optional): Tracks the count of active
+                delivery points for the instance.
+        """
+        super().__init__(*args, **kwargs)
+        self._count_active_delivery_points = None
+
     def __str__(self):  # noqa: D105
         return self.name
 
@@ -240,6 +250,15 @@ class Entity(DashboardBase):
     def count_unsubmitted_quarterly_renewables(self) -> int:
         """Count delivery points with pending renewable, within the current quarter."""
         return self.get_unsubmitted_quarterly_renewables().count()
+
+    def count_active_delivery_points(self, update=False) -> int:
+        """Counts the number of active delivery points for this entity."""
+        if self._count_active_delivery_points is None or update:
+            self._count_active_delivery_points = self.delivery_points.filter(
+                is_active=True
+            ).count()
+
+        return self._count_active_delivery_points
 
 
 class DeliveryPoint(DashboardBase):

--- a/src/dashboard/apps/renewable/templates/renewable/includes/_summary_delivery_points.html
+++ b/src/dashboard/apps/renewable/templates/renewable/includes/_summary_delivery_points.html
@@ -15,7 +15,7 @@
       {% endif %}
 
       {# awaiting renewable meter - no items #}
-      {% if not has_pending_renewable %}
+      {% if not has_active_delivery_points %}
         {% include "renewable/includes/_no_data_card.html" with description="Aucun points de livraison." %}
       {% endif %}
     </div>

--- a/src/dashboard/apps/renewable/templates/renewable/includes/_summary_delivery_points_content.html
+++ b/src/dashboard/apps/renewable/templates/renewable/includes/_summary_delivery_points_content.html
@@ -28,20 +28,22 @@
             </thead>
             <tbody>
               {% for entity in entities %}
-                {% if entity.count_unsubmitted_quarterly_renewables %}
                 <tr id="undefined-row-key-{{ forloop.counter }}" data-row-key="forloop.counter">
                   <td>
                     <p>{{ entity.name }}</p>
                   </td>
                   <td class="fr-cell--center">
-                    <a class="fr-link fr-icon-arrow-right-line fr-link--icon-right"
-                       href="{% url "renewable:delivery-points" entity.slug %}"
-                       data-fr-js-link-actionee="true">
-                      Gestion des points de livraison
-                    </a>
+                    {% if entity.count_active_delivery_points %}
+                      <a class="fr-link fr-icon-arrow-right-line fr-link--icon-right"
+                         href="{% url "renewable:delivery-points" entity.slug %}"
+                         data-fr-js-link-actionee="true">
+                        Gestion des points de livraison
+                      </a>
+                      {% else %}
+                        <em>Aucun point de livraison actif</em>
+                    {% endif %}
                   </td>
                 </tr>
-                {% endif %}
               {% endfor %}
             </tbody>
           </table>

--- a/src/dashboard/apps/renewable/views.py
+++ b/src/dashboard/apps/renewable/views.py
@@ -66,6 +66,9 @@ class IndexView(BaseView, TemplateView):
 
         context = super().get_context_data(**kwargs)
         context["entities"] = entities
+        context["has_active_delivery_points"] = any(
+            entity.count_active_delivery_points(update=True) for entity in entities
+        )
         context["has_pending_renewable"] = any(
             entity.count_unsubmitted_quarterly_renewables() for entity in entities
         )


### PR DESCRIPTION
## Purpose

Currently, users cannot access the delivery points management interface unless at least one delivery point has the "has_renewable" checked.

## Proposal

- [x] Remove the restriction that requires at least one delivery point to have "has_renewable" checked to access delivery points management
- [x] Add a new function `has_active_delivery_points()` to the Entity model to check for any active delivery points
- [x] Update relevant templates to reflect this change
- [x] Add comprehensive test coverage for the new functionality