### PR TITLE
🚚(tariff) export tariffs to opendata service using data7

### DIFF
--- a/src/opendata/CHANGELOG.md
+++ b/src/opendata/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - Configured Data7 1.0.2
 - Use the `Statique` materialized view for the `statiques` dataset
 - Integrate HTTP Basic Authentication using NGINX as a reverse-proxy
+- Export active tariffs and their active charge-point associations
 
 ### Changed
 

--- a/src/opendata/data7.yaml
+++ b/src/opendata/data7.yaml
@@ -18,6 +18,46 @@ default:
           etat_prise_type_ef
         FROM
           LatestStatus
+    - basename: tariffs
+      query: >-
+        WITH tariff_charge_points AS (
+          SELECT
+            pointdechargetariff.tariff_id,
+            jsonb_agg(
+              pointdecharge.id_pdc_itinerance
+              ORDER BY pointdecharge.id_pdc_itinerance
+            ) FILTER (
+              WHERE pointdecharge.id_pdc_itinerance IS NOT NULL
+            ) AS id_pdc_itinerance
+          FROM
+            pointdechargetariff
+          INNER JOIN
+            pointdecharge
+            ON pointdecharge.id = pointdechargetariff.point_de_charge_id
+          GROUP BY
+            pointdechargetariff.tariff_id
+        )
+        SELECT
+          tariff.id::text AS id,
+          tariff.original_id,
+          tariff.original_last_updated,
+          tariff.raw::text AS raw,
+          tariff.start,
+          tariff."end",
+          COALESCE(
+            tariff_charge_points.id_pdc_itinerance,
+            '[]'::jsonb
+          )::text AS id_pdc_itinerance
+        FROM
+          tariff
+        LEFT JOIN
+          tariff_charge_points
+          ON tariff_charge_points.tariff_id = tariff.id
+        WHERE
+          tariff.deleted_at IS NULL
+        ORDER BY
+          tariff.created_at,
+          tariff.id
     - basename: statiques
       query: >-
         SELECT

--- a/src/opendata/data7.yaml
+++ b/src/opendata/data7.yaml
@@ -38,9 +38,6 @@ default:
             pointdechargetariff.tariff_id
         )
         SELECT
-          tariff.id::text AS id,
-          tariff.original_id,
-          tariff.original_last_updated,
           tariff.raw::text AS raw,
           tariff.start,
           tariff."end",
@@ -55,9 +52,6 @@ default:
           ON tariff_charge_points.tariff_id = tariff.id
         WHERE
           tariff.deleted_at IS NULL
-        ORDER BY
-          tariff.created_at,
-          tariff.id
     - basename: statiques
       query: >-
         SELECT


### PR DESCRIPTION
## What changed

Adds the `tariffs` dataset to `src/opendata/data7.yaml`.

The dataset exports active tariffs and their associated charge-point identifiers through the Data7 CSV and Parquet endpoints.

## Why

This makes tariff data available through the existing opendata service, alongside the `statuses` and `statiques` datasets.

## Validation

- Validated the Data7 YAML configuration.
- Executed the query against PostgreSQL.
- Generated and read the resulting Parquet export.
- Verified the exported columns and JSON-encoded fields.
- Confirmed that deleted tariffs are excluded and tariffs without charge points return an empty list.