### PR TITLE
⚡️(opendata) use LatestStatus table

### DIFF
--- a/src/opendata/CHANGELOG.md
+++ b/src/opendata/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
 
 ### Changed
 
+- Use the `LatestStatus` cache table to speed up query performance
+
 #### Dependencies
 
 - Upgrade Psycopg to `3.2.9`

--- a/src/opendata/data7.yaml
+++ b/src/opendata/data7.yaml
@@ -7,36 +7,17 @@ default:
   datasets:
     - basename: statuses
       query: >-
-        WITH
-          pdc_status AS (
-            SELECT
-              LAST (Status.id, Status.horodatage) AS latest_id
-            FROM
-              PointDeCharge
-              INNER JOIN Status ON Status.point_de_charge_id = PointDeCharge.id
-            GROUP BY
-              PointDeCharge.id_pdc_itinerance
-          )
         SELECT
-          PointDeCharge.id_pdc_itinerance,
-          Status.etat_pdc,
-          Status.occupation_pdc,
-          Status.horodatage,
-          Status.etat_prise_type_2,
-          Status.etat_prise_type_combo_ccs,
-          Status.etat_prise_type_chademo,
-          Status.etat_prise_type_ef
+          id_pdc_itinerance,
+          etat_pdc,
+          occupation_pdc,
+          horodatage,
+          etat_prise_type_2,
+          etat_prise_type_combo_ccs,
+          etat_prise_type_chademo,
+          etat_prise_type_ef
         FROM
-          Status
-          INNER JOIN PointDeCharge ON Status.point_de_charge_id = PointDeCharge.id
-        WHERE
-          Status.id IN (
-            SELECT
-              latest_id
-            FROM
-              pdc_status
-          )
-        ORDER BY Status.horodatage DESC
+          LatestStatus
     - basename: statiques
       query: >-
         SELECT


### PR DESCRIPTION
## Purpose

Current database query is too greedy and the corresponding HTTP request always fails when it reaches the request timeout.

## Proposal

- [x] improve performance by using the recent LatestStatus cache table

### Known issue

For now, we only expose recent statuses, not all charge points will have a status. We will fill the blanks (if required) in a near future.
