### PR TITLE
🔖(api:minor) bump release to 0.25.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.25.0] - 2025-06-20
+
 ### Added
 
 - Add a configurable retention policy for `Status` and `Session` data
@@ -517,7 +519,8 @@ and this project adheres to
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.24.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.25.0...main
+[0.25.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.22.1...v0.23.0
 [0.22.1]: https://github.com/MTES-MCT/qualicharge/compare/v0.22.0...v0.22.1

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -3,7 +3,7 @@
 #
 [project]
 name = "qualicharge"
-version = "0.24.0"
+version = "0.25.0"
 
 # Third party packages configuration
 [tool.coverage.run]

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.24.0"
+__version__ = "0.25.0"


### PR DESCRIPTION
### Added

- Add a configurable retention policy for `Status` and `Session` data
- Create new database indexes:
  - `ix_pointdecharge_station_id`
  - `ix_station_amenageur_id`
  - `ix_station_operateur_id`

### Changed

- Update the list of active operational units

#### Dependencies

- Upgrade `alembic` to `1.16.2`
- Upgrade `cachetools` to `6.1.0`
- Upgrade `FastAPI` to `0.115.13`
- Upgrade `Pydantic` to `2.11.7`
- Upgrade `pydantic-settings` to `2.10.0`
- Upgrade `sentry-sdk` to `2.30.0`
- Upgrade `urllib3` to `2.5.0`

### Removed

- Drop database indexes:
  - `status_horodatage_idx`
  - `ix_status_horodatage_pdc_id`
  - `session_start_idx`
  - `ix_session_start_pdc_id`
