### PR TITLE
🚀(project) configure uv link mode to "copy"

### DIFF
--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
 
 [tool.uv]
 package = true
+link-mode = "copy"
 
 [[tool.uv.index]]
 name = "pypi"

--- a/src/client/pyproject.toml
+++ b/src/client/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
 
 [tool.uv]
 package = true
+link-mode = "copy"
 
 [[tool.uv.index]]
 name = "pypi"

--- a/src/dashboard/pyproject.toml
+++ b/src/dashboard/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
 
 [tool.uv]
 package = true
+link-mode = "copy"
 
 [[tool.uv.index]]
 name = "pypi"

--- a/src/opendata/pyproject.toml
+++ b/src/opendata/pyproject.toml
@@ -14,3 +14,6 @@ dependencies = [
 dev = [
     "honcho==2.0.0",
 ]
+
+[tool.uv]
+link-mode = "copy"

--- a/src/prefect/pyproject.toml
+++ b/src/prefect/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
 
 [tool.uv]
 package = true
+link-mode = "copy"
 
 [[tool.uv.index]]
 name = "pypi"


### PR DESCRIPTION
## Purpose

When deploying a new Prefect release, we often encounter cache issues with the UI assets that are not found; leading to a blank page when trying to access the service.

## Proposal

To prevent cache issues when deploying to Scalingo using UV, it is recommended to use the "copy" link-mode (hard-linking also fails on Scalingo).

References:

1. https://github.com/PrefectHQ/prefect/issues/10452
2. https://docs.astral.sh/uv/reference/settings/#link-mode
