### PR TITLE
✨(dashboard) add contact link configuration to settings and templates

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -57,6 +57,7 @@ jobs:
       DASHBOARD_CONTROL_AUTHORITY_EMAIL: jdoe@exemple.com
       DASHBOARD_CONSENT_SIGNATURE_LOCATION: Paris
       DASHBOARD_CONTACT_EMAIL: contact@exemple.com
+      DASHBOARD_CONTACT_LINK: https://www.qualicharge.beta.gouv.fr/contact/
       DASHBOARD_DEFAULT_FROM_EMAIL: contact@exemple.com
       DASHBOARD_BREVO_API_KEY: the_secret_api_key
       DASHBOARD_CONSENT_VALIDATION_TEMPLATE_ID: 3
@@ -153,6 +154,7 @@ jobs:
           DASHBOARD_CONTROL_AUTHORITY_EMAIL: jdoe@exemple.com
           DASHBOARD_CONSENT_SIGNATURE_LOCATION: Paris
           DASHBOARD_CONTACT_EMAIL: contact@exemple.com
+          DASHBOARD_CONTACT_LINK: https://www.qualicharge.beta.gouv.fr/contact/
           DASHBOARD_DEFAULT_FROM_EMAIL: contact@exemple.com
           DASHBOARD_BREVO_API_KEY: the_secret_api_key
           DASHBOARD_CONSENT_VALIDATION_TEMPLATE_ID: 3

--- a/env.d/dashboard
+++ b/env.d/dashboard
@@ -54,6 +54,7 @@ DASHBOARD_RENEWABLE_OPENING_PERIOD_DAYS=15
 
 # Email to contact the QualiCharge team
 DASHBOARD_CONTACT_EMAIL=contact@exemple.com
+DASHBOARD_CONTACT_LINK=https://www.qualicharge.beta.gouv.fr/contact/
 DASHBOARD_DEFAULT_FROM_EMAIL=no-reply@qualicharge.beta.gouv.fr
 
 # Brevo Emailing

--- a/src/dashboard/apps/auth/mails.py
+++ b/src/dashboard/apps/auth/mails.py
@@ -32,6 +32,7 @@ def send_validation_email(users) -> None:
             "first_name": user.first_name,  # type: ignore[union-attr]
             "link": email_config.get("link"),
             "support_email": settings.CONTACT_EMAIL,
+            "support_link": settings.CONTACT_LINK,
         }
 
     email = AnymailMessage(

--- a/src/dashboard/apps/auth/templates/auth/user_not_validated.html
+++ b/src/dashboard/apps/auth/templates/auth/user_not_validated.html
@@ -28,9 +28,7 @@
 
           <ul class="fr-btns-group fr-btns-group--inline-md">
             <li>
-              <a class="fr-btn fr-btn--secondary" href="mailto:{{ contact_email }}" target="_blank">
-                {% trans "Contact us" %}
-              </a>
+              {% include "components/_contact_link.html" with link_style="btn" %}
             </li>
           </ul>
 

--- a/src/dashboard/apps/auth/tests/test_mails.py
+++ b/src/dashboard/apps/auth/tests/test_mails.py
@@ -32,6 +32,7 @@ def test_send_validation_email_success():
                     "first_name": user1.first_name,
                     "link": expected_email_config.get("link"),
                     "support_email": settings.CONTACT_EMAIL,
+                    "support_link": settings.CONTACT_LINK,
                 },
             },
         )
@@ -56,12 +57,14 @@ def test_send_validation_email_success():
                     "first_name": user1.first_name,
                     "link": expected_email_config.get("link"),
                     "support_email": settings.CONTACT_EMAIL,
+                    "support_link": settings.CONTACT_LINK,
                 },
                 "user2@example.com": {
                     "last_name": user2.last_name,
                     "first_name": user2.first_name,
                     "link": expected_email_config.get("link"),
                     "support_email": settings.CONTACT_EMAIL,
+                    "support_link": settings.CONTACT_LINK,
                 },
             },
         )

--- a/src/dashboard/apps/consent/helpers.py
+++ b/src/dashboard/apps/consent/helpers.py
@@ -56,6 +56,7 @@ def send_notification_for_awaiting_consents(entity: Entity) -> None:
             "first_name": user.first_name,
             "link": email_config.get("link"),
             "support_email": settings.CONTACT_EMAIL,
+            "support_link": settings.CONTACT_LINK,
         }
 
     send_mail(recipients, template_id, email_data)

--- a/src/dashboard/apps/consent/templates/consent/includes/_manage_company_informations.html
+++ b/src/dashboard/apps/consent/templates/consent/includes/_manage_company_informations.html
@@ -16,10 +16,7 @@
     signataire du présent formulaire.
     <br />
     En cas d'informations erronées, merci de nous contacter :
-    <a class="fr-link fr-link--icon-left fr-icon-mail-line"
-       href="mailto:{{ contact_email }}?subject=[QualiCharge] Informations erronées dans le formulaire de gestion des autorisations" target="_blank">
-      {{ contact_email }}
-    </a>
+    {% include "components/_contact_link.html" %}
   </p>
 
   {% with row_number=0 %}

--- a/src/dashboard/apps/consent/templates/consent/includes/_no_data_card.html
+++ b/src/dashboard/apps/consent/templates/consent/includes/_no_data_card.html
@@ -3,9 +3,6 @@
     {{ description }}
     <br />
     Si vous pensez qu'il s'agit d'une erreur, merci de contacter l'équipe QualiCharge.
-    <a class="fr-link fr-card__desc"
-      href="mailto:{{ contact_email }}?subject=[QualiCharge] Dashboard - {{ description }}." target="_blank">
-      {{ contact_email }}
-    </a>
+    {% include "components/_contact_link.html" %}
   </p>
 </div>

--- a/src/dashboard/apps/consent/tests/test_helpers.py
+++ b/src/dashboard/apps/consent/tests/test_helpers.py
@@ -26,9 +26,11 @@ def test_send_notification_for_awaiting_consents(mock_send_mail, settings):
     expected_template_id = 6
     expected_link = "https://example.com/consent"
     expected_support = "support@example.com"
+    expected_support_link = "https://example.com/contact/"
 
     # setup email config
     settings.CONTACT_EMAIL = expected_support
+    settings.CONTACT_LINK = expected_support_link
     settings.DASHBOARD_EMAIL_AWAITING_EMAIL = "awaiting_email"
     settings.DASHBOARD_EMAIL_CONFIGS = {
         "awaiting_email": {
@@ -63,6 +65,7 @@ def test_send_notification_for_awaiting_consents(mock_send_mail, settings):
                     "first_name": user.first_name,
                     "link": expected_link,
                     "support_email": expected_support,
+                    "support_link": expected_support_link,
                 }
             },
         )

--- a/src/dashboard/apps/core/context_processors.py
+++ b/src/dashboard/apps/core/context_processors.py
@@ -6,3 +6,8 @@ from django.conf import settings
 def contact_email(request):
     """Context processor to add CONTACT_EMAIL to the context."""
     return {"contact_email": settings.CONTACT_EMAIL}
+
+
+def contact_link(request):
+    """Context processor to add CONTACT_LINK to the context."""
+    return {"contact_link": settings.CONTACT_LINK}

--- a/src/dashboard/apps/renewable/helpers.py
+++ b/src/dashboard/apps/renewable/helpers.py
@@ -73,6 +73,7 @@ def send_notification_for_opening(entity: Entity) -> None:
             "first_name": user.first_name,
             "link": email_config.get("link"),
             "support_email": settings.CONTACT_EMAIL,
+            "support_link": settings.CONTACT_LINK,
             "start_period": start_period.strftime("%d/%m/%Y"),
             "end_period": end_period.strftime("%d/%m/%Y"),
         }

--- a/src/dashboard/apps/renewable/templates/renewable/includes/_no_data_card.html
+++ b/src/dashboard/apps/renewable/templates/renewable/includes/_no_data_card.html
@@ -3,9 +3,6 @@
     {{ description }}
     <br />
     Si vous pensez qu'il s'agit d'une erreur, merci de contacter l'équipe QualiCharge.
-    <a class="fr-link fr-card__desc"
-      href="mailto:{{ contact_email }}?subject=[QualiCharge] Dashboard - {{ description }}." target="_blank">
-      {{ contact_email }}
-    </a>
+    {% include "components/_contact_link.html" %}
   </p>
 </div>

--- a/src/dashboard/apps/renewable/templates/renewable/restricted_period.html
+++ b/src/dashboard/apps/renewable/templates/renewable/restricted_period.html
@@ -28,9 +28,7 @@
 
           <ul class="fr-btns-group fr-btns-group--inline-md">
             <li>
-              <a class="fr-btn fr-btn--secondary" href="mailto:{{ contact_email }}" target="_blank">
-                {% trans "Contact us" %}
-              </a>
+              {% include "components/_contact_link.html" with style_link="btn" %}
             </li>
           </ul>
 

--- a/src/dashboard/apps/renewable/tests/test_helpers.py
+++ b/src/dashboard/apps/renewable/tests/test_helpers.py
@@ -78,9 +78,11 @@ def test_send_notification_for_opening(settings, monkeypatch):
     expected_template_id = 8
     expected_link = "https://example.com/consent"
     expected_support = "support@example.com"
+    expected_support_link = "https://example.com/contact"
 
     # setup email config
     settings.CONTACT_EMAIL = expected_support
+    settings.CONTACT_LINK = expected_support_link
     settings.DASHBOARD_EMAIL_RENEWABLE_OPENING_PERIOD = "renewable_opening_period"
     settings.DASHBOARD_EMAIL_CONFIGS = {
         "renewable_opening_period": {
@@ -117,6 +119,7 @@ def test_send_notification_for_opening(settings, monkeypatch):
                     "first_name": user.first_name,
                     "link": expected_link,
                     "support_email": expected_support,
+                    "support_link": expected_support_link,
                     "start_period": "01/01/2025",
                     "end_period": "15/01/2025",
                 }

--- a/src/dashboard/dashboard/settings.py
+++ b/src/dashboard/dashboard/settings.py
@@ -97,6 +97,7 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "dsfr.context_processors.site_config",
                 "apps.core.context_processors.contact_email",
+                "apps.core.context_processors.contact_link",
             ],
         },
     },
@@ -265,6 +266,11 @@ RENEWABLE_OPENING_PERIOD_DAYS = env.int("RENEWABLE_OPENING_PERIOD_DAYS")
 
 # Email to contact the QualiCharge team
 CONTACT_EMAIL = env.str("CONTACT_EMAIL")
+
+# Link to the contact page to contact the QualiCharge team
+CONTACT_LINK = env.str(
+    "CONTACT_LINK", default="https://www.qualicharge.beta.gouv.fr/contact/"
+)
 
 # Configuration of Anymail for Brevo
 EMAIL_BACKEND = "anymail.backends.sendinblue.EmailBackend"

--- a/src/dashboard/templates/403.html
+++ b/src/dashboard/templates/403.html
@@ -31,9 +31,7 @@
           </li>
 
           <li>
-            <a class="fr-btn fr-btn--secondary" href="mailto:{{ contact_email }}" target="_blank">
-              {% trans "Contact us" %}
-            </a>
+            {% include "components/_contact_link.html" with link_style="btn" %}
           </li>
         </ul>
 

--- a/src/dashboard/templates/404.html
+++ b/src/dashboard/templates/404.html
@@ -30,9 +30,7 @@
           </li>
 
           <li>
-            <a class="fr-btn fr-btn--secondary" href="mailto:{{ contact_email }}" target="_blank">
-              {% trans "Contact us" %}
-            </a>
+            {% include "components/_contact_link.html" with link_style="btn" %}
           </li>
         </ul>
       </div>

--- a/src/dashboard/templates/500.html
+++ b/src/dashboard/templates/500.html
@@ -24,9 +24,7 @@
 
         <ul class="fr-btns-group fr-btns-group--inline-md">
           <li>
-            <a class="fr-btn fr-btn--secondary" href="mailto:{{ contact_email }}" target="_blank">
-              {% trans "Contact us" %}
-            </a>
+            {% include "components/_contact_link.html" with link_style="btn" %}
           </li>
         </ul>
       </div>

--- a/src/dashboard/templates/components/_contact_link.html
+++ b/src/dashboard/templates/components/_contact_link.html
@@ -1,0 +1,30 @@
+{% load i18n %}
+
+{% comment %}
+  option :
+    link_style="btn"
+
+  usage with a link to a form:
+  {% include "components/_contact_link.html" %}
+
+  usage with a mailto link :
+  {% include "components/_contact_link.html" with link_type="mailto" object="subject of the email" %}
+
+  Optionally, you can display the link as a button with link_style="btn".
+  {% include "components/_contact_link.html" with link_style="btn" %}
+{% endcomment %}
+
+{% with link_classes=link_style|yesno:"fr-btn fr-btn--secondary,fr-link fr-card__desc" %}
+
+  {% if link_type == "mailto" %}
+    <a class="{{ link_classes }}"
+      href="mailto:{{ contact_email }}?subject=[QualiCharge] Dashboard - {{ object }}." target="_blank">
+      {{ contact_email }}
+    </a>
+  {% else %}
+    <a class="{{ link_classes }}" href="{{ contact_link }}" target="_blank">
+      {% trans "Contact us" %}
+    </a>
+  {% endif %}
+
+{% endwith %}


### PR DESCRIPTION
## Description

The `contact links` in the `dashboard` and emails should no longer point to a `mailto` but to a contact form.

## Proposal

- [x]  add `CONTACT_LINK` to the `settings` and `environment variables`
- [x]  add a new `support_link` parameter when sending emails to display the link in the emails
- [x] add a `context processor` to access `contact_link` in templates
- [x] add a `_contact_link.html `component to simplify integration of the new link
- [x] update the templates accordingly
- [x] update the changelog