### PR TITLE
🐛(project) fix minio service seeding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ default: help
 data:
 	mkdir -p data
 
+data/archives: data
+	mkdir data/archives
+
 data/afirev-charging.csv: data
 	@echo "You should download CSV file from $(AFIREV_CHARGING_DATASET_URL)"
 
@@ -60,6 +63,7 @@ bench: ## run API benchmark
 bootstrap: ## bootstrap the project for development
 bootstrap: \
   env.d/notebook-extras \
+  data/archives \
   build \
   migrate-api \
   create-api-test-db \
@@ -425,6 +429,7 @@ seed-metabase: ## seed the Metabase server
 .PHONY: seed-metabase
 
 seed-minio: ## seed the Minio server
+seed-minio: data/archives
 	@echo "Running minio service …"
 	@$(COMPOSE_UP) --wait minio
 	@echo "Create Minio user and buckets…"


### PR DESCRIPTION
## Purpose

At the first bootstrap, Minio fails to boot with the following log:

```
Error: unable to rename (/data/.minio.sys/tmp -> /data/.minio.sys/tmp-old/71095ded-b24c-43cd-89dd-1a0de6fb9e39) file access denied, drive may be faulty, please investigate (*fmt.wrapError)
```

## Proposal

To avoid permission issues on the minio volume, it needs to be created first by the current user and not root (docker default).
