### PR TITLE
⏪️(api) revert qcm script calls to module main entrypoint

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -25,7 +25,7 @@ function qcm() {
     --app "${SCALINGO_APP}" \
     --region osc-fr1 \
     run --silent \
-    qcm "$@"
+    python -m qualicharge "$@"
 }
 
 # Create a Vaultwarden send with the user password

--- a/src/api/cron.json
+++ b/src/api/cron.json
@@ -1,7 +1,7 @@
 {
   "jobs": [
     {
-      "command": "*/10 * * * * qcm statics refresh --concurrently"
+      "command": "*/10 * * * * python -m qualicharge statics refresh --concurrently"
     },
     {
       "command": "19 * * * * dbclient-fetcher psql && psql $SCALINGO_POSTGRESQL_URL -f scripts/clean-orphans.sql"


### PR DESCRIPTION
## Purpose

Scalingo Pipenv build doesn't install the qualicharge package, hence the `qcm` script is not callable.

## Proposal

We should instead call the `qualicharge` module main entrypoint until we use a different package manager + build-system. UV we are looking at you.
