### PR TITLE
🔖(api:minor) bump release to 0.30.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.30.0] - 2025-10-31
+
 ### Changed
 
 - Update the list of active operational units
@@ -612,7 +614,8 @@ update` command
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.29.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.30.0...main
+[0.30.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.26.0...v0.27.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qualicharge"
-version = "0.29.0"
+version = "0.30.0"
 requires-python = "~=3.12.0"
 dependencies = [
     "alembic==1.17.0",

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.29.0"
+__version__ = "0.30.0"

--- a/src/api/uv.lock
+++ b/src/api/uv.lock
@@ -1519,7 +1519,7 @@ wheels = [
 
 [[package]]
 name = "qualicharge"
-version = "0.29.0"
+version = "0.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
### Changed

- Update the list of active operational units

#### Dependencies

- Upgrade `alembic` to `1.17.0`
- Upgrade `email-validator` to `2.3.0`
- Upgrade `fastapi` to `0.120.0`
- Upgrade `pandas` to `2.3.3`
- Upgrade `psycopg` to `3.2.11`
- Upgrade `pydantic-extra-types` to `2.10.6`
- Upgrade `pydantic-settings` to `2.11.0`
- Upgrade `questionary` to `2.1.1`
- Upgrade `sentry-sdk` to `2.42.1`
- Upgrade `sqlalchemy-utils` to `0.42.0`
- Upgrade `sqlmodel` to `0.0.27`
- Upgrade `typer` to `0.20.0`
