### PR TITLE
🔧(prefect) rollback uv link-mode

### DIFF
--- a/src/prefect/pyproject.toml
+++ b/src/prefect/pyproject.toml
@@ -42,7 +42,6 @@ dev = [
 
 [tool.uv]
 package = true
-link-mode = "copy"
 
 [[tool.uv.index]]
 name = "pypi"


### PR DESCRIPTION
## Purpose

We investigate why the build size increased by 700Mo and prevent us from deploying to Scalingo as the container size is higher than the 1.5Gb limit.

## Proposal

Looks like uv default link mode (hard link) fixes the issue.
