### PR TITLE
🔖(prefect) extend volume indicators to OpertionalUnit level

### DIFF
--- a/src/prefect/CHANGELOG.md
+++ b/src/prefect/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 - Implement extract indicators (e4)
 - Implement historicization (up)
 - Implement usage indicators (u5, u6, u9, u10, u11, u12, u13)
+- Add usage indicator u14
 
 #### Quality
 
@@ -55,5 +56,6 @@ and this project adheres to
   - ENEA : add power threshold
   - LONS : extend threshold to 7 days
   - ERRT : add 'inconnu' statuses
+- Add OperationalUnit level for infrastructure and usage indicators
 
 [unreleased]: https://github.com/MTES-MCT/qualicharge/

--- a/src/prefect/indicators/extract/e4.py
+++ b/src/prefect/indicators/extract/e4.py
@@ -30,20 +30,17 @@ from indicators.utils import (
 HISTORY_STRATEGY_FIELD: str = "mean"
 LIST_POCS_FOR_LEVEL_QUERY_TEMPLATE = """
 SELECT
-    id_pdc_itinerance,
+    statique.id_pdc_itinerance,
     $level_id AS level_id
 FROM
     SESSION
-    INNER JOIN PointDeCharge ON point_de_charge_id = PointDeCharge.id
-    LEFT JOIN station ON station_id = station.id
-    LEFT JOIN localisation ON localisation_id = localisation.id
-    LEFT JOIN city ON city.code = code_insee_commune
+    INNER JOIN statique ON point_de_charge_id = pdc_id
     $join_extras
 WHERE
     $level_id IN ($indexes)
     AND $timespan
 GROUP BY
-    id_pdc_itinerance,
+    statique.id_pdc_itinerance,
     $level_id
 """
 QUERY_NATIONAL_TEMPLATE = """

--- a/src/prefect/indicators/infrastructure/i1.py
+++ b/src/prefect/indicators/infrastructure/i1.py
@@ -30,11 +30,10 @@ from indicators.utils import (
 HISTORY_STRATEGY_FIELD: str = "mean"
 NUM_POCS_FOR_LEVEL_QUERY_TEMPLATE = """
 SELECT
-    COUNT(DISTINCT id_pdc_itinerance) AS value,
+    COUNT(DISTINCT statique.id_pdc_itinerance) AS value,
     $level_id AS level_id
 FROM
     Statique
-    INNER JOIN City ON code_insee_commune = City.code
     $join_extras
 WHERE $level_id IN ($indexes)
 GROUP BY $level_id

--- a/src/prefect/indicators/infrastructure/i4.py
+++ b/src/prefect/indicators/infrastructure/i4.py
@@ -30,11 +30,10 @@ from indicators.utils import (
 HISTORY_STRATEGY_FIELD: str = "mean"
 NUM_STATIONS_FOR_LEVEL_QUERY_TEMPLATE = """
 SELECT
-    COUNT(DISTINCT id_station_itinerance) AS value,
+    COUNT(DISTINCT Statique.id_station_itinerance) AS value,
     $level_id AS level_id
 FROM
     Statique
-    INNER JOIN City ON code_insee_commune = City.code
     $join_extras
 WHERE $level_id IN ($indexes)
 GROUP BY $level_id

--- a/src/prefect/indicators/infrastructure/i7.py
+++ b/src/prefect/indicators/infrastructure/i7.py
@@ -30,11 +30,10 @@ from indicators.utils import (
 HISTORY_STRATEGY_FIELD: str = "mean"
 SUM_POWER_FOR_LEVEL_QUERY_TEMPLATE = """
 SELECT
-    sum(puissance_nominale) AS value,
+    sum(statique.puissance_nominale) AS value,
     $level_id AS level_id
 FROM
     statique
-    INNER JOIN city on city.code = code_insee_commune
     $join_extras
 WHERE $level_id IN ($indexes)
 GROUP BY $level_id

--- a/src/prefect/indicators/infrastructure/t1.py
+++ b/src/prefect/indicators/infrastructure/t1.py
@@ -31,12 +31,11 @@ NUM_POCS_BY_POWER_RANGE_FOR_LEVEL_QUERY_TEMPLATE = """
 WITH
     $power_range
 SELECT
-    COUNT(DISTINCT id_pdc_itinerance) AS value,
+    COUNT(DISTINCT Statique.id_pdc_itinerance) AS value,
     category,
     $level_id AS level_id
 FROM
     Statique
-    INNER JOIN City ON code_insee_commune = City.code
     LEFT JOIN puissance ON puissance_nominale::numeric <@ category
     $join_extras
 WHERE
@@ -51,7 +50,7 @@ QUERY_NATIONAL_TEMPLATE = """
 WITH
     $power_range
 SELECT
-    COUNT(DISTINCT id_pdc_itinerance) AS value,
+    COUNT(DISTINCT Statique.id_pdc_itinerance) AS value,
     category
 FROM
     Statique

--- a/src/prefect/indicators/models.py
+++ b/src/prefect/indicators/models.py
@@ -16,7 +16,7 @@ class Level(IntEnum):
     DEPARTMENT = 2
     EPCI = 3
     CITY = 4
-    OU = 5  # Operational Unit
+    OPERATIONALUNIT = 5  # Operational Unit
     AMENAGEUR = 6
 
 

--- a/src/prefect/indicators/run.py
+++ b/src/prefect/indicators/run.py
@@ -22,3 +22,4 @@ from .usage.u10 import u10
 from .usage.u11 import u11
 from .usage.u12 import u12
 from .usage.u13 import u13
+from .usage.u14 import u14

--- a/src/prefect/indicators/strategy.py
+++ b/src/prefect/indicators/strategy.py
@@ -20,6 +20,7 @@ from .usage.u10 import HISTORY_STRATEGY_FIELD as U10_STRATEGY
 from .usage.u11 import HISTORY_STRATEGY_FIELD as U11_STRATEGY
 from .usage.u12 import HISTORY_STRATEGY_FIELD as U12_STRATEGY
 from .usage.u13 import HISTORY_STRATEGY_FIELD as U13_STRATEGY
+from .usage.u14 import HISTORY_STRATEGY_FIELD as U14_STRATEGY
 
 STRATEGY = {
     "i1": I1_STRATEGY,
@@ -34,5 +35,6 @@ STRATEGY = {
     "u11": U11_STRATEGY,
     "u12": U12_STRATEGY,
     "u13": U13_STRATEGY,
+    "u14": U14_STRATEGY,
     "qua": QUA_STRATEGY,
 }

--- a/src/prefect/indicators/usage/u11.py
+++ b/src/prefect/indicators/usage/u11.py
@@ -34,7 +34,6 @@ SELECT
 FROM
     SESSION
     INNER JOIN statique ON point_de_charge_id = pdc_id
-    LEFT JOIN City ON City.code = code_insee_commune
     $join_extras
 WHERE
     $timespan

--- a/src/prefect/indicators/usage/u12.py
+++ b/src/prefect/indicators/usage/u12.py
@@ -48,7 +48,6 @@ SELECT
 FROM
     filtered_status
     INNER JOIN statique ON point_de_charge_id = pdc_id
-    LEFT JOIN City ON City.code = code_insee_commune
     LEFT JOIN puissance ON puissance_nominale::numeric <@ category
     $join_extras
 WHERE

--- a/src/prefect/indicators/usage/u13.py
+++ b/src/prefect/indicators/usage/u13.py
@@ -41,12 +41,11 @@ WITH
             point_de_charge_id
     )
 SELECT
-    sum(puissance_nominale) AS value,
+    sum(statique.puissance_nominale) AS value,
     $level_id AS level_id
 FROM
     fitered_status
     INNER JOIN statique ON point_de_charge_id = pdc_id
-    LEFT JOIN City ON City.code = code_insee_commune
     $join_extras
 WHERE
     $level_id IN ($indexes)

--- a/src/prefect/indicators/usage/u14.py
+++ b/src/prefect/indicators/usage/u14.py
@@ -1,6 +1,6 @@
 """QualiCharge prefect indicators: usage.
 
-U10: the number of sessions.
+U14: energy by unit code and by delivery (direct/indirect, AC/DC, valid/invalid PDL).
 """
 
 from datetime import datetime
@@ -19,6 +19,9 @@ from indicators.db import get_api_db_engine
 from indicators.models import IndicatorPeriod, IndicatorTimeSpan, Level
 from indicators.types import Environment
 from indicators.utils import (
+    ALIMENTATION,
+    IS_DC,
+    IS_VALID_PDL,
     export_indicators,
     get_num_for_level_query_params,
     get_period_start_from_pit,
@@ -27,27 +30,129 @@ from indicators.utils import (
 )
 
 HISTORY_STRATEGY_FIELD: str = "mean"
-NUM_SESSIONS_FOR_LEVEL_QUERY_TEMPLATE = """
+ENERGY_BY_DELIVERY_TEMPLATE = """
+WITH
+  Stations AS (
+    SELECT
+      Station.id,
+      operational_unit_id,
+      code_insee_commune,
+      raccordement = 'Direct' AS is_direct,
+      $is_valid_pdl AS is_valid_pdl,
+      $is_dc AS is_dc
+    FROM
+      Pointdecharge
+      LEFT JOIN Station ON Station.id = station_id
+      LEFT JOIN Localisation ON Localisation.id = localisation_id
+    GROUP BY
+      station.id,
+      code_insee_commune,
+      operational_unit_id,
+      is_direct,
+      is_valid_pdl
+  ),
+  Statiques AS (
+    SELECT
+      code,
+      $alimentation AS alimentation,
+      Pointdecharge.id AS pdc_id,
+      code_insee_commune,
+      puissance_nominale
+    FROM
+      Pointdecharge
+      LEFT JOIN Stations ON stations.id = station_id
+      LEFT JOIN Operationalunit ON operational_unit_id = Operationalunit.id
+  ),
+  Sessions_uniques AS (
+    SELECT
+      max(energy) AS max_energy_kwh,
+      point_de_charge_id
+    FROM
+      SESSION
+      INNER JOIN Statiques ON point_de_charge_id = Statiques.pdc_id
+    WHERE
+      $timespan
+      AND energy < 1.1 * puissance_nominale * EXTRACT(
+          EPOCH FROM (Session.end - Session.start)
+        ) / 3600
+    GROUP BY
+      START,
+      SESSION.end,
+      point_de_charge_id
+  )
 SELECT
-    count(*) AS value,
-    $level_id AS level_id
+  $level_id AS level_id,
+  alimentation AS category,
+  sum(max_energy_kwh) AS VALUE
 FROM
-    SESSION
-    INNER JOIN statique ON point_de_charge_id = pdc_id
-    $join_extras
+  Sessions_uniques
+  INNER JOIN Statiques ON point_de_charge_id = Statiques.pdc_id
+  $join_extras
 WHERE
-    $timespan
-    AND $level_id IN ($indexes)
-GROUP BY $level_id
+    $level_id IN ($indexes)
+GROUP BY
+  $level_id,
+  category
 """
 
 QUERY_NATIONAL_TEMPLATE = """
+WITH
+  Stations AS (
+    SELECT
+      Station.id,
+      id_station_itinerance,
+      operational_unit_id,
+      code_insee_commune,
+      raccordement = 'Direct' AS is_direct,
+      $is_valid_pdl AS is_valid_pdl,
+      $is_dc AS is_dc
+    FROM
+      Pointdecharge
+      LEFT JOIN Station ON Station.id = station_id
+      LEFT JOIN Localisation ON Localisation.id = localisation_id
+    GROUP BY
+      Station.id,
+      id_station_itinerance,
+      code_insee_commune,
+      operational_unit_id,
+      is_direct,
+      is_valid_pdl
+  ),
+  Statiques AS (
+    SELECT
+      $alimentation AS alimentation,
+      Pointdecharge.id AS pdc_id,
+      station_id,
+      puissance_nominale
+    FROM
+      Pointdecharge
+      LEFT JOIN Stations ON stations.id = station_id
+  ),
+  Sessions_uniques AS (
+    SELECT
+      max(energy) AS max_energy_kwh,
+      point_de_charge_id
+    FROM
+      SESSION
+      INNER JOIN Statiques ON point_de_charge_id = Statiques.pdc_id
+    WHERE
+      $timespan
+      AND energy < 1.1 * puissance_nominale * EXTRACT(
+          EPOCH FROM (Session.end - Session.start)
+        ) / 3600
+    GROUP BY
+      START,
+      SESSION.end,
+      point_de_charge_id
+  )
 SELECT
-    count(*) AS value
+  alimentation AS category,
+  sum(max_energy_kwh) AS VALUE
 FROM
-    SESSION
-WHERE
-    $timespan
+  Sessions_uniques
+  INNER JOIN Statiques ON point_de_charge_id = Statiques.pdc_id
+GROUP BY
+  category
 """
 
 
@@ -59,8 +164,9 @@ def get_values_for_targets(
     environment: Environment,
 ) -> pd.DataFrame:
     """Fetch sessions given input level, timestamp and target index."""
-    query_template = Template(NUM_SESSIONS_FOR_LEVEL_QUERY_TEMPLATE)
+    query_template = Template(ENERGY_BY_DELIVERY_TEMPLATE)
     query_params = {"indexes": ",".join(f"'{i}'" for i in map(str, indexes))}
+    query_params |= IS_VALID_PDL | IS_DC | ALIMENTATION
     query_params |= get_num_for_level_query_params(level)
     query_params |= get_timespan_filter_query_params(timespan, session=True)
     with Session(get_api_db_engine(environment)) as session:
@@ -70,17 +176,17 @@ def get_values_for_targets(
 
 
 @flow(
-    flow_run_name="u10-{timespan.period.value}-{level:02d}-{timespan.start:%y-%m-%d}",
+    flow_run_name="u14-{timespan.period.value}-{level:02d}-{timespan.start:%y-%m-%d}",
 )
-def u10_for_level(
+def u14_for_level(
     level: Level,
     timespan: IndicatorTimeSpan,
     environment: Environment,
     chunk_size: int = settings.DEFAULT_CHUNK_SIZE,
 ) -> pd.DataFrame:
-    """Calculate u10 for a level and a timestamp."""
+    """Calculate u14 for a level and a timestamp."""
     if level == Level.NATIONAL:
-        return u10_national(timespan, environment)
+        return u14_national(timespan, environment)
     targets = get_targets_for_level(level, environment)
     ids = targets["id"]
     chunks = (
@@ -102,23 +208,24 @@ def u10_for_level(
     indicators = {
         "target": merged["code"],
         "value": merged["value"].fillna(0),
-        "code": "u10",
+        "code": "u14",
         "level": level,
         "period": timespan.period,
         "timestamp": timespan.start.isoformat(),
-        "category": None,
+        "category": merged["category"],
         "extras": None,
     }
     return pd.DataFrame(indicators)
 
 
 @flow(
-    flow_run_name="u10-{timespan.period.value}-00-{timespan.start:%y-%m-%d}",
+    flow_run_name="u14-{timespan.period.value}-00-{timespan.start:%y-%m-%d}",
 )
-def u10_national(timespan: IndicatorTimeSpan, environment: Environment) -> pd.DataFrame:
-    """Calculate u10 at the national level."""
+def u14_national(timespan: IndicatorTimeSpan, environment: Environment) -> pd.DataFrame:
+    """Calculate u14 at the national level."""
     query_template = Template(QUERY_NATIONAL_TEMPLATE)
     query_params = get_timespan_filter_query_params(timespan, session=True)
+    query_params |= IS_VALID_PDL | IS_DC | ALIMENTATION
     with Session(get_api_db_engine(environment)) as session:
         result = pd.read_sql_query(
             query_template.substitute(query_params), con=session.connection()
@@ -126,20 +233,20 @@ def u10_national(timespan: IndicatorTimeSpan, environment: Environment) -> pd.Da
     indicators = {
         "target": "00",
         "value": result["value"].fillna(0),
-        "code": "u10",
+        "code": "u14",
         "level": Level.NATIONAL,
         "period": timespan.period,
         "timestamp": timespan.start.isoformat(),
-        "category": None,
+        "category": result["category"],
         "extras": None,
     }
     return pd.DataFrame(indicators)
 
 
 @flow(
-    flow_run_name="meta-u10-{period.value}",
+    flow_run_name="meta-u14-{period.value}",
 )
-def u10(  # noqa: PLR0913
+def u14(  # noqa: PLR0913
     environment: Environment,
     levels: List[Level],
     start: datetime | None = None,
@@ -149,7 +256,7 @@ def u10(  # noqa: PLR0913
     create_artifact: bool = False,
     persist: bool = False,
 ) -> pd.DataFrame:
-    """Run all u10 subflows."""
+    """Run all u14 subflows."""
     start = (
         datetime.now()
         if not offset and start is None
@@ -157,11 +264,11 @@ def u10(  # noqa: PLR0913
     )
     timespan = IndicatorTimeSpan(period=period, start=start)
     subflows_results = [
-        u10_for_level(level, timespan, environment, chunk_size=chunk_size)
+        u14_for_level(level, timespan, environment, chunk_size=chunk_size)
         for level in levels
     ]
     indicators = pd.concat(subflows_results, ignore_index=True)
-    description = f"u10 report at {timespan.start} (period: {timespan.period.value})"
+    description = f"u14 report at {timespan.start} (period: {timespan.period.value})"
     flow_name = runtime.flow_run.name
     export_indicators(
         indicators, environment, flow_name, description, create_artifact, persist

--- a/src/prefect/indicators/usage/u5.py
+++ b/src/prefect/indicators/usage/u5.py
@@ -35,7 +35,6 @@ SELECT
 FROM
     Session
     INNER JOIN statique ON point_de_charge_id = pdc_id
-    LEFT JOIN City ON City.code = code_insee_commune
     $join_extras
 WHERE
     $timespan

--- a/src/prefect/indicators/usage/u6.py
+++ b/src/prefect/indicators/usage/u6.py
@@ -49,7 +49,6 @@ SELECT
 FROM
     filtered_session
     INNER JOIN statique ON point_de_charge_id = pdc_id
-    LEFT JOIN City ON City.code = code_insee_commune
     LEFT JOIN puissance ON puissance_nominale::numeric <@ category
     $join_extras
 WHERE

--- a/src/prefect/indicators/usage/u9.py
+++ b/src/prefect/indicators/usage/u9.py
@@ -49,7 +49,6 @@ SELECT
 FROM
     fitered_session
     INNER JOIN statique ON point_de_charge_id = pdc_id
-    LEFT JOIN City ON City.code = code_insee_commune
     LEFT JOIN puissance ON puissance_nominale::numeric <@ category
     $join_extras
 WHERE

--- a/src/prefect/indicators/utils.py
+++ b/src/prefect/indicators/utils.py
@@ -27,6 +27,34 @@ POWER_RANGE_CTE: dict = {"power_range": """
             (numrange(150, 350.0), 5),
             (numrange(350, NULL), 6)
     )"""}
+IS_VALID_PDL: dict = {"is_valid_pdl": """
+    NOT (
+        num_pdl IS NULL
+        OR num_pdl LIKE '%% %%'
+        OR num_pdl LIKE '%%123456789%%'
+        OR num_pdl LIKE '000%%'
+        OR num_pdl IN ('', '11111111111111', '99999999999999')
+        OR num_pdl !~ '[0-9]'
+    )"""}
+IS_DC: dict = {"is_dc": """
+    max(
+      (
+        puissance_nominale >= 50
+        OR prise_type_combo_ccs
+        OR prise_type_chademo
+      ) :: int
+    ) :: bool
+"""}
+ALIMENTATION: dict = {"alimentation": """
+    CASE
+      WHEN is_dc AND is_direct AND is_valid_pdl THEN 'DC_direct_valid'
+      WHEN is_dc AND is_direct AND not is_valid_pdl THEN 'DC_direct_invalid'
+      WHEN is_dc AND not is_direct THEN 'DC_indirect'
+      WHEN NOT is_dc AND is_direct AND is_valid_pdl THEN 'AC_direct_valid'
+      WHEN NOT is_dc AND is_direct AND not is_valid_pdl THEN 'AC_direct_invalid'
+      ELSE 'AC_indirect'
+    END
+"""}
 
 
 def get_period_start_from_pit(  # noqa: PLR0911
@@ -74,16 +102,22 @@ def get_num_for_level_query_params(level: Level):
     """Get level_id and join_extras query parameters."""
     match level:
         case Level.CITY:
-            return {"level_id": "City.id", "join_extras": ""}
+            return {
+                "level_id": "City.id",
+                "join_extras": "INNER JOIN City ON code_insee_commune = City.code",
+            }
         case Level.EPCI:
             return {
                 "level_id": "EPCI.id",
-                "join_extras": "INNER JOIN EPCI ON City.epci_id = EPCI.id",
+                "join_extras": """
+                    INNER JOIN City ON code_insee_commune = City.code
+                    INNER JOIN EPCI ON City.epci_id = EPCI.id""",
             }
         case Level.DEPARTMENT:
             return {
                 "level_id": "Department.id",
                 "join_extras": """
+                    INNER JOIN City ON code_insee_commune = City.code
                     INNER JOIN Department ON City.department_id = Department.id
                     """,
             }
@@ -91,19 +125,29 @@ def get_num_for_level_query_params(level: Level):
             return {
                 "level_id": "Region.id",
                 "join_extras": """
+                    INNER JOIN City ON code_insee_commune = City.code
                     INNER JOIN Department ON City.department_id = Department.id
                     INNER JOIN Region ON Department.region_id = Region.id
                     """,
             }
+        case Level.OPERATIONALUNIT:
+            return {
+                "level_id": "Operationalunit.id",
+                "join_extras": """
+                    INNER JOIN Pointdecharge ON Pointdecharge.id = pdc_id
+                    INNER JOIN Station ON station.id = station_id
+                    INNER JOIN Operationalunit ON Station.operational_unit_id = Operationalunit.id
+                    """,  # noqa: E501
+            }
         case _:
-            raise NotImplementedError("Unsupported level %d", level)
+            raise NotImplementedError(f"Unsupported level {level}")
 
 
 @task(task_run_name="targets-for-level-{level:02d}")
 def get_targets_for_level(level: Level, environment: Environment) -> pd.DataFrame:
     """Get registered targets for level from QualiCharge database."""
     if level == Level.NATIONAL:
-        raise NotImplementedError("Unsupported level %d", level)
+        raise NotImplementedError(f"Unsupported level {level}")
     with Session(get_api_db_engine(environment)) as session:
         return pd.read_sql_table(level.name.lower(), con=session.connection())
 

--- a/src/prefect/prefect.yaml
+++ b/src/prefect/prefect.yaml
@@ -16,7 +16,7 @@ deployments:
         active: true
     parameters:
       environment: production
-      levels: [0, 1, 2, 3]
+      levels: [0, 1, 2, 3, 5]
       period: d
       create_artifact: true
       persist: true
@@ -33,7 +33,7 @@ deployments:
         active: true
     parameters:
       environment: production
-      levels: [0, 1, 2, 3]
+      levels: [0, 1, 2, 3, 5]
       period: d
       create_artifact: true
       persist: true
@@ -50,7 +50,7 @@ deployments:
         active: true
     parameters:
       environment: production
-      levels: [0, 1, 2, 3]
+      levels: [0, 1, 2, 3, 5]
       period: d
       create_artifact: true
       persist: true
@@ -67,7 +67,7 @@ deployments:
         active: true
     parameters:
       environment: production
-      levels: [0, 1, 2, 3]
+      levels: [0, 1, 2, 3, 5]
       period: d
       create_artifact: true
       persist: true
@@ -135,7 +135,7 @@ deployments:
         active: true
     parameters:
       environment: production
-      levels: [0, 1]
+      levels: [0, 1, 5]
       period: d
       create_artifact: true
       persist: true
@@ -152,7 +152,7 @@ deployments:
         active: true
     parameters:
       environment: production
-      levels: [0, 1]
+      levels: [0, 1, 5]
       period: d
       create_artifact: true
       persist: true
@@ -186,7 +186,7 @@ deployments:
         active: true
     parameters:
       environment: production
-      levels: [0, 1]
+      levels: [0, 1, 5]
       period: d
       create_artifact: true
       persist: true
@@ -211,6 +211,23 @@ deployments:
       name: indicators
       work_queue_name: default
   
+  - name: u14-daily
+    entrypoint: indicators/usage/u14.py:u14
+    concurrency_limit: 10
+    schedules:
+      - cron: "36 5 * * *"
+        timezone: "Europe/Paris"
+        active: true
+    parameters:
+      environment: production
+      levels: [0, 1, 5]
+      period: d
+      create_artifact: true
+      persist: true
+    work_pool:
+      name: indicators
+      work_queue_name: default
+
   # offset (default -1): 0 -> init period = start value 
   - name: up-monthly
     entrypoint: indicators/historicize/up.py:up

--- a/src/prefect/quality/flows/quality_run.py
+++ b/src/prefect/quality/flows/quality_run.py
@@ -221,7 +221,7 @@ def run_api_db_checkpoint_by_unit(  # noqa: PLR0913
                     if value > 0:
                         indicators.loc[len(indicators)] = {
                             "value": value,
-                            "level": Level.OU,
+                            "level": Level.OPERATIONALUNIT,
                             "target": unit,
                             "category": code,
                             "code": "qua",

--- a/src/prefect/tests/extract/test_e4.py
+++ b/src/prefect/tests/extract/test_e4.py
@@ -18,10 +18,10 @@ from tests.parameters import (
 )
 
 # expected result
-N_LEVEL = [9, 452, 797, 2417]
+N_LEVEL = [9, 452, 797, 2417, 1307]
 N_LEVEL_NATIONAL = 5782
 N_DPTS = 109
-N_NAT_REG_DPT_EPCI_CITY = 36465
+N_NAT_REG_DPT_EPCI_CITY_OU = 36984
 
 TIMESPAN = IndicatorTimeSpan(start=datetime(2024, 12, 28), period=IndicatorPeriod.DAY)
 TIMESPAN_QUERY = IndicatorTimeSpan(
@@ -86,6 +86,7 @@ def test_flow_e4():
         Level.DEPARTMENT,
         Level.CITY,
         Level.EPCI,
+        Level.OPERATIONALUNIT,
     ]
     indicators = e4.e4(
         Environment.TEST,

--- a/src/prefect/tests/historicize/test_up.py
+++ b/src/prefect/tests/historicize/test_up.py
@@ -228,7 +228,7 @@ def test_flow_up_persistence(indicators_db_engine):
     """Test the `up` flow."""
     indicators = i1.i1(
         Environment.TEST,
-        levels=[Level.NATIONAL, Level.REGION],
+        levels=[Level.NATIONAL, Level.REGION, Level.OPERATIONALUNIT],
         start=TIMESPAN.start,
         period=IndicatorPeriod.DAY,
         create_artifact=True,
@@ -236,7 +236,7 @@ def test_flow_up_persistence(indicators_db_engine):
     )
     e4.e4(
         Environment.TEST,
-        levels=[Level.NATIONAL, Level.REGION],
+        levels=[Level.NATIONAL, Level.REGION, Level.OPERATIONALUNIT],
         start=TIMESPAN.start,
         period=IndicatorPeriod.DAY,
         create_artifact=False,

--- a/src/prefect/tests/infrastructure/test_i1.py
+++ b/src/prefect/tests/infrastructure/test_i1.py
@@ -19,10 +19,10 @@ from ..parameters import (
     PARAMETERS_CHUNK,
 )
 
-# expected result for level [city, epci, dpt, reg]
-N_LEVEL = [56, 2484, 4242, 12147]
+# expected result for level [city, epci, dpt, reg, ou]
+N_LEVEL = [56, 2484, 4242, 12147, 6501]
 N_DPTS = 109
-N_NAT_REG_DPT_EPCI_CITY = 36465
+N_NAT_REG_DPT_EPCI_CITY_OU = 36984
 
 TIMESPAN = IndicatorTimeSpan(start=datetime.now(), period=IndicatorPeriod.DAY)
 PARAMETERS_FLOW = [prm + (lvl,) for prm, lvl in zip(PARAM_FLOW, N_LEVEL, strict=True)]
@@ -74,13 +74,14 @@ def test_flow_i1_national(db_connection):
 
 def test_flow_i1():
     """Test the `i1` flow."""
-    expected = N_NAT_REG_DPT_EPCI_CITY
+    expected = N_NAT_REG_DPT_EPCI_CITY_OU
     all_levels = [
         Level.NATIONAL,
         Level.REGION,
         Level.DEPARTMENT,
         Level.CITY,
         Level.EPCI,
+        Level.OPERATIONALUNIT,
     ]
     indicators = i1.i1(
         Environment.TEST,

--- a/src/prefect/tests/infrastructure/test_i4.py
+++ b/src/prefect/tests/infrastructure/test_i4.py
@@ -18,10 +18,10 @@ from ..parameters import (
     PARAMETERS_CHUNK,
 )
 
-# expected result for level [city, epci, dpt, reg]
-N_LEVEL = [8, 490, 849, 2436]
+# expected result for level [city, epci, dpt, reg, operationalunit]
+N_LEVEL = [8, 490, 849, 2436, 664]
 N_DPTS = 109
-N_NAT_REG_DPT_EPCI_CITY = 36465
+N_NAT_REG_DPT_EPCI_CITY_OU = 36984
 
 TIMESPAN = IndicatorTimeSpan(start=datetime.now(), period=IndicatorPeriod.DAY)
 PARAMETERS_FLOW = [prm + (lvl,) for prm, lvl in zip(PARAM_FLOW, N_LEVEL, strict=True)]
@@ -73,13 +73,14 @@ def test_flow_i4_national(db_connection):
 
 def test_flow_i4(db_connection):
     """Test the `i4` flow."""
-    expected = N_NAT_REG_DPT_EPCI_CITY
+    expected = N_NAT_REG_DPT_EPCI_CITY_OU
     all_levels = [
         Level.NATIONAL,
         Level.REGION,
         Level.DEPARTMENT,
         Level.CITY,
         Level.EPCI,
+        Level.OPERATIONALUNIT,
     ]
     indicators = i4.i4(
         Environment.TEST,

--- a/src/prefect/tests/infrastructure/test_i7.py
+++ b/src/prefect/tests/infrastructure/test_i7.py
@@ -18,10 +18,10 @@ from ..parameters import (
     PARAMETERS_CHUNK,
 )
 
-# expected result for level [city, epci, dpt, reg]
-N_LEVEL = [8462, 293432, 317084, 1420791]
+# expected result for level [city, epci, dpt, reg, ou]
+N_LEVEL = [8462, 293432, 317084, 1420791, 1408228]
 N_DPTS = 109
-N_NAT_REG_DPT_EPCI_CITY = 36465
+N_NAT_REG_DPT_EPCI_CITY_OU = 36984
 
 TIMESPAN = IndicatorTimeSpan(start=datetime.now(), period=IndicatorPeriod.DAY)
 PARAMETERS_FLOW = [prm + (lvl,) for prm, lvl in zip(PARAM_FLOW, N_LEVEL, strict=True)]
@@ -81,13 +81,14 @@ def test_flow_i7_national(db_connection):
 
 def test_flow_i7(db_connection):
     """Test the `i7` flow."""
-    expected = N_NAT_REG_DPT_EPCI_CITY
+    expected = N_NAT_REG_DPT_EPCI_CITY_OU
     all_levels = [
         Level.NATIONAL,
         Level.REGION,
         Level.DEPARTMENT,
         Level.CITY,
         Level.EPCI,
+        Level.OPERATIONALUNIT,
     ]
     indicators = i7.i7(
         Environment.TEST,

--- a/src/prefect/tests/infrastructure/test_t1.py
+++ b/src/prefect/tests/infrastructure/test_t1.py
@@ -18,10 +18,9 @@ from ..parameters import (
     PARAMETERS_CHUNK,
 )
 
-# expected result
-N_LEVEL = [56, 2484, 4242, 12147]
+# expected result for level [city, epci, dpt, reg, ou]
+N_LEVEL = [56, 2484, 4242, 12147, 6501]
 N_DPTS = 109
-N_NAT_REG_DPT_EPCI_CITY = 36465
 
 TIMESPAN = IndicatorTimeSpan(start=datetime.now(), period=IndicatorPeriod.DAY)
 PARAMETERS_FLOW = [prm + (lvl,) for prm, lvl in zip(PARAM_FLOW, N_LEVEL, strict=True)]
@@ -77,6 +76,7 @@ def test_flow_t1():
         Level.DEPARTMENT,
         Level.CITY,
         Level.EPCI,
+        Level.OPERATIONALUNIT,
     ]
     indicators = t1.t1(
         Environment.TEST,

--- a/src/prefect/tests/infrastructure/test_utils.py
+++ b/src/prefect/tests/infrastructure/test_utils.py
@@ -17,6 +17,7 @@ PARAMETERS_GET_TARGETS = [
     (Level.DEPARTMENT, 109),
     (Level.EPCI, 1255),
     (Level.REGION, 26),
+    (Level.OPERATIONALUNIT, 519),
 ]
 
 

--- a/src/prefect/tests/parameters.py
+++ b/src/prefect/tests/parameters.py
@@ -31,6 +31,11 @@ PARAM_FLOW = [
         "SELECT COUNT(*) FROM Region",
         ["11", "84", "75"],
     ),
+    (
+        Level.OPERATIONALUNIT,
+        "SELECT COUNT(*) FROM OperationalUnit",
+        ["FRATL", "FRELC", "FRTSL"],
+    ),
 ]
 
 PARAM_VALUE = [
@@ -49,5 +54,9 @@ PARAM_VALUE = [
     (
         Level.REGION,
         "SELECT id FROM Region WHERE code IN ('11', '84', '75')",
+    ),
+    (
+        Level.OPERATIONALUNIT,
+        "SELECT id FROM OperationalUnit WHERE code IN ('FRATL', 'FRELC', 'FRTSL')",
     ),
 ]

--- a/src/prefect/tests/usage/test_u11.py
+++ b/src/prefect/tests/usage/test_u11.py
@@ -48,8 +48,8 @@ from tests.parameters import (
     PARAMETERS_CHUNK,
 )
 
-# expected result for level [city, epci, dpt, reg]
-N_LEVEL = [8, 204, 373, 1078]
+# expected result for level [city, epci, dpt, reg, operationalunit]
+N_LEVEL = [8, 204, 373, 1078, 606]
 N_LEVEL_NATIONAL = 2487
 N_DPTS = 109
 
@@ -107,6 +107,7 @@ def test_flow_u11(db_connection):
         Level.DEPARTMENT,
         Level.CITY,
         Level.EPCI,
+        Level.OPERATIONALUNIT,
     ]
     indicators = u11.u11(
         Environment.TEST,

--- a/src/prefect/tests/usage/test_u12.py
+++ b/src/prefect/tests/usage/test_u12.py
@@ -17,8 +17,8 @@ from tests.parameters import (
     PARAMETERS_CHUNK,
 )
 
-# expected result for level [city, epci, dpt, reg]
-N_LEVEL = [7, 299, 550, 1589]
+# expected result for level [city, epci, dpt, reg, ou]
+N_LEVEL = [7, 299, 550, 1589, 870]
 N_LEVEL_NATIONAL = 3857
 
 TIMESPAN = IndicatorTimeSpan(start=datetime(2024, 12, 24), period=IndicatorPeriod.DAY)
@@ -75,6 +75,7 @@ def test_flow_u12(db_connection):
         Level.DEPARTMENT,
         Level.CITY,
         Level.EPCI,
+        Level.OPERATIONALUNIT,
     ]
     indicators = u12.u12(
         Environment.TEST,

--- a/src/prefect/tests/usage/test_u13.py
+++ b/src/prefect/tests/usage/test_u13.py
@@ -17,8 +17,8 @@ from tests.parameters import (
     PARAMETERS_CHUNK,
 )
 
-# expected result for level [city, epci, dpt, reg]
-N_LEVEL = [1164, 37208, 41978, 195354]
+# expected result for level [city, epci, dpt, reg, ou]
+N_LEVEL = [1164, 37208, 41978, 195354, 186473]
 N_LEVEL_NATIONAL = 527061
 
 TIMESPAN = IndicatorTimeSpan(start=datetime(2024, 12, 24), period=IndicatorPeriod.DAY)
@@ -79,6 +79,7 @@ def test_flow_u13(db_connection):
         Level.DEPARTMENT,
         Level.CITY,
         Level.EPCI,
+        Level.OPERATIONALUNIT,
     ]
     indicators = u13.u13(
         Environment.TEST,

--- a/src/prefect/tests/usage/test_u14.py
+++ b/src/prefect/tests/usage/test_u14.py
@@ -1,6 +1,6 @@
 """QualiCharge prefect indicators tests: usage.
 
-U10: the number of sessions.
+U14: energy by power level.
 """
 
 from datetime import datetime
@@ -10,17 +10,16 @@ from sqlalchemy import text
 
 from indicators.models import IndicatorPeriod, IndicatorTimeSpan, Level  # type: ignore
 from indicators.types import Environment
-from indicators.usage import u10  # type: ignore
+from indicators.usage import u14  # type: ignore
 from tests.parameters import (
     PARAM_FLOW,
     PARAM_VALUE,
     PARAMETERS_CHUNK,
 )
 
-# expected result for level [city, epci, dpt, reg, operationalunit]
-N_LEVEL = [8, 209, 388, 1105, 623]
-N_LEVEL_NATIONAL = 2553
-N_DPTS = 109
+# expected result for level [city, epci, dpt, reg, ou]
+N_LEVEL = [205, 3831, 3435, 19559, 17984]
+N_LEVEL_NATIONAL = 50245
 
 TIMESPAN = IndicatorTimeSpan(start=datetime(2024, 12, 24), period=IndicatorPeriod.DAY)
 PARAMETERS_FLOW = [prm + (lvl,) for prm, lvl in zip(PARAM_FLOW, N_LEVEL, strict=True)]
@@ -32,44 +31,47 @@ def test_task_get_values_for_target(db_connection, level, query, expected):
     """Test the `get_values_for_target` task."""
     result = db_connection.execute(text(query))
     indexes = list(result.scalars().all())
-    values = u10.get_values_for_targets.fn(level, TIMESPAN, indexes, Environment.TEST)
-    assert len(values) == len(indexes)
-    assert values["value"].sum() == expected
+    values = u14.get_values_for_targets.fn(level, TIMESPAN, indexes, Environment.TEST)
+    assert int(values["value"].sum()) == expected
 
 
 def test_task_get_values_for_target_unexpected_level(db_connection):
     """Test the `get_values_for_target` task (unknown level)."""
     with pytest.raises(NotImplementedError, match="Unsupported level"):
-        u10.get_values_for_targets.fn(Level.NATIONAL, TIMESPAN, [], Environment.TEST)
+        u14.get_values_for_targets.fn(Level.NATIONAL, TIMESPAN, [], Environment.TEST)
 
 
 @pytest.mark.parametrize("level,query,targets,expected", PARAMETERS_FLOW)
-def test_flow_u10_for_level(db_connection, level, query, targets, expected):
-    """Test the `u10_for_level` flow."""
-    indicators = u10.u10_for_level(level, TIMESPAN, Environment.TEST, chunk_size=1000)
-    assert len(indicators) == db_connection.execute(text(query)).scalars().one()
-    assert indicators.loc[indicators["target"].isin(targets), "value"].sum() == expected
+def test_flow_u14_for_level(db_connection, level, query, targets, expected):
+    """Test the `u14_for_level` flow."""
+    indicators = u14.u14_for_level(level, TIMESPAN, Environment.TEST, chunk_size=1000)
+    assert (
+        int(indicators.loc[indicators["target"].isin(targets), "value"].sum())
+        == expected
+    )
 
 
 @pytest.mark.parametrize("chunk_size", PARAMETERS_CHUNK)
-def test_flow_u10_for_level_with_various_chunk_sizes(chunk_size):
-    """Test the `u10_for_level` flow with various chunk sizes."""
+def test_flow_u14_for_level_with_various_chunk_sizes(chunk_size):
+    """Test the `u14_for_level` flow with various chunk sizes."""
     level, query, targets, expected = PARAMETERS_FLOW[2]
-    indicators = u10.u10_for_level(
+    indicators = u14.u14_for_level(
         level, TIMESPAN, Environment.TEST, chunk_size=chunk_size
     )
-    assert len(indicators) == N_DPTS
-    assert indicators.loc[indicators["target"].isin(targets), "value"].sum() == expected
+    assert (
+        int(indicators.loc[indicators["target"].isin(targets), "value"].sum())
+        == expected
+    )
 
 
-def test_flow_u10_national(db_connection):
-    """Test the `u10_national` flow."""
-    indicators = u10.u10_national(TIMESPAN, Environment.TEST)
-    assert indicators.at[0, "value"] == N_LEVEL_NATIONAL
+def test_flow_u14_national(db_connection):
+    """Test the `u14_national` flow."""
+    indicators = u14.u14_national(TIMESPAN, Environment.TEST)
+    assert int(indicators["value"].sum()) == N_LEVEL_NATIONAL
 
 
-def test_flow_u10(db_connection):
-    """Test the `u10` flow."""
+def test_flow_u14(db_connection):
+    """Test the `u14` flow."""
     all_levels = [
         Level.NATIONAL,
         Level.REGION,
@@ -78,7 +80,7 @@ def test_flow_u10(db_connection):
         Level.EPCI,
         Level.OPERATIONALUNIT,
     ]
-    indicators = u10.u10(
+    indicators = u14.u14(
         Environment.TEST,
         all_levels,
         start=TIMESPAN.start,
@@ -89,9 +91,9 @@ def test_flow_u10(db_connection):
     assert list(indicators["level"].unique()) == all_levels
 
 
-def test_flow_u10_persistence(indicators_db_engine):
-    """Test the `u10` flow."""
-    indicators = u10.u10(
+def test_flow_u14_persistence(indicators_db_engine):
+    """Test the `u14` flow."""
+    indicators = u14.u14(
         Environment.TEST,
         [Level.NATIONAL],
         start=TIMESPAN.start,
@@ -102,6 +104,6 @@ def test_flow_u10_persistence(indicators_db_engine):
 
     with indicators_db_engine.connect() as connection:
         result = connection.execute(
-            text("SELECT COUNT(*) FROM test WHERE code = 'u10'")
+            text("SELECT COUNT(*) FROM test WHERE code = 'u14'")
         )
         assert result.one()[0] == len(indicators)

--- a/src/prefect/tests/usage/test_u5.py
+++ b/src/prefect/tests/usage/test_u5.py
@@ -17,8 +17,8 @@ from tests.parameters import (
     PARAMETERS_CHUNK,
 )
 
-# expected result for level [city, epci, dpt, reg]
-N_LEVEL = [8, 209, 388, 1105]
+# expected result for level [city, epci, dpt, reg, ou]
+N_LEVEL = [8, 209, 388, 1105, 623]
 N_LEVEL_NATIONAL = 2553
 
 TIMESPAN = IndicatorTimeSpan(start=datetime(2024, 12, 24), period=IndicatorPeriod.DAY)
@@ -73,6 +73,7 @@ def test_flow_u5(db_connection):
         Level.DEPARTMENT,
         Level.CITY,
         Level.EPCI,
+        Level.OPERATIONALUNIT,
     ]
     indicators = u5.u5(
         Environment.TEST,

--- a/src/prefect/tests/usage/test_u6.py
+++ b/src/prefect/tests/usage/test_u6.py
@@ -79,8 +79,8 @@ from tests.parameters import (
     PARAMETERS_CHUNK,
 )
 
-# expected result for level [city, epci, dpt, reg]
-N_LEVEL = [5, 106, 205, 644]
+# expected result for level [city, epci, dpt, reg, ou]
+N_LEVEL = [5, 106, 205, 644, 353]
 N_LEVEL_NATIONAL = 1427
 
 TIMESPAN = IndicatorTimeSpan(start=datetime(2024, 12, 24), period=IndicatorPeriod.DAY)
@@ -141,6 +141,7 @@ def test_flow_u6(db_connection):
         Level.DEPARTMENT,
         Level.CITY,
         Level.EPCI,
+        Level.OPERATIONALUNIT,
     ]
     indicators = u6.u6(
         Environment.TEST,

--- a/src/prefect/tests/usage/test_u9.py
+++ b/src/prefect/tests/usage/test_u9.py
@@ -17,8 +17,8 @@ from tests.parameters import (
     PARAMETERS_CHUNK,
 )
 
-# expected result for level [city, epci, dpt, reg]
-N_LEVEL = [289, 6634, 12505, 36838]
+# expected result for level [city, epci, dpt, reg, ou]
+N_LEVEL = [289, 6634, 12505, 36838, 19627]
 N_LEVEL_NATIONAL = 83363
 
 TIMESPAN = IndicatorTimeSpan(start=datetime(2024, 12, 24), period=IndicatorPeriod.DAY)
@@ -79,6 +79,7 @@ def test_flow_u9(db_connection):
         Level.DEPARTMENT,
         Level.CITY,
         Level.EPCI,
+        Level.OPERATIONALUNIT,
     ]
     indicators = u9.u9(
         Environment.TEST,


### PR DESCRIPTION
## Purpose

Current quality controls via Prefect are calculated by geographic levels and doesn't incorporate the operational unit level. 
Therefore, Quality indicators use queries on the production database rather than the indicator database to include energy volumes per operational unit.

Several improvements are included:
- extend levels to operational units for existing infrastructure and usage indicators
- add an energy indicator by delivery category 

## Proposal

- [x] Add the OperationalUnit level for infrastructure indicators (t1, i1, i4, i7) and usage indicators (u5, u6, u9, u10, u11, u12, u13)
- [x] Add the energy by delivery category indicator (u14)
- [x] Add level 5 (OperationalUnit) to Prefect deployments : t1, i1, i4, i7, u9, u10, u12, u14