### PR TITLE
🚑️(dashboard) update DEBUG setting to use boolean type

### DIFF
--- a/src/dashboard/CHANGELOG.md
+++ b/src/dashboard/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to
 ## Fixed
 
 - Fix static file path formatting (remove leading "/" in template paths)
+- Fix DEBUG setting to use boolean type
 
 ## [0.2.0] - 2025-06-23
 

--- a/src/dashboard/dashboard/settings.py
+++ b/src/dashboard/dashboard/settings.py
@@ -40,7 +40,7 @@ env.prefix = "DASHBOARD_"
 SECRET_KEY = env.str("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = env.str("DEBUG")
+DEBUG = env.bool("DEBUG")
 
 #'DASHBOARD_ALLOWED_HOSTS' should be a single string of hosts with a space between each.
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")


### PR DESCRIPTION
## Description

Adjusted the `DEBUG` environment variable parsing from string to boolean using `env.bool()` for better type consistency.