### PR TITLE
🔖(api:minor) bump release to 0.34.0

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-05-29
+
 ### Added 
 
 - CLI: add a new `qcm ou update` command
@@ -754,7 +756,8 @@ update` command
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.33.1...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.34.0...main
+[0.34.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.33.1...v0.34.0
 [0.33.1]: https://github.com/MTES-MCT/qualicharge/compare/v0.33.0...v0.33.1
 [0.33.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.31.2...v0.32.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qualicharge"
-version = "0.33.1"
+version = "0.34.0"
 requires-python = "~=3.12.0"
 dependencies = [
     "alembic==1.18.4",

--- a/src/api/uv.lock
+++ b/src/api/uv.lock
@@ -1539,7 +1539,7 @@ wheels = [
 
 [[package]]
 name = "qualicharge"
-version = "0.33.1"
+version = "0.34.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
### Added

- CLI: add a new `qcm ou update` command

### Changed

#### Dependencies

- Upgrade `cachetools` to `7.0.5`
- Upgrade `fastapi` to `0.135.3`
- Upgrade `pandas` to `3.0.2`
- Upgrade `pydantic` to `2.12.5`
- Upgrade `pydantic-extra-types` to `2.11.1`
- Upgrade `PyJWT` to `2.12.1`
- Upgrade `python-multipart` to `0.0.24`
- Upgrade `sentry-sdk` to `2.57.0`
- Upgrade `sqlmodel` to `0.0.38`

### Removed

- Remove API requests user cache and related configuration
