### PR TITLE
✨(dashboard) add cron schedule for renewable opening notifications

### DIFF
--- a/src/dashboard/cron.json
+++ b/src/dashboard/cron.json
@@ -8,6 +8,9 @@
     },
     {
       "command": "51 5 * * 1 python manage.py notifawaitingconsents"
+    },
+    {
+      "command": "53 1 1,10 * * python manage.py notifopening"
     }
   ]
 }


### PR DESCRIPTION
Add a new cron job to trigger the `notifopening` command for renewable opening notifications on specified dates.