### PR TITLE
🐛(prefect) fix ENEX quality Expectation error

### DIFF
--- a/src/prefect/quality/expectations/dynamic.py
+++ b/src/prefect/quality/expectations/dynamic.py
@@ -156,11 +156,14 @@ FROM
 WHERE
   session.end != start
   AND energy > $excess_threshold_kWh
+  AND energy <= $highest_energy_kwh
+  AND start >= $start
+  AND start < $end
   AND energy > extract(
     'epoch' FROM (session.end - start)
   ) / 3600.0 * puissance_nominale * $excess_coef
                 """
-            ).substitute(date_params | ENEX.params),
+            ).substitute(date_params | ENEX.params | ENERGY),
             meta={"code": ENEX.code},
         ),
     ]


### PR DESCRIPTION
## Purpose

The ENEX quality Expectation find incorrect data

## Proposal

Add missing time constraints in the query (AND session.start >= $start  AND session.start < $end)