### PR TITLE
🔖(prefect) extend quality Expectations to charge points without sessions

### DIFF
--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -68,6 +68,7 @@ Specific rules applies for submitted datasets consistency:
 | 46      | The number of stations per location should be less than **1.5**                                                                     |
 | 47      | The number of charge points per station should be equal to (or greater than) the value `nbre_pdc`                                   |
 | 48      | Two stations with identical first 5 characters of the `id_station_itinerance` should not be associated with two different operators |
+| 51 - 52 | A charge point without statuses since one month should be decommissioned                                                            |
 
 > The rule number corresponds to our data-quality control referencial.
 
@@ -140,8 +141,10 @@ Specific rules applies for submitted datasets consistency:
 | 21      | A status with `occupation_pdc="occupe"` should be associated with a session                                                     |
 | 37      | A status with `etat_pdc="hors_service"` cannot define `occupation_pdc="occupe"` (the later is reserved for charging activities) |
 | 44      | Statuses cannot be duplicated (identical `horodatage` values for a target charge point)                                         |
+| 53      | The number of statuses for a charge point should be less than **1 440 per day**                                                  |
 
 > The rule number corresponds to our data-quality control referencial.
+> Rule 21 is only available for charge points where session flow is enabled
 
 ### Sessions
 
@@ -181,7 +184,7 @@ Specific rules applies for submitted datasets consistency:
 | Rule N° | Rule                                                                                                                                        |
 | :------ | :------------------------------------------------------------------------------------------------------------------------------------------ |
 | 10      | Sessions cannot overlap                                                                                                                     |
-| 13      | The number of sessions at a charge point should be lower than **60 per day**                                                                |
+| 13      | The number of sessions for a charge point should be less than **60 per day**                                                                 |
 | 14      | A session cannot end before it starts                                                                                                       |
 | 15      | A session should last more than **3 days**                                                                                                  |
 | 17      | Sessions cannot be duplicated (identical start/end dates and energy for a target charge point)                                              |

--- a/src/prefect/CHANGELOG.md
+++ b/src/prefect/CHANGELOG.md
@@ -25,11 +25,13 @@ and this project adheres to
   - Locations (INSE, ADDR, LOCP)
   - Power supply (PDLM, NE10)
   - Operator and owner (OPEM, AMEM)
-- Add dynamic expectations
+- Add session expectations
   - Sesssions (DUPS, OVRS, LONS, NEGS, FRES)
   - Energy (ENEU, ENEA, ENEX, ODUR)
-  - statuses (ERRT, FTRT, DUPT, FRET)
   - consistency (RATS, OCCT, SEST)
+- Add status expectations
+  - statuses (ERRT, FTRT, DUPT, FRET, OVRT)
+  - pdc activity (INAC, DECL)
 - Separate sessions and statuses expectations
 - Implement expectations as indicators
 
@@ -44,5 +46,6 @@ and this project adheres to
 - Update indicators table indexes
 - Optimize queries for indexes added on session and status tables
 - Add delay parameter for dynamic Expectations
+- Extend quality to data without sessions
 
 [unreleased]: https://github.com/MTES-MCT/qualicharge/

--- a/src/prefect/quality/expectations/parameters.py
+++ b/src/prefect/quality/expectations/parameters.py
@@ -10,6 +10,12 @@ class QARule(BaseModel):
     params: dict
 
 
+IS_DC: str = """(
+puissance_nominale >= 50
+OR prise_type_combo_ccs
+OR prise_type_chademo
+)"""
+
 # static parameters
 POWU = QARule(code="POWU", params={"max_power_kw": 4000.0})
 POWL = QARule(code="POWL", params={"min_power_kw": 1.3})
@@ -41,7 +47,7 @@ session_p = [DUPS, OVRS, LONS, FRES, NEGS]
 # Abnormal energy : if energy > abnormal_coef * max_energy
 ENERGY = {"highest_energy_kwh": 1000, "lowest_energy_kwh": 1}
 ENEX = QARule(code="ENEX", params={"excess_coef": 2, "excess_threshold_kWh": 50})
-ENEA = QARule(code="ENEA", params={"abnormal_coef": 1.1, "threshold_percent": 0.1})
+ENEA = QARule(code="ENEA", params={"abnormal_coef": 1.1, "threshold_percent": 0.001})
 ENEU = QARule(code="ENEU", params={})
 ODUR = QARule(code="ODUR", params={"threshold_percent": 0.001})
 energy_p = [ENEX, ENEA, ENEU, ODUR]
@@ -51,7 +57,15 @@ DUPT = QARule(code="DUPT", params={"threshold_percent": 0.01})
 FRET = QARule(code="FRET", params={"mean_duration_second": 300})
 FTRT = QARule(code="FTRT", params={})
 ERRT = QARule(code="ERRT", params={})
-status_p = [DUPT, FRET, FTRT, ERRT]
+OVRT = QARule(code="OVRT", params={"max_statuses_per_day": 1440})
+status_p = [DUPT, FRET, FTRT, ERRT, OVRT]
+
+# pdc-status parameters
+INAC = QARule(
+    code="INAC", params={"inactivity_duration": "1 month", "threshold_percent": 0.02}
+)
+DECL = QARule(code="DECL", params={"threshold_percent": 0.02})
+pdc_status_p = [INAC, DECL]
 
 # statuses-sessions consistency parameters
 RATS = QARule(
@@ -63,9 +77,25 @@ SEST = QARule(code="SEST", params={"threshold_percent": 0.01})
 session_status_p = [RATS, OCCT, SEST]
 
 # evaluable parameters (check a threshold)
-eval_p = [PDCM, LOCP, NE10, ODUR, ENEA, DUPS, LONS, FRES, DUPT, FRET, RATS, OCCT, SEST]
+eval_p = [
+    PDCM,
+    LOCP,
+    NE10,
+    ODUR,
+    ENEA,
+    DUPS,
+    LONS,
+    FRES,
+    DUPT,
+    FRET,
+    RATS,
+    OCCT,
+    SEST,
+    INAC,
+    DECL,
+]
 
 # parameters categories
 EVALUABLE_PARAMS = [params.code for params in eval_p]
 SESSION_PARAMS = [params.code for params in session_p + energy_p + session_status_p]
-STATUS_PARAMS =  [params.code for params in status_p]
+STATUS_PARAMS = [params.code for params in status_p + pdc_status_p]

--- a/src/prefect/quality/expectations/static.py
+++ b/src/prefect/quality/expectations/static.py
@@ -6,15 +6,11 @@ from string import Template
 import great_expectations as gx
 import great_expectations.expectations as gxe
 
-from .parameters import CRDF, LOCP, NE10, PDCM, POWL, POWU
+from .parameters import CRDF, IS_DC, LOCP, NE10, PDCM, POWL, POWU
 
 NAME: str = "static"
 
-IS_DC: str = """(
-puissance_nominale >= 50
-OR prise_type_combo_ccs
-OR prise_type_chademo
-)"""
+
 FAKE_PDL: str = """(
 '', '00000000000000', '012345678987654', '11111111111111', '99999999999999')
 """
@@ -123,6 +119,7 @@ FROM
   {batch}
 WHERE
   id_pdc_itinerance not like 'FR___E%'
+  OR substring(id_pdc_itinerance from 1 for 5) != substring(id_station_itinerance from 1 for 5)
         """,
         meta={"code": "AFIE"},
     ),
@@ -268,7 +265,7 @@ num_PDL_expectations = [
     gxe.UnexpectedRowsExpectation(
         unexpected_rows_query=Template(
             """
-SELECT
+SELECT DISTINCT ON (id_station_itinerance)
   id_station_itinerance
 FROM
   {batch}

--- a/src/prefect/quality/flows/quality_run.py
+++ b/src/prefect/quality/flows/quality_run.py
@@ -250,15 +250,16 @@ def run_api_db_checkpoint_by_amenageur(  # noqa: PLR0913
                     )
                     if code in EVALUABLE_PARAMS and "details" in r.result:
                         value = r.result["details"]["unexpected_rows"][0]["ratio"]
-                    indicators.loc[len(indicators)] = {
-                        "value": value,
-                        "level": Level.OU,
-                        "target": amenageur,
-                        "category": code,
-                        "code": "qua",
-                        "period": period,
-                        "timestamp": check_date.isoformat(),
-                    }
+                    if value > 0:
+                        indicators.loc[len(indicators)] = {
+                            "value": value,
+                            "level": Level.OU,
+                            "target": amenageur,
+                            "category": code,
+                            "code": "qua",
+                            "period": period,
+                            "timestamp": check_date.isoformat(),
+                        }
         report.results.append(qc_results)
 
     # Generate report

--- a/src/prefect/tests/quality/test_dynamic.py
+++ b/src/prefect/tests/quality/test_dynamic.py
@@ -25,7 +25,7 @@ def test_run_api_db_validation():
     for _, v in results.run_results.items():
         for result in v.results:
             code = result.expectation_config.meta.get("code")  # type: ignore[union-attr]
-            if code in ["FRES", "FRET", "ENEX", "ENEA", "OCCT", "SEST"]:
+            if code in ["FRES", "FRET", "ENEX", "ENEA", "OCCT", "SEST", "INAC"]:
                 assert not result.success
             else:
                 assert result.success
@@ -58,17 +58,33 @@ def test_run_api_db_validation_by_amenageur(monkeypatch):
         for result in results.suite:
             match results.amenageur:
                 case "Tesla":
-                    if result.code in ["FRES", "FRET", "OCCT", "SEST"]:
+                    if result.code in ["FRES", "FRET", "OCCT", "SEST", "INAC", "ENEA"]:
                         assert not result.success
                     else:
                         assert result.success
                 case "Ionity":
-                    if result.code in ["FRES", "FRET", "ENEX", "ENEA", "OCCT", "SEST"]:
+                    if result.code in [
+                        "FRES",
+                        "FRET",
+                        "ENEX",
+                        "ENEA",
+                        "OCCT",
+                        "SEST",
+                        "INAC",
+                    ]:
                         assert not result.success
                     else:
                         assert result.success
                 case "Electra":
-                    if result.code in ["FRES", "FRET", "ENEX", "ENEA", "OCCT", "SEST"]:
+                    if result.code in [
+                        "FRES",
+                        "FRET",
+                        "ENEX",
+                        "ENEA",
+                        "OCCT",
+                        "SEST",
+                        "INAC",
+                    ]:
                         assert not result.success
                     else:
                         assert result.success


### PR DESCRIPTION
## Purpose

Current quality controls via Prefect are designed for charge points with session flow and status flow. 
The Qualicharge extension to charge points with only a status flow necessitates an adaptation of certain quality Expectations

## Proposal

- [x] Limit RATS and OCCT consistency Expectations to DC stations with direct connection (num_PDL)
- [x] Add OVRT Expectations to check the number of charge point statuses per day 
- [x] Add INAC and DECL Expectations to detect charge points without statuses 
- [x] Fix three bugs (0 value indicator, PDLM query, ENEA threshold)