### PR TITLE
🔖(api:patch) bump release to 0.30.1

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.30.1] - 2025-11-24
+
 ### Changed
 
 - Update the list of active operational units
@@ -633,7 +635,8 @@ update` command
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.30.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.30.1...main
+[0.30.1]: https://github.com/MTES-MCT/qualicharge/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.27.0...v0.28.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qualicharge"
-version = "0.30.0"
+version = "0.30.1"
 requires-python = "~=3.12.0"
 dependencies = [
     "alembic==1.17.2",

--- a/src/api/qualicharge/__init__.py
+++ b/src/api/qualicharge/__init__.py
@@ -1,3 +1,3 @@
 """QualiCharge package root."""
 
-__version__ = "0.30.0"
+__version__ = "0.30.1"

--- a/src/api/uv.lock
+++ b/src/api/uv.lock
@@ -1518,7 +1518,7 @@ wheels = [
 
 [[package]]
 name = "qualicharge"
-version = "0.30.0"
+version = "0.30.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
### Changed

- Update the list of active operational units

#### Dependencies

- Upgrade `alembic` to `1.17.2`
- Upgrade `cachetools` to `6.2.2`
- Upgrade `fastapi` to `0.121.3`
- Upgrade `psycopg` to `3.2.12`
- Upgrade `pyarrow` to `22.0.0`
- Upgrade `pydantic-settings` to `2.12.0`
- Upgrade `sentry-sdk` to `2.45.0`

### Fixed

- Restrict `offset` and `limit` allowed values in statique list pagination
- Restore orphan stations cleanup
