### PR TITLE
🔧(project) inactivate renovate python version update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,10 @@
       "matchPackageNames": [
         "*"
       ]
+    },
+    {
+      "matchDepTypes": ["requires-python"],
+      "enabled": false
     }
   ],
   "prConcurrentLimit": 2,


### PR DESCRIPTION
## Purpose

Every week, renovate proposes to upgrade the major python release. We don't want this behavior as it will be handled by a human.

## Proposal

- [x] inactivate Renovate's `requires-python` package rule
