### PR TITLE
Make amenageur / operateur fields mandatory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@ SHELL := /bin/bash
 COMPOSE                    	 = bin/compose
 COMPOSE_UP                 	 = $(COMPOSE) up -d --remove-orphans
 COMPOSE_RUN                	 = $(COMPOSE) run --rm --no-deps
-COMPOSE_RUN_API            	 = $(COMPOSE_RUN) api
-COMPOSE_RUN_API_UV     	     = $(COMPOSE_RUN_API) uv run
+COMPOSE_EXEC                 = $(COMPOSE) exec
+COMPOSE_EXEC_API             = $(COMPOSE_EXEC) api
+COMPOSE_EXEC_API_UV     	   = $(COMPOSE_EXEC_API) uv run
 COMPOSE_RUN_CLIENT         	 = $(COMPOSE_RUN) client
 COMPOSE_RUN_PREFECT_PIPENV 	 = $(COMPOSE_RUN) prefect pipenv run
 COMPOSE_RUN_DASHBOARD_PIPENV = $(COMPOSE_RUN) dashboard pipenv run
@@ -44,7 +45,7 @@ bench-reset-db: ## Reset API database to run benchmark
 .PHONY: bench-reset-db
 
 bench: ## run API benchmark
-	$(COMPOSE_RUN_API_UV) \
+	$(COMPOSE_EXEC_API_UV) \
 		locust \
 		  -f /mnt/bench/locustfile.py \
 			--headless \
@@ -327,7 +328,7 @@ post-deploy-prefect:  ## run prefect post-deployment script
 
 create-api-superuser: ## create api super user
 	@echo "Creating super user…"
-	@$(COMPOSE_RUN_API_UV) qcm users create \
+	@$(COMPOSE_EXEC_API_UV) qcm users create \
 		admin \
 		--email admin@example.com \
 		--password admin \
@@ -495,42 +496,42 @@ lint-dashboard: \
 
 lint-api-black: ## lint api python sources with black
 	@echo 'lint:black started…'
-	@$(COMPOSE_RUN_API_UV) black qualicharge tests
+	@$(COMPOSE_EXEC_API_UV) black qualicharge tests
 .PHONY: lint-api-black
 
 lint-api-ruff: ## lint api python sources with ruff
 	@echo 'lint:ruff started…'
-	@$(COMPOSE_RUN_API_UV) ruff check qualicharge tests
+	@$(COMPOSE_EXEC_API_UV) ruff check qualicharge tests
 .PHONY: lint-api-ruff
 
 lint-api-ruff-fix: ## lint and fix api python sources with ruff
 	@echo 'lint:ruff-fix started…'
-	@$(COMPOSE_RUN_API_UV) ruff check --fix qualicharge tests
+	@$(COMPOSE_EXEC_API_UV) ruff check --fix qualicharge tests
 .PHONY: lint-api-ruff-fix
 
 lint-api-mypy: ## lint api python sources with mypy
 	@echo 'lint:mypy started…'
-	@$(COMPOSE_RUN_API_UV) mypy qualicharge tests
+	@$(COMPOSE_EXEC_API_UV) mypy qualicharge tests
 .PHONY: lint-api-mypy
 
 lint-bench-black: ## lint bench python sources with black
 	@echo 'lint:black started…'
-	@$(COMPOSE_RUN_API_UV) black /mnt/bench
+	@$(COMPOSE_EXEC_API_UV) black /mnt/bench
 .PHONY: lint-bench-black
 
 lint-bench-ruff: ## lint bench python sources with ruff
 	@echo 'lint:ruff started…'
-	@$(COMPOSE_RUN_API_UV) ruff check /mnt/bench
+	@$(COMPOSE_EXEC_API_UV) ruff check /mnt/bench
 .PHONY: lint-bench-ruff
 
 lint-bench-ruff-fix: ## lint and fix api python sources with ruff
 	@echo 'lint:ruff-fix started…'
-	@$(COMPOSE_RUN_API_UV) ruff check --fix /mnt/bench
+	@$(COMPOSE_EXEC_API_UV) ruff check --fix /mnt/bench
 .PHONY: lint-bench-ruff-fix
 
 lint-bench-mypy: ## lint bench python sources with mypy
 	@echo 'lint:mypy started…'
-	@$(COMPOSE_RUN_API_UV) mypy /mnt/bench
+	@$(COMPOSE_EXEC_API_UV) mypy /mnt/bench
 .PHONY: lint-bench-mypy
 
 lint-client-black: ## lint api python sources with black

--- a/bin/pytest
+++ b/bin/pytest
@@ -22,5 +22,6 @@ DOCKER_USER=${DOCKER_USER} \
   docker compose run --rm \
     -e QUALICHARGE_OIDC_IS_ENABLED=True \
     -e TEST="${TEST}" \
+    -v "./src/${service}:/app" \
     "${service}" \
     ${cmd} "$@"

--- a/src/api/qualicharge/models/static.py
+++ b/src/api/qualicharge/models/static.py
@@ -122,41 +122,33 @@ def not_future(value: date):
 NotFutureDate = Annotated[date, AfterValidator(not_future)]
 
 # Default values (if not provided)
-DEFAULT_CHAR_VALUE: str = "NA"
-DEFAULT_EMAIL_ADDRESS: str = "na@example.org"
-DEFAULT_PHONE_NUMBER: FrenchPhoneNumber = FrenchPhoneNumber("+33.123456789")
-DEFAULT_SIREN_NUMBER: str = "123456789"
+# DEFAULT_CHAR_VALUE: str = "NA"
+# DEFAULT_EMAIL_ADDRESS: str = "na@example.org"
+# DEFAULT_PHONE_NUMBER: FrenchPhoneNumber = FrenchPhoneNumber("+33.123456789")
+# DEFAULT_SIREN_NUMBER: str = "123456789"
 
 
 class Statique(ModelSchemaMixin, BaseModel):
     """IRVE static model."""
 
-    nom_amenageur: Optional[
-        Annotated[str, StringConstraints(strip_whitespace=True)]
-    ] = DEFAULT_CHAR_VALUE
-    siren_amenageur: Optional[
-        Annotated[
-            str,
-            StringConstraints(
-                pattern=r"^\d{9}$",
-            ),
-            Field(
-                examples=[
-                    "853300010",
-                ]
-            ),
-        ]
-    ] = DEFAULT_SIREN_NUMBER
-    contact_amenageur: Optional[
-        Annotated[EmailStr, StringConstraints(strip_whitespace=True)]
-    ] = DEFAULT_EMAIL_ADDRESS
-    nom_operateur: Optional[
-        Annotated[str, StringConstraints(strip_whitespace=True)]
-    ] = DEFAULT_CHAR_VALUE
+    nom_amenageur: Annotated[str, StringConstraints(strip_whitespace=True)]
+    siren_amenageur: Annotated[
+        str,
+        StringConstraints(
+            pattern=r"^\d{9}$",
+        ),
+        Field(
+            examples=[
+                "853300010",
+            ]
+        ),
+    ]
+    contact_amenageur: Annotated[EmailStr, StringConstraints(strip_whitespace=True)]
+    nom_operateur: Annotated[str, StringConstraints(strip_whitespace=True)]
     contact_operateur: Annotated[EmailStr, StringConstraints(strip_whitespace=True)]
-    telephone_operateur: Optional[
-        Annotated[FrenchPhoneNumber, StringConstraints(strip_whitespace=True)]
-    ] = DEFAULT_PHONE_NUMBER
+    telephone_operateur: Annotated[
+        FrenchPhoneNumber, StringConstraints(strip_whitespace=True)
+    ]
     nom_enseigne: Annotated[str, StringConstraints(strip_whitespace=True)]
     id_station_itinerance: Annotated[
         str,

--- a/src/api/tests/models/test_static.py
+++ b/src/api/tests/models/test_static.py
@@ -212,25 +212,3 @@ def test_statique_model_str_fields_strip():
     assert statique.restriction_gabarit == restriction_gabarit.strip()
     assert statique.num_pdl == num_pdl.strip()
     assert statique.observations == observations.strip()
-
-
-def test_statique_model_defaults():
-    """Test the Statique model defaut values (when not provided)."""
-    example = StatiqueFactory.build()
-    statique = Statique(
-        **example.model_dump(
-            exclude={
-                "nom_amenageur",
-                "siren_amenageur",
-                "contact_amenageur",
-                "nom_operateur",
-                "telephone_operateur",
-            }
-        )
-    )
-
-    assert statique.nom_amenageur == "NA"
-    assert statique.siren_amenageur == "123456789"
-    assert statique.contact_amenageur == "na@example.org"
-    assert statique.nom_operateur == "NA"
-    assert statique.telephone_operateur == "+33.123456789"


### PR DESCRIPTION
## Purpose

Since the begining of the project we have been too permissive on Amenageur and Operateur fields. We did our best to avoid breaking things for our clients, but it was too hacky and weak solutions. For data consistency and regulatory purposes, those fields should be filled.

## Proposal

- [x] mark the following fields as required:
    - `nom_amenageur`
    - `siren_amenageur`
    - `contact_amenageur`
    - `nom_operateur`
    - `telephone_operateur`

## Extras

During this work, we also had to:

- [x] use docker exec to ensure sources are up-to-date
