### PR TITLE
🐛(api) restrict offset & limit allowed values in statique list pagination

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to
 
 ### Fixed 
 
+- Restrict `offset` and `limit` allowed values in statique list pagination
 - Restore orphan stations cleanup
 
 ## [0.30.0] - 2025-10-31

--- a/src/api/qualicharge/api/v1/routers/static.py
+++ b/src/api/qualicharge/api/v1/routers/static.py
@@ -109,10 +109,14 @@ BulkStatiqueList = Annotated[
 async def list(
     user: Annotated[User, Security(get_user, scopes=[ScopesEnum.STATIC_READ.value])],
     request: Request,
-    offset: int = 0,
+    offset: int = Query(
+        default=0,
+        ge=0,
+    ),
     limit: int = Query(
         default=settings.API_STATIQUE_PAGE_SIZE,
         le=settings.API_STATIQUE_PAGE_MAX_SIZE,
+        ge=0,
     ),
     session: Session = Depends(get_session),
 ) -> PaginatedStatiqueListResponse:

--- a/src/api/tests/api/v1/routers/test_statique.py
+++ b/src/api/tests/api/v1/routers/test_statique.py
@@ -292,6 +292,12 @@ def test_list_pagination(client_auth, db_session):
     save_statiques(db_session, StatiqueFactory.batch(n_statiques))
     refresh_materialized_view(db_session, STATIQUE_MV_TABLE_NAME)
 
+    # Invalid limit or offset
+    for offset, limit in ((0, -2), (-1, 0), (-3, -3)):
+        response = client_auth.get(f"/statique/?{offset=}&{limit=}")
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    # Two pages
     offset = 0
     limit = 2
     response = client_auth.get(f"/statique/?{offset=}&{limit=}")


### PR DESCRIPTION
## Purpose

Negative values for offset or limit statique list pagination parameters should not be allowed.

## Proposal

- [x] fix query parameters range
