### PR TITLE
🐛(api) fix timescaledb cleanup parameter

### DIFF
--- a/src/api/scripts/data_retention_procedure.sql
+++ b/src/api/scripts/data_retention_procedure.sql
@@ -4,6 +4,6 @@
 -- REQUIREMENT:
 -- One should set the `drop_after` variable while calling this script
 --
--- psql --set=drop_after='2 months' "${DATABASE_URL}" -f scripts/data_retention_procedure.sql  
+-- psql --set=drop_after='{"drop_after":"20 days"}' "${DATABASE_URL}" -f scripts/data_retention_procedure.sql  
 --
-call generic_retention(config => '{"drop_after":' || :'drop_after' || '}');
+call generic_retention(config => :'drop_after');


### PR DESCRIPTION
## Purpose

Concatenating strings in a PostgreSQLprocedure call argument is not allowed.

## Proposal

The easiest way to fix this is to set the `DYNAMIC_CLEAN_AFTER` environment variable to expected JSON argument, e.g. `'{"drop_after":"20 days"}'`
