### PR TITLE
📈(dashboard) add 'noindex' meta tag block to base template

### DIFF
--- a/src/dashboard/dashboard/urls.py
+++ b/src/dashboard/dashboard/urls.py
@@ -18,6 +18,7 @@ Including another URLconf
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
+from django.views.generic import TemplateView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -28,6 +29,10 @@ urlpatterns = [
     path("consent/", include("apps.consent.urls")),
     path("renewable/", include("apps.renewable.urls")),
     path("", include("apps.home.urls")),
+    path(
+        "robots.txt",
+        TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
+    ),
     # internationalization
     path("i18n/", include("django.conf.urls.i18n")),
 ]

--- a/src/dashboard/templates/base.html
+++ b/src/dashboard/templates/base.html
@@ -1,6 +1,10 @@
 {% extends "dsfr/base.html" %}
 {% load static i18n dsfr_tags %}
 
+{% block opengraph %}
+  <meta name="robots" content="noindex">
+{% endblock opengraph %}
+
 {% block extra_css %}
   {% block dashboard_extra_css %}
   {% endblock dashboard_extra_css %}

--- a/src/dashboard/templates/robots.txt
+++ b/src/dashboard/templates/robots.txt
@@ -1,0 +1,2 @@
+User-Agent: *
+Disallow:


### PR DESCRIPTION
- add an 'opengraph' block with a 'noindex' meta tag to prevent search engines from indexing certain pages.
- add robots.txt 