### PR TITLE
⚗️(prefect) rename indicators meta flow name

### DIFF
--- a/src/prefect/indicators/infrastructure/i1.py
+++ b/src/prefect/indicators/infrastructure/i1.py
@@ -123,7 +123,7 @@ def i1_national(timespan: IndicatorTimeSpan, environment: Environment) -> pd.Dat
 @flow(
     flow_run_name="meta-i1-{period.value}",
 )
-def calculate(  # noqa: PLR0913
+def i1(  # noqa: PLR0913
     environment: Environment,
     levels: List[Level],
     start: datetime | None = None,

--- a/src/prefect/indicators/infrastructure/i4.py
+++ b/src/prefect/indicators/infrastructure/i4.py
@@ -122,7 +122,7 @@ def i4_national(timespan: IndicatorTimeSpan, environment: Environment) -> pd.Dat
 @flow(
     flow_run_name="meta-i4-{period.value}",
 )
-def calculate(  # noqa: PLR0913
+def i4(  # noqa: PLR0913
     environment: Environment,
     levels: List[Level],
     start: datetime | None = None,

--- a/src/prefect/indicators/infrastructure/i7.py
+++ b/src/prefect/indicators/infrastructure/i7.py
@@ -125,7 +125,7 @@ def i7_national(timespan: IndicatorTimeSpan, environment: Environment) -> pd.Dat
 @flow(
     flow_run_name="meta-i7-{period.value}",
 )
-def calculate(  # noqa: PLR0913
+def i7(  # noqa: PLR0913
     environment: Environment,
     levels: List[Level],
     start: datetime | None = None,

--- a/src/prefect/indicators/infrastructure/t1.py
+++ b/src/prefect/indicators/infrastructure/t1.py
@@ -148,7 +148,7 @@ def t1_national(timespan: IndicatorTimeSpan, environment: Environment) -> pd.Dat
 @flow(
     flow_run_name="meta-t1-{period.value}",
 )
-def calculate(  # noqa: PLR0913
+def t1(  # noqa: PLR0913
     environment: Environment,
     levels: List[Level],
     start: datetime | None = None,

--- a/src/prefect/indicators/run.py
+++ b/src/prefect/indicators/run.py
@@ -9,10 +9,10 @@ from .extract.e4 import calculate as e4_calculate
 from .historicize.up import calculate as up_calculate
 
 # infrastructure
-from .infrastructure.i1 import calculate as i1_calculate
-from .infrastructure.i4 import calculate as i4_calculate
-from .infrastructure.i7 import calculate as i7_calculate
-from .infrastructure.t1 import calculate as t1_calculate
+from .infrastructure.i1 import i1
+from .infrastructure.i4 import i4
+from .infrastructure.i7 import i7
+from .infrastructure.t1 import t1
 
 # usage
 from .usage.u5 import calculate as u5_calculate

--- a/src/prefect/prefect.yaml
+++ b/src/prefect/prefect.yaml
@@ -8,7 +8,7 @@ deployments:
 
   # null start value -> datetime.now()
   - name: i1-daily
-    entrypoint: indicators/run.py:i1_calculate
+    entrypoint: indicators/infrastructure/i1.py:i1
     concurrency_limit: 10
     schedules:
       - cron: "0 5 * * *"
@@ -25,7 +25,7 @@ deployments:
       work_queue_name: default
 
   - name: i4-daily
-    entrypoint: indicators/run.py:i4_calculate
+    entrypoint: indicators/infrastructure/i4.py:i4
     concurrency_limit: 10
     schedules:
       - cron: "3 5 * * *"
@@ -42,7 +42,7 @@ deployments:
       work_queue_name: default
 
   - name: i7-daily
-    entrypoint: indicators/run.py:i7_calculate
+    entrypoint: indicators/infrastructure/i7.py:i7
     concurrency_limit: 10
     schedules:
       - cron: "6 5 * * *"
@@ -59,7 +59,7 @@ deployments:
       work_queue_name: default
 
   - name: t1-daily
-    entrypoint: indicators/run.py:t1_calculate
+    entrypoint: indicators/infrastructure/t1.py:t1
     concurrency_limit: 10
     schedules:
       - cron: "9 5 * * *"

--- a/src/prefect/tests/historicize/test_up.py
+++ b/src/prefect/tests/historicize/test_up.py
@@ -183,7 +183,7 @@ def test_to_historicization_up_extras():
 
 def test_flow_up_calculate():
     """Test the `calculate` flow."""
-    indicators = i1.calculate(
+    indicators = i1.i1(
         Environment.TEST,
         levels=[Level.NATIONAL, Level.REGION],
         start=TIMESPAN.start,
@@ -205,7 +205,7 @@ def test_flow_up_calculate():
 
 def test_flow_calculate_persistence(indicators_db_engine):
     """Test the `calculate` flow."""
-    indicators = i1.calculate(
+    indicators = i1.i1(
         Environment.TEST,
         levels=[Level.NATIONAL, Level.REGION],
         start=TIMESPAN.start,
@@ -220,7 +220,7 @@ def test_flow_calculate_persistence(indicators_db_engine):
         period=IndicatorPeriod.DAY,
         create_artifact=False,
     )
-    t1.calculate(
+    t1.t1(
         Environment.TEST,
         levels=[Level.NATIONAL],
         start=TIMESPAN.start,
@@ -246,7 +246,7 @@ def test_flow_calculate_persistence(indicators_db_engine):
 
 def test_flow_calculate_up_with_start_none(indicators_db_engine):
     """Test the `calculate` flow with start=None."""
-    i1.calculate(
+    i1.i1(
         Environment.TEST,
         levels=[Level.NATIONAL],
         start=TIMESPAN.start,

--- a/src/prefect/tests/infrastructure/test_i1.py
+++ b/src/prefect/tests/infrastructure/test_i1.py
@@ -72,8 +72,8 @@ def test_flow_i1_national(db_connection):
     assert indicators.at[0, "value"] == expected
 
 
-def test_flow_i1_calculate():
-    """Test the `calculate` flow."""
+def test_flow_i1():
+    """Test the `i1` flow."""
     expected = N_NAT_REG_DPT_EPCI_CITY
     all_levels = [
         Level.NATIONAL,
@@ -82,23 +82,23 @@ def test_flow_i1_calculate():
         Level.CITY,
         Level.EPCI,
     ]
-    indicators = i1.calculate(
+    indicators = i1.i1(
         Environment.TEST,
         all_levels,
         TIMESPAN.start,
-        TIMESPAN.period.value,
+        TIMESPAN.period,
         create_artifact=True,
     )
     assert len(indicators) == expected
 
 
-def test_flow_calculate_persistence(indicators_db_engine):
-    """Test the `calculate` flow."""
-    indicators = i1.calculate(
+def test_flow_i1_persistence(indicators_db_engine):
+    """Test the `i1` flow."""
+    indicators = i1.i1(
         Environment.TEST,
         [Level.NATIONAL],
         TIMESPAN.start,
-        TIMESPAN.period.value,
+        TIMESPAN.period,
         persist=True,
     )
 
@@ -107,9 +107,9 @@ def test_flow_calculate_persistence(indicators_db_engine):
         assert result.one()[0] == len(indicators)
 
 
-def test_flow_calculate_with_start_none():
-    """Test the `calculate` flow with start=None."""
-    assert isinstance(i1.calculate(Environment.TEST, [Level.NATIONAL]), pd.DataFrame)
+def test_flow_i1_with_start_none():
+    """Test the `i1` flow with start=None."""
+    assert isinstance(i1.i1(Environment.TEST, [Level.NATIONAL]), pd.DataFrame)
 
 
 # query used to get N_LEVEL

--- a/src/prefect/tests/infrastructure/test_i4.py
+++ b/src/prefect/tests/infrastructure/test_i4.py
@@ -71,8 +71,8 @@ def test_flow_i4_national(db_connection):
     assert indicators.at[0, "value"] == expected
 
 
-def test_flow_i4_calculate(db_connection):
-    """Test the `calculate` flow."""
+def test_flow_i4(db_connection):
+    """Test the `i4` flow."""
     expected = N_NAT_REG_DPT_EPCI_CITY
     all_levels = [
         Level.NATIONAL,
@@ -81,23 +81,23 @@ def test_flow_i4_calculate(db_connection):
         Level.CITY,
         Level.EPCI,
     ]
-    indicators = i4.calculate(
+    indicators = i4.i4(
         Environment.TEST,
         all_levels,
         TIMESPAN.start,
-        TIMESPAN.period.value,
+        TIMESPAN.period,
         create_artifact=True,
     )
     assert len(indicators) == expected
 
 
-def test_flow_calculate_persistence(indicators_db_engine):
-    """Test the `calculate` flow."""
-    indicators = i4.calculate(
+def test_flow_i4_persistence(indicators_db_engine):
+    """Test the `i4` flow."""
+    indicators = i4.i4(
         Environment.TEST,
         [Level.NATIONAL],
         TIMESPAN.start,
-        TIMESPAN.period.value,
+        TIMESPAN.period,
         persist=True,
     )
 

--- a/src/prefect/tests/infrastructure/test_i7.py
+++ b/src/prefect/tests/infrastructure/test_i7.py
@@ -79,8 +79,8 @@ def test_flow_i7_national(db_connection):
     assert int(indicators.at[0, "value"]) == expected
 
 
-def test_flow_i7_calculate(db_connection):
-    """Test the `calculate` flow."""
+def test_flow_i7(db_connection):
+    """Test the `i7` flow."""
     expected = N_NAT_REG_DPT_EPCI_CITY
     all_levels = [
         Level.NATIONAL,
@@ -89,23 +89,23 @@ def test_flow_i7_calculate(db_connection):
         Level.CITY,
         Level.EPCI,
     ]
-    indicators = i7.calculate(
+    indicators = i7.i7(
         Environment.TEST,
         all_levels,
         TIMESPAN.start,
-        TIMESPAN.period.value,
+        TIMESPAN.period,
         create_artifact=True,
     )
     assert len(indicators) == expected
 
 
-def test_flow_calculate_persistence(indicators_db_engine):
-    """Test the `calculate` flow."""
-    indicators = i7.calculate(
+def test_flow_i7_persistence(indicators_db_engine):
+    """Test the `i7` flow."""
+    indicators = i7.i7(
         Environment.TEST,
         [Level.NATIONAL],
         TIMESPAN.start,
-        TIMESPAN.period.value,
+        TIMESPAN.period,
         persist=True,
     )
     with indicators_db_engine.connect() as connection:

--- a/src/prefect/tests/infrastructure/test_t1.py
+++ b/src/prefect/tests/infrastructure/test_t1.py
@@ -69,8 +69,8 @@ def test_flow_t1_national(db_connection):
     assert indicators["value"].sum() == expected
 
 
-def test_flow_t1_calculate():
-    """Test the `calculate` flow."""
+def test_flow_t1():
+    """Test the `t1` flow."""
     all_levels = [
         Level.NATIONAL,
         Level.REGION,
@@ -78,23 +78,23 @@ def test_flow_t1_calculate():
         Level.CITY,
         Level.EPCI,
     ]
-    indicators = t1.calculate(
+    indicators = t1.t1(
         Environment.TEST,
         all_levels,
         TIMESPAN.start,
-        TIMESPAN.period.value,
+        TIMESPAN.period,
         create_artifact=True,
     )
     assert list(indicators["level"].unique()) == all_levels
 
 
-def test_flow_calculate_persistence(indicators_db_engine):
-    """Test the `calculate` flow."""
-    indicators = t1.calculate(
+def test_flow_t1_persistence(indicators_db_engine):
+    """Test the `t1` flow."""
+    indicators = t1.t1(
         Environment.TEST,
         [Level.NATIONAL],
         TIMESPAN.start,
-        TIMESPAN.period.value,
+        TIMESPAN.period,
         persist=True,
     )
 


### PR DESCRIPTION
## Purpose

Calculate is too generic and confusing in the Prefect UI. We should have a more explicit name for our flows.

## Proposal

- [x] rename meta-flows by their indicator code
