### PR TITLE
♻️(dashboard) improve delivery point sorting logic and templates

### DIFF
--- a/src/dashboard/CHANGELOG.md
+++ b/src/dashboard/CHANGELOG.md
@@ -15,7 +15,10 @@ and this project adheres to
 - Add `footer` block with legal and accessibility links in base template
 - Add explicit session management configuration to enhance security (`SESSION_COOKIE_AGE` and 
   `SESSION_EXPIRE_AT_BROWSER_CLOSE`)
-
+- Improved sorting of delivery points by station name in meter reading management forms
+- Added an utility function `sort_delivery_points_by_station()` to `apps/renewable/helpers.py` 
+to centralize the logic for sorting delivery points by station name
+ 
 ### Changed
 
 - Update French translations for improved readability and consistency
@@ -23,6 +26,9 @@ and this project adheres to
 - Update html templates to improve responsiveness
 - Update the display of stations in the management form tables to ensure complete 
   rendering of information
+
+### Fixed
+- Fixed form sorting to prevent misalignment between checkboxes and displayed data
 
 #### Dependencies
 

--- a/src/dashboard/apps/core/models.py
+++ b/src/dashboard/apps/core/models.py
@@ -312,6 +312,15 @@ class DeliveryPoint(DashboardBase):
 
         return dict(stations_grouped)
 
+    @property
+    def latest_renewable(self):
+        """Get the most recent renewable meter reading for this delivery point.
+
+        Returns:
+             Renewable: latest renewable, ordered by collected_at descending.
+        """
+        return self.renewables.order_by("-collected_at").first()
+
 
 class Station(DashboardBase):
     """Represents a station for electric vehicles."""

--- a/src/dashboard/apps/renewable/templates/renewable/includes/_manage_delivery_points.html
+++ b/src/dashboard/apps/renewable/templates/renewable/includes/_manage_delivery_points.html
@@ -35,7 +35,7 @@
             </thead>
 
             <tbody>
-              {% for form in formset|sort_formset_by_station %}
+              {% for form in formset %}
                   <tr>
                       <td>
                         {{ form.id }}

--- a/src/dashboard/apps/renewable/templates/renewable/includes/_manage_meters.html
+++ b/src/dashboard/apps/renewable/templates/renewable/includes/_manage_meters.html
@@ -72,7 +72,7 @@
                 </td>
 
                 <td>
-                  {% with last_renewable=form.delivery_point_obj.last_renewable.0 %}
+                  {% with last_renewable=form.delivery_point_obj.latest_renewable %}
                     {% if last_renewable.meter_reading %}
                       {{ last_renewable.meter_reading|floatformat:5  }} kWh
                       <button class="fr-btn--tooltip fr-btn"

--- a/src/dashboard/apps/renewable/templatetags/renewable_tags.py
+++ b/src/dashboard/apps/renewable/templatetags/renewable_tags.py
@@ -68,19 +68,3 @@ def quarter_period_dates(reference_date: date | None = None):
     """Return formatted date range string for current quarter."""
     start_date, end_date = get_quarter_date_range(_get_reference_date(reference_date))
     return _(_format_date_range(start_date, end_date))
-
-
-@register.filter
-def sort_formset_by_station(formset):
-    """Sorts a formset of delivery point forms by their associated station names."""
-    return sorted(
-        formset,
-        key=lambda form: (
-            not form.instance.has_renewable,
-            (
-                list(form.stations_grouped.keys())[0].casefold()
-                if form.stations_grouped
-                else ""
-            ),
-        ),
-    )

--- a/src/dashboard/apps/renewable/tests/test_renewable_tags.py
+++ b/src/dashboard/apps/renewable/tests/test_renewable_tags.py
@@ -1,7 +1,6 @@
 """Dashboard renewable_tags tests."""
 
 from datetime import date
-from unittest.mock import Mock
 
 import pytest
 from django.utils import timezone
@@ -12,7 +11,6 @@ from apps.renewable.templatetags.renewable_tags import (
     previous_quarter_period_dates,
     quarter_period,
     quarter_period_dates,
-    sort_formset_by_station,
 )
 
 
@@ -112,36 +110,3 @@ def test_quarter_period_dates_period_without_reference_date(monkeypatch):
     monkeypatch.setattr(timezone, "now", lambda: date(2025, 5, 6))
     result = quarter_period_dates()
     assert result == "01/04/2025 to 30/06/2025"
-
-
-@pytest.mark.django_db
-def test_sort_formset_by_station():
-    """Test sort_formset_by_station."""
-    # Test sort_formset_by_station with an empty formset
-    formset = []
-    result = sort_formset_by_station(formset)
-    assert result == []
-
-    # Test sort_formset_by_station with a populated formset
-    # Mocking forms in the formset
-    form1 = Mock()
-    form1.instance = Mock()
-    form1.instance.has_renewable = False
-    form1.stations_grouped = {"Station C": None}
-
-    form2 = Mock()
-    form2.instance = Mock()
-    form2.instance.has_renewable = True
-    form2.stations_grouped = {"Station A": None}
-
-    form3 = Mock()
-    form3.instance = Mock()
-    form3.instance.has_renewable = True
-    form3.stations_grouped = {"Station B": None}
-
-    formset = [form1, form2, form3]
-
-    result = sort_formset_by_station(formset)
-
-    # Expected order: form2 (Station A), form3 (Station B), form1 (Station C)
-    assert result == [form2, form3, form1]


### PR DESCRIPTION
## Purpose

The sorting applied to the forms in the "Manage Delivery Points" and "Manage Renewables" views does not guarantee that the data is saved in the same order it is displayed.

This can lead to mismatches between the displayed form data and what is actually recorded in the database.

Example:
If the user enters:
- Line 1 (Station A): 1000 kWh
- Line 2 (Station B): 2000 kWh
- Line 3 (Station C): 3000 kWh

The POST request might incorrectly save:
- Station B: 1000 kWh ❌
- Station C: 2000 kWh ❌
- Station A: 3000 kWh ❌

Fix: Ensure form sorting and POST data order are aligned to preserve consistency between displayed and saved data.

## Proposal

- [x] update views and templates to ensure delivery points are consistently sorted by station name. 
- [x] centralize delivery point sorting logic with `sort_delivery_points_by_station()` utility. 
- [x] the sorting logic is now consistent across the GET output, formset definition, and POST processing.
- [x] to ensure compatibility with the formset, the sorting function now returns a QuerySet instead of a list of dictionaries.
- [x] remove deprecated `sort_formset_by_station` filter. 
- [x] enhanced test coverage to validate sorting behavior.
- [x] update changelog
