### PR TITLE
🔖(api:minor) bump release to 0.26.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,13 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
-### Changed
-
-- Improve bulk importation error message
+## [0.26.0] - 2025-07-01
 
 ### Added
 
 - Implement latest status cache in the `LatestStatus` table
+
+### Changed
+
+- Improve bulk importation error message
 
 ### Fixed
 
@@ -531,7 +533,8 @@ and this project adheres to
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.25.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.26.0...main
+[0.26.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.22.1...v0.23.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -3,7 +3,7 @@
 #
 [project]
 name = "qualicharge"
-version = "0.25.0"
+version = "0.26.0"
 
 # Third party packages configuration
 [tool.coverage.run]

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.25.0"
+__version__ = "0.26.0"


### PR DESCRIPTION
### Added

- Implement latest status cache in the `LatestStatus` table

### Changed

- Improve bulk importation error message

### Fixed

- Fix same address / different location bulk importation
