### PR TITLE
[API] Add latest status table

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Implement latest status cache in the `LatestStatus` table
+
 ## [0.25.0] - 2025-06-20
 
 ### Added

--- a/src/api/qualicharge/factories/dynamic.py
+++ b/src/api/qualicharge/factories/dynamic.py
@@ -6,7 +6,7 @@ from polyfactory.factories.pydantic_factory import ModelFactory
 
 from ..fixtures.operational_units import prefixes
 from ..models.dynamic import SessionCreate, StatusCreate
-from ..schemas.core import Session, Status
+from ..schemas.core import LatestStatus, Session, Status
 from . import FrenchDataclassFactory, TimestampedSQLModelFactory
 
 
@@ -34,3 +34,7 @@ class SessionFactory(TimestampedSQLModelFactory[Session]):
 
 class StatusFactory(TimestampedSQLModelFactory[Status]):
     """Status schema factory."""
+
+
+class LatestStatusFactory(TimestampedSQLModelFactory[LatestStatus]):
+    """LatestStatus schema factory."""

--- a/src/api/qualicharge/migrations/versions/0abf671b893f_add_lateststatus_schema.py
+++ b/src/api/qualicharge/migrations/versions/0abf671b893f_add_lateststatus_schema.py
@@ -1,0 +1,111 @@
+"""add LatestStatus schema
+
+Revision ID: 0abf671b893f
+Revises: f2f66c7c092a
+Create Date: 2025-06-26 12:52:32.809721
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0abf671b893f"
+down_revision: Union[str, None] = "f2f66c7c092a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create the lateststatus stable."""
+    op.create_table(
+        "lateststatus",
+        sa.Column("horodatage", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "etat_pdc",
+            postgresql.ENUM(
+                "en_service",
+                "hors_service",
+                "inconnu",
+                name="etat_pdc_enum",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "occupation_pdc",
+            postgresql.ENUM(
+                "libre",
+                "occupe",
+                "reserve",
+                "inconnu",
+                name="occupation_pdc_enum",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "etat_prise_type_2",
+            postgresql.ENUM(
+                "fonctionnel",
+                "hors_service",
+                "inconnu",
+                name="etat_prise_enum",
+                create_type=False,
+            ),
+            nullable=True,
+        ),
+        sa.Column(
+            "etat_prise_type_combo_ccs",
+            postgresql.ENUM(
+                "fonctionnel",
+                "hors_service",
+                "inconnu",
+                name="etat_prise_enum",
+                create_type=False,
+            ),
+            nullable=True,
+        ),
+        sa.Column(
+            "etat_prise_type_chademo",
+            postgresql.ENUM(
+                "fonctionnel",
+                "hors_service",
+                "inconnu",
+                name="etat_prise_enum",
+                create_type=False,
+            ),
+            nullable=True,
+        ),
+        sa.Column(
+            "etat_prise_type_ef",
+            postgresql.ENUM(
+                "fonctionnel",
+                "hors_service",
+                "inconnu",
+                name="etat_prise_enum",
+                create_type=False,
+            ),
+            nullable=True,
+        ),
+        sa.Column(
+            "id_pdc_itinerance", sqlmodel.sql.sqltypes.AutoString(), nullable=False
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("created_at <= updated_at", name="pre-creation-update"),
+        sa.PrimaryKeyConstraint("id_pdc_itinerance"),
+    )
+    op.create_index(
+        op.f("ix_lateststatus_horodatage"), "lateststatus", ["horodatage"], unique=False
+    )
+
+
+def downgrade() -> None:
+    """Delete the lateststatus table and related indexes."""
+    op.drop_index(op.f("ix_lateststatus_horodatage"), table_name="lateststatus")
+    op.drop_table("lateststatus")

--- a/src/api/qualicharge/schemas/core.py
+++ b/src/api/qualicharge/schemas/core.py
@@ -39,6 +39,7 @@ from ..models.dynamic import (
     OccupationPDCEnum,
     SessionBase,
     StatusBase,
+    StatusCreate,
 )
 from ..models.static import (
     AccessibilitePMREnum,
@@ -470,7 +471,7 @@ class Session(BaseAuditableSQLModel, SessionBase, table=True):
 
 
 class Status(BaseTimestampedSQLModel, StatusBase, table=True):
-    """IRVE recharge status."""
+    """EVSE status."""
 
     __table_args__ = BaseTimestampedSQLModel.__table_args__ + (
         PrimaryKeyConstraint("id", "horodatage", name="ix_status_id_horodatage"),
@@ -512,6 +513,36 @@ class Status(BaseTimestampedSQLModel, StatusBase, table=True):
     def id_pdc_itinerance(self) -> str:
         """Return the PointDeCharge.id_pdc_itinerance (used for serialization only)."""
         return self.point_de_charge.id_pdc_itinerance
+
+
+class LatestStatus(BaseTimestampedSQLModel, StatusCreate, table=True):
+    """EVSE latest status."""
+
+    id_pdc_itinerance: str = Field(
+        regex="(?:(?:^|,)(^[A-Z]{2}[A-Z0-9]{4,33}$|Non concerné))+$", primary_key=True
+    )
+    horodatage: PastDatetime = Field(
+        sa_type=DateTime(timezone=True),
+        description="The timestamp indicating when the status changed.",
+        index=True,
+    )  # type: ignore
+
+    etat_pdc: EtatPDCEnum = Field(sa_column=SAColumn(EtatPDCDBEnum, nullable=False))
+    occupation_pdc: OccupationPDCEnum = Field(
+        sa_column=SAColumn(OccupationPDCDBEnum, nullable=False)
+    )
+    etat_prise_type_2: Optional[EtatPriseEnum] = Field(
+        sa_column=SAColumn(EtatPriseDBEnum, nullable=True)
+    )
+    etat_prise_type_combo_ccs: Optional[EtatPriseEnum] = Field(
+        sa_column=SAColumn(EtatPriseDBEnum, nullable=True)
+    )
+    etat_prise_type_chademo: Optional[EtatPriseEnum] = Field(
+        sa_column=SAColumn(EtatPriseDBEnum, nullable=True)
+    )
+    etat_prise_type_ef: Optional[EtatPriseEnum] = Field(
+        sa_column=SAColumn(EtatPriseDBEnum, nullable=True)
+    )
 
 
 class StatiqueMV(Statique, SQLModel):


### PR DESCRIPTION
## Purpose

Accessing all charge points last known status is too greedy, we need to find a way to "cache" charge points last known status.

## Proposal

- [x] add `LatestStatus` schema
- [x] add database migration
- [x] create latest status in the `POST /dynamique/status/` endpoint
- [x] create latest statuses in the `POST /dynamique/status/bulk` endpoint
- [x] use latest status in the `GET /dynamique/status/{id_pdc_itinerance}`
- [x] use latest statuses in the `GET /dynamique/status/` endpoint
