### PR TITLE
🐛(prefect:tiruert) add support for empty response from CARBURE API

### DIFF
--- a/src/prefect/tests/tiruert/test_carbure.py
+++ b/src/prefect/tests/tiruert/test_carbure.py
@@ -156,10 +156,6 @@ def test_carbure_bulk_create_certificates(responses, carbure_client):
     responses.post(
         f"{carbure_client.root_url}api/elec/provision-certificates-qualicharge/bulk-create/",
         status=201,
-        json={
-            "status": "success",
-            "errors": [],
-        },
     )
     carbure_client.bulk_create_certificates(certificates)
 

--- a/src/prefect/tests/tiruert/test_submit.py
+++ b/src/prefect/tests/tiruert/test_submit.py
@@ -201,10 +201,6 @@ def test_task_submit(responses):
     responses.post(
         "http://localhost:8088/api/elec/provision-certificates-qualicharge/bulk-create/",
         status=201,
-        json={
-            "status": "success",
-            "errors": [],
-        },
     )
     result = tiruert_submit.submit(payload, "891118473", date(2024, 12, 1))
     assert (
@@ -238,10 +234,6 @@ def test_flow_tiruert_for_month_and_amenageur(indicators_db_engine, responses):
     responses.post(
         "http://localhost:8088/api/elec/provision-certificates-qualicharge/bulk-create/",
         status=201,
-        json={
-            "status": "success",
-            "errors": [],
-        },
     )
     tiruert_submit.tiruert_for_month_and_amenageur(
         Environment.TEST, year=2024, month=12, siren="891118473"
@@ -275,8 +267,8 @@ def test_flow_tiruert_for_month_and_amenageur_failed_submission(
         "http://localhost:8088/api/elec/provision-certificates-qualicharge/bulk-create/",
         status=400,
         json={
-            "status": "success",
-            "errors": [],
+            "status": "validation_error",
+            "errors": ["Misc"],
         },
     )
     tiruert_submit.tiruert_for_month_and_amenageur(
@@ -307,10 +299,6 @@ def test_flow_tiruert_for_month(indicators_db_engine, responses, monkeypatch):
     responses.post(
         "http://localhost:8088/api/elec/provision-certificates-qualicharge/bulk-create/",
         status=201,
-        json={
-            "status": "success",
-            "errors": [],
-        },
     )
 
     # Pretend to have only two amenageurs to speed up test execution

--- a/src/prefect/tiruert/carbure.py
+++ b/src/prefect/tiruert/carbure.py
@@ -54,7 +54,7 @@ class CarbureClient:
         method: str,
         endpoint: str,
         payload: Optional[dict | List[dict]] = None,
-    ) -> dict | List[dict]:
+    ) -> dict | List[dict] | None:
         """Perform an API request."""
         url = urljoin(str(self.root_url), endpoint)
 
@@ -74,7 +74,7 @@ class CarbureClient:
             logger.error(f"[HTTP {response.status_code}] {response.text}")
 
         response.raise_for_status()
-        return response.json()
+        return response.json() if response.text else None
 
     def _auth(self) -> None:
         """Authenticate to the Carbure API."""


### PR DESCRIPTION
## Purpose

CARBURE API response body is empty when submitted certificates have been validated.

## Proposal

- [x] fix mocked responses in tests
- [x] add support for API empty responses
