### PR TITLE
🐛(api) restore orphan stations cleanup

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to
 - Upgrade `pyarrow` to `22.0.0`
 - Upgrade `sentry-sdk` to `2.43.0`
 
+### Fixed 
+
+- Restore orphan stations cleanup
+
 ## [0.30.0] - 2025-10-31
 
 ### Changed

--- a/src/api/scripts/clean-orphans.sql
+++ b/src/api/scripts/clean-orphans.sql
@@ -5,9 +5,9 @@ WHERE id IN (
       _Station.id
     FROM
       _Station
-      LEFT JOIN PointDeCharge ON station_id = _Station.id
+      LEFT JOIN _PointDeCharge ON station_id = _Station.id
     WHERE
-      PointDeCharge.station_id ISNULL
+      _PointDeCharge.station_id ISNULL
 );
 
 DELETE


### PR DESCRIPTION
## Purpose

Since our soft-delete implementation, orphan objects cleanup is partial and, thus, stations without any related charge points are not deleted.

## Proposal

Target the `_PointDeCharge` table and not `PointDeCharge`.
