### PR TITLE
🔖(api:minor) bump release to 0.27.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.27.0] - 2025-07-16
+
 ### Added
 
 - CLI: install a `qcm` script for management commands instead of using a module
@@ -554,7 +556,8 @@ update` command
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.26.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.27.0...main
+[0.27.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.23.0...v0.24.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qualicharge"
-version = "0.26.0"
+version = "0.27.0"
 requires-python = "~=3.12.11"
 dependencies = [
     "alembic==1.16.2",

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.26.0"
+__version__ = "0.27.0"

--- a/src/api/uv.lock
+++ b/src/api/uv.lock
@@ -1486,7 +1486,7 @@ wheels = [
 
 [[package]]
 name = "qualicharge"
-version = "0.26.0"
+version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
### Added

- CLI: install a `qcm` script for management commands instead of using a module entrypoint (`python -m qualicharge`)
- CLI: implement add/remove operational units options to the `qcm groups update` command
- CLI: add new `qcm ou list` command to explore operational units and related groups

### Changed

- Move CLI commands to grouped sub-commands for `users`, `groups` and `statics`
- Switched to UV package manager

#### Dependencies

- Upgrade `FastAPI` to `0.115.14`
- Upgrade `geopandas` to `1.1.1`
- Upgrade `pydantic-settings` to `2.10.1`
- Upgrade `sentry-sdk` to `2.32.0`
