### PR TITLE
🔖(prefect) add indicators for quality Expectations

### DIFF
--- a/src/prefect/CHANGELOG.md
+++ b/src/prefect/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to
   - Energy (ENEU, ENEA, ENEX, ODUR)
   - statuses (ERRT, FTRT, DUPT, FRET)
   - consistency (RATS, OCCT, SEST)
+- Separate sessions and statuses expectations
+- Implement expectations as indicators
 
 #### Cooling
 

--- a/src/prefect/indicators/models.py
+++ b/src/prefect/indicators/models.py
@@ -29,6 +29,11 @@ class IndicatorPeriod(Enum):
     QUARTER = "q"
     YEAR = "y"
 
+    @property
+    def duration(self):
+        """Time delta of the period."""
+        return PeriodDuration[self.name].value
+
 
 class Indicator(BaseModel):
     """Indicator result."""

--- a/src/prefect/indicators/usage/u10.py
+++ b/src/prefect/indicators/usage/u10.py
@@ -156,7 +156,7 @@ def calculate(  # noqa: PLR0913
         if not offset and start is None
         else get_period_start_from_pit(start, offset, period)
     )
-    timespan = IndicatorTimeSpan(period=period.value, start=start)
+    timespan = IndicatorTimeSpan(period=period, start=start)
     subflows_results = [
         u10_for_level(level, timespan, environment, chunk_size=chunk_size)
         for level in levels

--- a/src/prefect/indicators/usage/u11.py
+++ b/src/prefect/indicators/usage/u11.py
@@ -160,7 +160,7 @@ def calculate(  # noqa: PLR0913
         if not offset and start is None
         else get_period_start_from_pit(start, offset, period)
     )
-    timespan = IndicatorTimeSpan(period=period.value, start=start)
+    timespan = IndicatorTimeSpan(period=period, start=start)
     subflows_results = [
         u11_for_level(level, timespan, environment, chunk_size=chunk_size)
         for level in levels

--- a/src/prefect/indicators/usage/u12.py
+++ b/src/prefect/indicators/usage/u12.py
@@ -189,7 +189,7 @@ def calculate(  # noqa: PLR0913
         if not offset and start is None
         else get_period_start_from_pit(start, offset, period)
     )
-    timespan = IndicatorTimeSpan(period=period.value, start=start)
+    timespan = IndicatorTimeSpan(period=period, start=start)
     subflows_results = [
         u12_for_level(level, timespan, environment, chunk_size=chunk_size)
         for level in levels

--- a/src/prefect/indicators/usage/u13.py
+++ b/src/prefect/indicators/usage/u13.py
@@ -179,7 +179,7 @@ def calculate(  # noqa: PLR0913
         if not offset and start is None
         else get_period_start_from_pit(start, offset, period)
     )
-    timespan = IndicatorTimeSpan(period=period.value, start=start)
+    timespan = IndicatorTimeSpan(period=period, start=start)
     subflows_results = [
         u13_for_level(level, timespan, environment, chunk_size=chunk_size)
         for level in levels

--- a/src/prefect/indicators/usage/u5.py
+++ b/src/prefect/indicators/usage/u5.py
@@ -162,7 +162,7 @@ def calculate(  # noqa: PLR0913
         if not offset and start is None
         else get_period_start_from_pit(start, offset, period)
     )
-    timespan = IndicatorTimeSpan(period=period.value, start=start)
+    timespan = IndicatorTimeSpan(period=period, start=start)
     subflows_results = [
         u5_for_level(level, timespan, environment, chunk_size=chunk_size)
         for level in levels

--- a/src/prefect/indicators/usage/u6.py
+++ b/src/prefect/indicators/usage/u6.py
@@ -191,7 +191,7 @@ def calculate(  # noqa: PLR0913
         if not offset and start is None
         else get_period_start_from_pit(start, offset, period)
     )
-    timespan = IndicatorTimeSpan(period=period.value, start=start)
+    timespan = IndicatorTimeSpan(period=period, start=start)
     subflows_results = [
         u6_for_level(level, timespan, environment, chunk_size=chunk_size)
         for level in levels

--- a/src/prefect/indicators/usage/u9.py
+++ b/src/prefect/indicators/usage/u9.py
@@ -191,7 +191,7 @@ def calculate(  # noqa: PLR0913
         if not offset and start is None
         else get_period_start_from_pit(start, offset, period)
     )
-    timespan = IndicatorTimeSpan(period=period.value, start=start)
+    timespan = IndicatorTimeSpan(period=period, start=start)
     subflows_results = [
         u9_for_level(level, timespan, environment, chunk_size=chunk_size)
         for level in levels

--- a/src/prefect/indicators/utils.py
+++ b/src/prefect/indicators/utils.py
@@ -13,7 +13,7 @@ from prefect.artifacts import create_markdown_artifact
 from sqlalchemy.orm import Session
 
 from .db import get_api_db_engine, save_indicators
-from .models import IndicatorPeriod, IndicatorTimeSpan, Level, PeriodDuration
+from .models import IndicatorPeriod, IndicatorTimeSpan, Level
 from .types import Environment
 
 # in AFIR regulation, 22 kw belongs interval [7.4, 22] and not [22, 50]
@@ -40,7 +40,7 @@ def get_period_start_from_pit(  # noqa: PLR0911
     first_minute = {"minute": 0, "second": 0, "microsecond": 0}
     first_hour = first_minute | {"hour": 0}
     start_date = datetime.now() if pit is None else pit
-    start_date += PeriodDuration[period.name].value * offset
+    start_date += period.duration * offset
     match period:
         case IndicatorPeriod.DAY:
             return start_date + relativedelta(**first_hour)  # type: ignore[arg-type]
@@ -61,7 +61,7 @@ def get_period_start_from_pit(  # noqa: PLR0911
 
 def get_timespan_filter_query_params(timespan: IndicatorTimeSpan, session: bool = True):
     """Get timespan query parameters."""
-    date_end = timespan.start + PeriodDuration[timespan.period.name].value
+    date_end = timespan.start + timespan.period.duration
     sql_start = f"'{timespan.start.isoformat(sep=' ')}'"
     sql_end = f"'{date_end.isoformat(sep=' ')}'"
     interval_session = "start >= timestamp $start AND start < timestamp $end"

--- a/src/prefect/prefect.yaml
+++ b/src/prefect/prefect.yaml
@@ -337,7 +337,9 @@ deployments:
         active: true
     parameters:
       environment: staging
+      period: d
       report_by_email: true
+      persist: true
     work_pool:
       name: indicators
       work_queue_name: default
@@ -363,7 +365,9 @@ deployments:
         active: true
     parameters:
       environment: production
+      period: d
       report_by_email: true
+      persist: true
     work_pool:
       name: indicators
       work_queue_name: default
@@ -376,8 +380,7 @@ deployments:
         active: true
     parameters:
       environment: staging
-      duration:
-        days: 7
+      period: d
       from_now: 
         days: 15
       report_by_email: true
@@ -385,7 +388,7 @@ deployments:
       name: indicators
       work_queue_name: default
 
-  - name: quality-dynamic-staging-by-amenageur
+  - name: quality-session-staging-by-amenageur
     entrypoint: quality/flows/dynamic.py:run_api_db_validation_by_amenageur
     schedules:
       - cron: "52 2 * * *"
@@ -393,11 +396,30 @@ deployments:
         active: true
     parameters:
       environment: staging
-      duration:
-        days: 7
+      period: d
       from_now: 
         days: 15
       report_by_email: true
+      create_artifact: true
+      persist: true
+      check_status: false
+    work_pool:
+      name: indicators
+      work_queue_name: default
+
+  - name: quality-status-staging-by-amenageur
+    entrypoint: quality/flows/dynamic.py:run_api_db_validation_by_amenageur
+    schedules:
+      - cron: "2 3 * * *"
+        timezone: "Europe/Paris"
+        active: true
+    parameters:
+      environment: staging
+      period: d
+      report_by_email: true
+      create_artifact: true
+      persist: true
+      check_session: false
     work_pool:
       name: indicators
       work_queue_name: default
@@ -405,13 +427,12 @@ deployments:
   - name: quality-dynamic-production
     entrypoint: quality/flows/dynamic.py:run_api_db_validation
     schedules:
-      - cron: "47 3 * * *"
+      - cron: "17 3 * * *"
         timezone: "Europe/Paris"
         active: true
     parameters:
       environment: production
-      duration:
-        days: 7
+      period: d
       from_now: 
         days: 15
       report_by_email: true
@@ -419,19 +440,38 @@ deployments:
       name: indicators
       work_queue_name: default
 
-  - name: quality-dynamic-production-by-amenageur
+  - name: quality-session-production-by-amenageur
     entrypoint: quality/flows/dynamic.py:run_api_db_validation_by_amenageur
     schedules:
-      - cron: "30 1 * * *"
+      - cron: "32 3 * * *"
         timezone: "Europe/Paris"
         active: true
     parameters:
       environment: production
-      duration:
-        days: 7
+      period: d
       from_now: 
         days: 15
       report_by_email: true
+      create_artifact: true
+      persist: true
+      check_status: false
+    work_pool:
+      name: indicators
+      work_queue_name: default
+
+  - name: quality-status-production-by-amenageur
+    entrypoint: quality/flows/dynamic.py:run_api_db_validation_by_amenageur
+    schedules:
+      - cron: "47 3 * * *"
+        timezone: "Europe/Paris"
+        active: true
+    parameters:
+      environment: production
+      period: d
+      report_by_email: true
+      create_artifact: true
+      persist: true
+      check_session: false
     work_pool:
       name: indicators
       work_queue_name: default

--- a/src/prefect/quality/expectations/parameters.py
+++ b/src/prefect/quality/expectations/parameters.py
@@ -31,6 +31,8 @@ LONS = QARule(
     code="LONS", params={"max_days_per_session": "3 day", "threshold_percent": 0.001}
 )
 FRES = QARule(code="FRES", params={"max_duration_day": 15})
+NEGS = QARule(code="NEGS", params={})
+session_p = [DUPS, OVRS, LONS, FRES, NEGS]
 
 # energy parameters
 # Maximum energy : max_energy = puissance_nominale * session_duration
@@ -40,11 +42,16 @@ FRES = QARule(code="FRES", params={"max_duration_day": 15})
 ENERGY = {"highest_energy_kwh": 1000, "lowest_energy_kwh": 1}
 ENEX = QARule(code="ENEX", params={"excess_coef": 2, "excess_threshold_kWh": 50})
 ENEA = QARule(code="ENEA", params={"abnormal_coef": 1.1, "threshold_percent": 0.1})
+ENEU = QARule(code="ENEU", params={})
 ODUR = QARule(code="ODUR", params={"threshold_percent": 0.001})
+energy_p = [ENEX, ENEA, ENEU, ODUR]
 
 # statuses parameters
 DUPT = QARule(code="DUPT", params={"threshold_percent": 0.01})
 FRET = QARule(code="FRET", params={"mean_duration_second": 300})
+FTRT = QARule(code="FTRT", params={})
+ERRT = QARule(code="ERRT", params={})
+status_p = [DUPT, FRET, FTRT, ERRT]
 
 # statuses-sessions consistency parameters
 RATS = QARule(
@@ -53,3 +60,12 @@ RATS = QARule(
 )
 OCCT = QARule(code="OCCT", params={"threshold_percent": 0.2})
 SEST = QARule(code="SEST", params={"threshold_percent": 0.01})
+session_status_p = [RATS, OCCT, SEST]
+
+# evaluable parameters (check a threshold)
+eval_p = [PDCM, LOCP, NE10, ODUR, ENEA, DUPS, LONS, FRES, DUPT, FRET, RATS, OCCT, SEST]
+
+# parameters categories
+EVALUABLE_PARAMS = [params.code for params in eval_p]
+SESSION_PARAMS = [params.code for params in session_p + energy_p + session_status_p]
+STATUS_PARAMS =  [params.code for params in status_p]

--- a/src/prefect/quality/expectations/static.py
+++ b/src/prefect/quality/expectations/static.py
@@ -21,15 +21,33 @@ FAKE_PDL: str = """(
 
 pdc_expectations = [
     # POWL : Power less than POWL_PARAMETER (rule 39)
-    gxe.ExpectColumnMinToBeBetween(
-        column="puissance_nominale",
-        min_value=POWL.params["min_power_kw"],
+    gxe.UnexpectedRowsExpectation(
+        unexpected_rows_query=Template(
+            """
+SELECT
+  id_pdc_itinerance,
+  puissance_nominale
+FROM
+  {batch}
+WHERE
+  puissance_nominale <= $min_power_kw
+        """
+        ).substitute(POWL.params),
         meta={"code": POWL.code},
     ),
     # POWU : Power greater than POWU_PARAMETER (rule 1)
-    gxe.ExpectColumnMaxToBeBetween(
-        column="puissance_nominale",
-        max_value=POWU.params["max_power_kw"],
+    gxe.UnexpectedRowsExpectation(
+        unexpected_rows_query=Template(
+            """
+SELECT
+  id_pdc_itinerance,
+  puissance_nominale
+FROM
+  {batch}
+WHERE
+  puissance_nominale >= $max_power_kw
+        """
+        ).substitute(POWU.params),
         meta={"code": POWU.code},
     ),
 ]
@@ -138,7 +156,7 @@ WITH
       {batch}
   )
 SELECT
-  *
+  nbre_stat_max::float / nbre_stat AS ratio
 FROM
   nb_stations_max,
   nb_stations
@@ -234,7 +252,7 @@ WITH
       {batch}
   )
 SELECT
-  *
+  nbre_stat::float / nbre_loc AS ratio
 FROM
   nb_localisation,
   nb_stations
@@ -302,7 +320,7 @@ WITH
       ) AS numpdl_dc
   )
 SELECT
-  *
+  nbre_numpdl_not14::float / nbre_stat_dc AS ratio
 FROM
   nb_station_dc,
   nb_numpdl_not14

--- a/src/prefect/quality/flows/static.py
+++ b/src/prefect/quality/flows/static.py
@@ -1,8 +1,11 @@
 """Prefect flows: static."""
 
+from datetime import date
+
 import great_expectations as gx
 from prefect import flow
 
+from indicators.models import IndicatorPeriod
 from quality.expectations import static
 from quality.flows.quality_run import (
     API_DATA_SOURCE_NAME,
@@ -14,7 +17,8 @@ from quality.flows.quality_run import (
 
 @flow(log_prints=True)
 def run_api_db_validation(
-    environment: str, report_by_email: bool = False
+    environment: str,
+    report_by_email: bool = False,
 ) -> gx.checkpoint.CheckpointResult:
     """Run API DB checkpoint."""
     # Context
@@ -38,7 +42,11 @@ def run_api_db_validation(
 
 @flow(log_prints=True)
 def run_api_db_validation_by_amenageur(
-    environment: str, report_by_email: bool = False
+    environment: str,
+    period: IndicatorPeriod = IndicatorPeriod.DAY,
+    report_by_email: bool = False,
+    create_artifact: bool = False,
+    persist: bool = False,
 ) -> QCReport:
     """Run API DB checkpoint by amenageur."""
     # Context
@@ -56,6 +64,15 @@ def run_api_db_validation_by_amenageur(
 
     # Checkpoints
     report = run_api_db_checkpoint_by_amenageur(
-        context, data_source, suite, environment, report_by_email, "static"
+        context,
+        data_source,
+        suite,
+        environment,
+        period,
+        date.today(),
+        report_by_email,
+        "static",
+        create_artifact=create_artifact,
+        persist=persist,
     )
     return report

--- a/src/prefect/tests/quality/test_static.py
+++ b/src/prefect/tests/quality/test_static.py
@@ -1,6 +1,7 @@
 """QualiCharge prefect quality tests: static data."""
 
 import pytest
+from sqlalchemy import text
 
 from indicators.types import Environment
 from quality.flows import quality_run, static
@@ -90,3 +91,15 @@ def test_run_api_db_validation_by_amenageur(monkeypatch):
                         assert not result.success
                     else:
                         assert result.success
+
+
+def test_run_indicator_validation_by_amenageur(indicators_db_engine):
+    """Run indicator validation by amenageur."""
+    static.run_api_db_validation_by_amenageur(Environment.TEST, persist=True)
+    with indicators_db_engine.connect() as connection:
+        query = """
+        select count(*) from test
+        where target = 'Tesla' and category = 'PDLM'
+        """
+        result = connection.execute(text(query))
+        assert result.one()[0] == 1


### PR DESCRIPTION
## Purpose

Current quality controls via Prefect allow for the direct and visual identification of errors by `amenageur` (simplifying the manual process).

Several improvements are planned:
- Returning a value in addition to a Boolean (allows for differentiation of severity levels)
- Integrating the results into Metabase (allows for tracking degradation or improvement over time and summarizing results)
- Having granularity by operational unit (a more homogeneous breakdown than by `amenageur` or `operateur`)

## Proposal

- [ ] Replace the allocation by `amenageur` with an allocation by operational unit
- [x] Replace query results with a numerical value
- [x] Maintain the current artifact
- [x] Add test results to the `indicators` table (one row per test type, per period, and per operational unit)
- [x] Adjust the test frequency to account for the 15-day session lag. 
- [x] Extend tests to indicators