### PR TITLE
⬆️(dashboard) update Pipfile.lock dependencies

### DIFF
--- a/src/dashboard/CHANGELOG.md
+++ b/src/dashboard/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
 - Upgrade `jsonschema` to `4.24.0`
 - Upgrade `requests` to `2.32.4`
 - Upgrade `urllib3` to `2.5.0`
+- Upgrade `pydantic` to `2.10.0` 
+- Upgrade `pygments` to `2.19.2`
 
 ### Added
 

--- a/src/dashboard/Pipfile.lock
+++ b/src/dashboard/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e7161f302a5e8f7742806add550b26ae88b6877cb0b080c7f04e0ce7f75e82f9"
+            "sha256": "5e449eca0f6aa1eeebb255849905000593858e6b4734e57557979ae2172cd6de"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -727,19 +727,19 @@
         },
         "pydantic-settings": {
             "hashes": [
-                "sha256:59b4f431b1defb26fe620c71a7d3968a710d719f5f4cdbbdb7926edeb770f6ef",
-                "sha256:c509bf79d27563add44e8446233359004ed85066cd096d8b510f715e6ef5d268"
+                "sha256:33781dfa1c7405d5ed2b6f150830a93bb58462a847357bd8f162f8bacb77c027",
+                "sha256:7a12e0767ba283954f3fd3fefdd0df3af21b28aa849c40c35811d52d682fa876"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.9.1"
+            "version": "==2.10.0"
         },
         "pygments": {
             "hashes": [
-                "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f",
-                "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"
+                "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887",
+                "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.19.1"
+            "version": "==2.19.2"
         },
         "python-dateutil": {
             "hashes": [
@@ -980,15 +980,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==0.15.4"
-        },
-        "types-python-dateutil": {
-            "hashes": [
-                "sha256:13e80d6c9c47df23ad773d54b2826bd52dbbb41be87c3f339381c1700ad21ee5",
-                "sha256:2b2b3f57f9c6a61fba26a9c0ffb9ea5681c9b83e69cd897c6b5f668d9c0cab93"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.9'",
-            "version": "==2.9.0.20250516"
         },
         "types-pyyaml": {
             "hashes": [
@@ -1510,11 +1501,11 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f",
-                "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"
+                "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887",
+                "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.19.1"
+            "version": "==2.19.2"
         },
         "pytest": {
             "hashes": [
@@ -1803,6 +1794,15 @@
             "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==5.2.0.20250516"
+        },
+        "types-python-dateutil": {
+            "hashes": [
+                "sha256:13e80d6c9c47df23ad773d54b2826bd52dbbb41be87c3f339381c1700ad21ee5",
+                "sha256:2b2b3f57f9c6a61fba26a9c0ffb9ea5681c9b83e69cd897c6b5f668d9c0cab93"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==2.9.0.20250516"
         },
         "types-requests": {
             "hashes": [


### PR DESCRIPTION
Upgraded `pydantic` to 2.10.0 and `pygments` to 2.19.2. 
Re-added `types-python-dateutil` dependency. 
Updated hash values to reflect changes.