### PR TITLE
🔖(api:minor) bump release to 0.29.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.29.0] - 2025-09-01
+
 ### Added
 
 - Implement `PointDeCharge` and `Station` soft-delete [BC]
@@ -591,7 +593,8 @@ update` command
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.28.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.29.0...main
+[0.29.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.25.0...v0.26.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qualicharge"
-version = "0.28.0"
+version = "0.29.0"
 requires-python = "~=3.12.11"
 dependencies = [
     "alembic==1.16.4",

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.28.0"
+__version__ = "0.29.0"

--- a/src/api/uv.lock
+++ b/src/api/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12.11, <3.13"
 
 [[package]]
@@ -1484,7 +1484,7 @@ wheels = [
 
 [[package]]
 name = "qualicharge"
-version = "0.28.0"
+version = "0.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
### Added

- Implement `PointDeCharge` and `Station` soft-delete [BC]
- Add new API endpoints for charge point (and station) decommissioning

### Changed

- Update the list of active operational units

#### Dependencies

- Upgrade `pandas` to `2.3.2`
- Upgrade `pyinstrument` to `5.1.1`
- Upgrade `sentry-sdk` to `2.35.0`
- Upgrade `typer` to `0.16.1`
