### PR TITLE
🗃️(prefect) update indicators table indexes

### DIFF
--- a/src/prefect/CHANGELOG.md
+++ b/src/prefect/CHANGELOG.md
@@ -38,5 +38,6 @@ and this project adheres to
 
 - Upgrade API database to PG 15 / TimescaleDB 2.19
 - Adjust level of historicization
+- Update indicators table indexes
 
 [unreleased]: https://github.com/MTES-MCT/qualicharge/

--- a/src/prefect/indicators/schemas.py
+++ b/src/prefect/indicators/schemas.py
@@ -21,13 +21,13 @@ class BaseIndicator(DeclarativeBase):
         UUID(as_uuid=True), primary_key=True, default=uuid4
     )
     category: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
-    code: Mapped[str] = mapped_column(String(5))
-    level: Mapped[int] = mapped_column(SmallInteger)
+    code: Mapped[str] = mapped_column(String(5), index=True)
+    level: Mapped[int] = mapped_column(SmallInteger, index=True)
     target: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
-    period: Mapped[str] = mapped_column(String(1))
+    period: Mapped[str] = mapped_column(String(1), index=True)
     value: Mapped[float] = mapped_column(Float)
     extras: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
-    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)
 
     def __repr__(self) -> str:
         """Indicator representation."""


### PR DESCRIPTION
## Purpose

Now that daily indicators jobs run for a while, we need to tune our table indexes.

## Proposal

We've updated the base indicator model to reflect changes operated in the staging and production tables:

```sql
-- Staging table
CREATE INDEX ix_staging_code ON staging (code);
CREATE INDEX ix_staging_level ON staging (level);
CREATE INDEX ix_staging_period ON staging (period);
CREATE INDEX ix_staging_timestamp ON staging (timestamp);

-- Production table
CREATE INDEX ix_production_code ON production (code);
CREATE INDEX ix_production_level ON production (level);
CREATE INDEX ix_production_period ON production (period);
CREATE INDEX ix_production_timestamp ON production (timestamp);
```
