### PR TITLE
🔖(api:minor) bump release to 0.28.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.28.0] - 2025-07-29
+
 ### Changed
 
 - mark the following static fields as required:
@@ -573,7 +575,8 @@ update` command
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.27.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.28.0...main
+[0.28.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.24.0...v0.25.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qualicharge"
-version = "0.27.0"
+version = "0.28.0"
 requires-python = "~=3.12.11"
 dependencies = [
     "alembic==1.16.4",

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.27.0"
+__version__ = "0.28.0"

--- a/src/api/uv.lock
+++ b/src/api/uv.lock
@@ -1480,7 +1480,7 @@ wheels = [
 
 [[package]]
 name = "qualicharge"
-version = "0.27.0"
+version = "0.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
### Changed

- mark the following static fields as required:
  - `nom_amenageur`
  - `siren_amenageur`
  - `contact_amenageur`
  - `nom_operateur`
  - `telephone_operateur`

#### Dependencies

- Upgrade `FastAPI` to `0.116.1`
- Upgrade `geoalchemy2` to `0.18.0`
- Upgrade `pandas` to `2.3.1`
- Upgrade `pyarrow` to `21.0.0`
- Upgrade `sentry-sdk` to `2.33.2`
