### PR TITLE
🔖(api:minor) bump release to 0.24.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.24.0] - 2025-06-11
+
 ### Added
 
 - Clean activity table every day using a cronjob
@@ -485,7 +487,8 @@ and this project adheres to
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.23.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.24.0...main
+[0.24.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.22.1...v0.23.0
 [0.22.1]: https://github.com/MTES-MCT/qualicharge/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.21.0...v0.22.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -3,7 +3,7 @@
 #
 [project]
 name = "qualicharge"
-version = "0.23.0"
+version = "0.24.0"
 
 # Third party packages configuration
 [tool.coverage.run]

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.23.0"
+__version__ = "0.24.0"


### PR DESCRIPTION
### Added

- Clean activity table every day using a cronjob

### Fixed

- Update `id_station_itinerance` field examples in the swagger documentation

### Changed

- `Statique` model string fields are now stripped
- `Statique.restriction_gabarit` field should be at least 2 characters long
- Update the list of active operational units (twice)

#### Dependencies

- Upgrade `alembic` to `1.16.1`
- Upgrade `cachetools` to `6.0.0`
- Upgrade `geopandas` to `1.1.0`
- Upgrade `pandas` to `2.3.0`
- Upgrade `psycopg` to `3.2.9`
- Upgrade `pydantic` to `2.11.5`
- Upgrade `pyinstrument` to `5.0.2`
- Upgrade `sentry-sdk` to `2.29.0`
- Upgrade `setuptools` to `80.9.0`
- Upgrade `typer` to `0.16.0`
