### PR TITLE
🦺(api) restrict submitted session and status max age

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to
 
 ### Changed
 
+- Forbid session older than `API_MAX_SESSION_AGE` submission
+  (defaults to 15 days)
+- Forbid status older than `API_MAX_STATUS_AGE` submission
+  (defaults to 1 day)
 - Update the list of active operational units
 
 #### Dependencies

--- a/src/api/qualicharge/conf.py
+++ b/src/api/qualicharge/conf.py
@@ -136,6 +136,9 @@ class Settings(BaseSettings):
     API_GET_PDC_ID_CACHE_MAXSIZE: int = 5000
     API_GET_PDC_ID_CACHE_TTL: int = 24 * 60 * 60
     API_GET_PDC_ID_CACHE_INFO: bool = False
+    # Dynamic data maximal age in seconds
+    API_MAX_SESSION_AGE: int = 365 * 24 * 60 * 60  # 1 year
+    API_MAX_STATUS_AGE: int = 24 * 60 * 60  # 1 day
 
     model_config = SettingsConfigDict(
         case_sensitive=True, env_nested_delimiter="__", env_prefix="QUALICHARGE_"

--- a/src/api/qualicharge/factories/dynamic.py
+++ b/src/api/qualicharge/factories/dynamic.py
@@ -1,9 +1,12 @@
 """QualiCharge dynamic factories."""
 
+from datetime import timezone
+
 from polyfactory import Use
 from polyfactory.factories.dataclass_factory import DataclassFactory
 from polyfactory.factories.pydantic_factory import ModelFactory
 
+from ..conf import settings
 from ..fixtures.operational_units import prefixes
 from ..models.dynamic import SessionCreate, StatusCreate
 from ..schemas.core import LatestStatus, Session, Status
@@ -17,6 +20,19 @@ class SessionCreateFactory(ModelFactory[SessionCreate]):
         lambda: DataclassFactory.__random__.choice(prefixes)
         + FrenchDataclassFactory.__faker__.pystr_format("E######")
     )
+    start = Use(
+        lambda: DataclassFactory.__faker__.date_time_between(
+            start_date=f"-{settings.API_MAX_SESSION_AGE}s",
+            end_date=f"-{settings.API_MAX_SESSION_AGE - 3600}s",
+            tzinfo=timezone.utc,
+        )
+    )
+    end = Use(
+        lambda: DataclassFactory.__faker__.date_time_between(
+            start_date=f"-{settings.API_MAX_SESSION_AGE - 3600}s",
+            tzinfo=timezone.utc,
+        )
+    )
 
 
 class StatusCreateFactory(ModelFactory[StatusCreate]):
@@ -25,6 +41,11 @@ class StatusCreateFactory(ModelFactory[StatusCreate]):
     id_pdc_itinerance = Use(
         lambda: DataclassFactory.__random__.choice(prefixes)
         + FrenchDataclassFactory.__faker__.pystr_format("E######")
+    )
+    horodatage = Use(
+        lambda: DataclassFactory.__faker__.date_time_between(
+            start_date=f"-{settings.API_MAX_STATUS_AGE}s", tzinfo=timezone.utc
+        )
     )
 
 

--- a/src/api/qualicharge/models/dynamic.py
+++ b/src/api/qualicharge/models/dynamic.py
@@ -1,11 +1,23 @@
 """QualiCharge dynamic odels."""
 
+from datetime import datetime, timedelta, timezone
 from enum import StrEnum
-from typing import Optional
+from typing import Annotated, Optional
 
-from pydantic import PositiveFloat
+from pydantic import AfterValidator, PositiveFloat, model_validator
 from pydantic.types import PastDatetime
 from sqlmodel import Field, SQLModel
+from typing_extensions import Self
+
+from ..conf import settings
+
+
+def not_older_than(value: datetime, max_age: timedelta):
+    """Validator function to ensure a datetime is not older than a now - max_age."""
+    now = datetime.now(tz=timezone.utc)
+    if value < now - max_age:
+        raise ValueError(f"{value} is older than {max_age}")
+    return value
 
 
 class EtatPDCEnum(StrEnum):
@@ -34,7 +46,7 @@ class EtatPriseEnum(StrEnum):
 
 
 class StatusBase(SQLModel):
-    """Base point of charge status."""
+    """Base charge point status."""
 
     etat_pdc: EtatPDCEnum
     occupation_pdc: OccupationPDCEnum
@@ -45,8 +57,8 @@ class StatusBase(SQLModel):
     etat_prise_type_ef: Optional[EtatPriseEnum] = None
 
 
-class StatusCreate(StatusBase):
-    """Point of charge status create."""
+class StatusAPIBase(StatusBase):
+    """Base charge point status for the API."""
 
     id_pdc_itinerance: str = Field(
         regex="(?:(?:^|,)(^[A-Z]{2}[A-Z0-9]{4,33}$|Non concerné))+$",
@@ -56,7 +68,18 @@ class StatusCreate(StatusBase):
     )
 
 
-class StatusRead(StatusCreate):
+class StatusCreate(StatusAPIBase):
+    """Point of charge status create."""
+
+    horodatage: Annotated[
+        PastDatetime,
+        AfterValidator(
+            lambda v: not_older_than(v, timedelta(seconds=settings.API_MAX_STATUS_AGE))
+        ),
+    ]
+
+
+class StatusRead(StatusAPIBase):
     """Point of charge status read."""
 
 
@@ -66,6 +89,13 @@ class SessionBase(SQLModel):
     start: PastDatetime
     end: PastDatetime
     energy: PositiveFloat
+
+    @model_validator(mode="after")
+    def check_session_dates(self) -> Self:
+        """Check start/end dates consistency."""
+        if self.start > self.end:
+            raise ValueError("A session cannot start after it has ended.")
+        return self
 
 
 class SessionCreate(SessionBase):
@@ -77,3 +107,9 @@ class SessionCreate(SessionBase):
             "examples": ["FR0NXEVSEXB9YG", "FRFASE3300405", "FR073012308585"]
         },
     )
+    start: Annotated[
+        PastDatetime,
+        AfterValidator(
+            lambda v: not_older_than(v, timedelta(seconds=settings.API_MAX_SESSION_AGE))
+        ),
+    ]

--- a/src/api/tests/models/test_dynamic.py
+++ b/src/api/tests/models/test_dynamic.py
@@ -1,20 +1,63 @@
 """QualiCharge dynamic models tests."""
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
+import pytest
+
+from qualicharge.conf import settings
 from qualicharge.factories.dynamic import SessionCreateFactory, StatusCreateFactory
+from qualicharge.models.dynamic import SessionCreate, StatusCreate
 
 
-def test_session_create_model():
-    """Test the dynamic SessionCreate model."""
+def test_session_create_factory():
+    """Test the dynamic SessionCreate model factory."""
     session = SessionCreateFactory.build()
+    now = datetime.now(tz=timezone.utc)
 
-    assert session.start < datetime.now()
-    assert session.end < datetime.now()
+    assert session.start < now
+    assert session.end < now
+
+
+def test_session_create_model_start_end_consistency():
+    """Test the dynamic SessionCreate model: start/end consistency."""
+    now = datetime.now(tz=timezone.utc)
+
+    with pytest.raises(ValueError, match="A session cannot start after it has ended."):
+        SessionCreate(
+            id_pdc_itinerance="FRFASE3300405",
+            start=now - timedelta(days=5),
+            end=now - timedelta(days=6),
+            energy=12.0,
+        )
+
+
+def test_session_create_model_start_max_age():
+    """Test the dynamic SessionCreate model: start max age."""
+    now = datetime.now(tz=timezone.utc)
+
+    with pytest.raises(ValueError, match="is older than 365 days"):
+        SessionCreate(
+            id_pdc_itinerance="FRFASE3300405",
+            start=now - timedelta(seconds=settings.API_MAX_SESSION_AGE + 3600),
+            end=now - timedelta(days=4),
+            energy=12.0,
+        )
+
+
+def test_status_create_factory():
+    """Test the dynamic StatusCreate model factory."""
+    status = StatusCreateFactory.build()
+
+    assert status.horodatage < datetime.now(tz=timezone.utc)
 
 
 def test_status_create_model():
     """Test the dynamic StatusCreate model."""
-    status = StatusCreateFactory.build()
+    now = datetime.now(tz=timezone.utc)
+    base = StatusCreateFactory.build()
 
-    assert status.horodatage < datetime.now()
+    with pytest.raises(ValueError, match="is older than 1 day"):
+        StatusCreate(
+            **base.model_dump(exclude={"horodatage"}),
+            horodatage=now - timedelta(seconds=settings.API_MAX_STATUS_AGE + 3600),
+        )


### PR DESCRIPTION
## Purpose

For legal reasons, we need to forbid sessions older than 15 days.

## Proposal

For now, we set this limit to a year, but it will be reconfigured to be set to its expected limit in **January 2026**.

We applied the same pattern to statuses to avoid receiving useless outdated statuses: statuses older than one-day are no longer accepted.

- [x] forbid session older than `settings.API_MAX_SESSION_AGE`
- [x] forbid status older than `settings.API_MAX_STATUS_AGE`
- [x] ~~fix `Makefile`'s `seed-api-sessions` rule~~ done in #691
- [x] ~~fix `Makefile`'s `seed-api-statuses` rule~~ done in #691