### PR TITLE
🔖(prefect) add e5 indicator

### DIFF
--- a/src/prefect/CHANGELOG.md
+++ b/src/prefect/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 - Implement historicization (up)
 - Implement usage indicators (u5, u6, u9, u10, u11, u12, u13)
 - Add usage indicator u14
+- Add extract indicator e5
 
 #### Quality
 

--- a/src/prefect/indicators/extract/e5.py
+++ b/src/prefect/indicators/extract/e5.py
@@ -1,0 +1,239 @@
+"""QualiCharge prefect indicators: extract.
+
+E5: the list of points of charge in activity.
+
+data : id_pdc_itinerance, id_station_itinerance, puissance_nominale, latitude, longitude
+"""
+
+from datetime import datetime
+from string import Template
+from typing import List
+from uuid import UUID
+
+import numpy as np
+import pandas as pd  # type: ignore
+from prefect import flow, runtime, task
+from prefect.cache_policies import NONE
+from prefect.futures import wait
+from sqlalchemy.orm import Session
+
+from indicators.conf import settings
+from indicators.db import get_api_db_engine
+from indicators.models import IndicatorPeriod, IndicatorTimeSpan, Level, PeriodDuration
+from indicators.types import Environment
+from indicators.utils import (
+    export_indicators,
+    get_num_for_level_query_params,
+    get_period_start_from_pit,
+    get_targets_for_level,
+    get_timespan_filter_query_params,
+)
+
+HISTORY_STRATEGY_FIELD: str = "mean"
+LIST_POCS_FOR_LEVEL_QUERY_TEMPLATE = """
+SELECT
+    statique.id_pdc_itinerance,
+    statique.id_station_itinerance,
+    statique.puissance_nominale,
+    ST_X (statique."coordonneesXY"::geometry) AS longitude,
+    ST_Y (statique."coordonneesXY"::geometry) AS latitude,
+    $level_id AS level_id
+FROM
+    lateststatus
+    INNER JOIN statique ON lateststatus.id_pdc_itinerance = statique.id_pdc_itinerance
+    $join_extras
+WHERE
+    $level_id IN ($indexes)
+    AND $timespan
+GROUP BY
+    statique.id_pdc_itinerance,
+    statique.id_station_itinerance,
+    statique.puissance_nominale,
+    longitude,
+    latitude,
+    $level_id
+"""
+QUERY_NATIONAL_TEMPLATE = """
+SELECT
+    statique.id_pdc_itinerance,
+    statique.id_station_itinerance,
+    statique.puissance_nominale,
+    ST_X (statique."coordonneesXY"::geometry) AS longitude,
+    ST_Y (statique."coordonneesXY"::geometry) AS latitude
+FROM
+    lateststatus
+    INNER JOIN statique ON lateststatus.id_pdc_itinerance = statique.id_pdc_itinerance
+WHERE
+    $timespan
+GROUP BY
+    statique.id_pdc_itinerance,
+    statique.id_station_itinerance,
+    statique.puissance_nominale,
+    longitude,
+    latitude
+"""
+
+
+@task(task_run_name="values-for-target-{level:02d}", cache_policy=NONE)
+def get_values_for_targets(
+    level: Level,
+    timespan: IndicatorTimeSpan,
+    indexes: List[UUID],
+    environment: Environment,
+) -> pd.DataFrame:
+    """Fetch points of charge given input level and target index."""
+    query_template = Template(LIST_POCS_FOR_LEVEL_QUERY_TEMPLATE)
+    query_params: dict = {"indexes": ",".join(f"'{i}'" for i in map(str, indexes))}
+    query_params |= get_num_for_level_query_params(level)
+    query_params |= get_timespan_filter_query_params(timespan, session=False)
+    with Session(get_api_db_engine(environment)) as session:
+        return pd.read_sql_query(
+            query_template.substitute(query_params), con=session.connection()
+        )
+
+
+@flow(
+    flow_run_name="e5-{timespan.period.value}-{level:02d}-{timespan.start:%y-%m-%d}",
+)
+def e5_for_level(
+    level: Level,
+    timespan: IndicatorTimeSpan,
+    environment: Environment,
+    chunk_size: int = settings.DEFAULT_CHUNK_SIZE,
+) -> pd.DataFrame:
+    """Calculate e5 for a level."""
+    timespan_query = IndicatorTimeSpan(
+        start=timespan.start - PeriodDuration.MONTH.value,
+        period=IndicatorPeriod.MONTH,
+    )
+    if level == Level.NATIONAL:
+        return e5_national(timespan, timespan_query, environment)
+    targets = get_targets_for_level(level, environment)
+    ids = targets["id"]
+    chunks = (
+        np.array_split(ids, int(len(ids) / chunk_size))
+        if len(ids) > chunk_size
+        else [ids.to_numpy()]
+    )
+    futures = [
+        get_values_for_targets.submit(level, timespan_query, chunk, environment)  # type: ignore[call-overload]
+        for chunk in chunks
+    ]
+    wait(futures)
+
+    # Concatenate results and serialize indicators
+    results = pd.concat([future.result() for future in futures], ignore_index=True)
+
+    grp = results.groupby("level_id")
+    results_list = pd.DataFrame()
+    results_list["level_id"] = [name for name, group in grp]
+    results_list["extras"] = [
+        {
+            "id_pdc_itinerance": list(group["id_pdc_itinerance"]),
+            "id_station_itinerance": list(group["id_station_itinerance"]),
+            "puissance_nominale": list(group["puissance_nominale"]),
+            "latitude": list(group["latitude"]),
+            "longitude": list(group["longitude"]),
+        }
+        for name, group in grp
+    ]  # type: ignore[assignment]
+    results_list["value"] = [
+        len(list(group["id_pdc_itinerance"])) for name, group in grp
+    ]
+
+    merged = targets.merge(results_list, how="left", left_on="id", right_on="level_id")
+
+    # Build result DataFrame
+    indicators = {
+        "target": merged["code"],
+        "value": merged["value"].fillna(0),
+        "code": "e5",
+        "level": level,
+        "period": timespan.period,
+        "timestamp": timespan.start.isoformat(),
+        "category": None,
+        "extras": merged["extras"].fillna(
+            pd.Series(
+                [
+                    {
+                        "id_pdc_itinerance": [],
+                        "id_station_itinerance": [],
+                        "puissance_nominale": [],
+                        "latitude": [],
+                        "longitude": [],
+                    }
+                ]
+                * len(merged)
+            )
+        ),
+    }
+    return pd.DataFrame(indicators)
+
+
+@flow(
+    flow_run_name="e5-{timespan.period.value}-00-{timespan.start:%y-%m-%d}",
+)
+def e5_national(
+    timespan: IndicatorTimeSpan,
+    timespan_query: IndicatorTimeSpan,
+    environment: Environment,
+) -> pd.DataFrame:
+    """Calculate e5 at the national level."""
+    query_template = Template(QUERY_NATIONAL_TEMPLATE)
+    query_params = get_timespan_filter_query_params(timespan_query, session=False)
+    with Session(get_api_db_engine(environment)) as session:
+        result = pd.read_sql_query(
+            query_template.substitute(query_params), con=session.connection()
+        )
+    indicators = {
+        "target": "00",
+        "value": len(result),
+        "code": "e5",
+        "level": Level.NATIONAL,
+        "period": timespan.period,
+        "timestamp": timespan.start.isoformat(),
+        "category": None,
+        "extras": [
+            {
+                "id_pdc_itinerance": list(result["id_pdc_itinerance"]),
+                "id_station_itinerance": list(result["id_station_itinerance"]),
+                "puissance_nominale": list(result["puissance_nominale"]),
+                "latitude": list(result["latitude"]),
+                "longitude": list(result["longitude"]),
+            }
+        ],
+    }
+    return pd.DataFrame(indicators)
+
+
+@flow(
+    flow_run_name="meta-e5-{period.value}",
+)
+def e5(  # noqa: PLR0913
+    environment: Environment,
+    levels: List[Level],
+    start: datetime | None = None,
+    offset: int = -1,
+    period: IndicatorPeriod = IndicatorPeriod.DAY,
+    chunk_size: int = 1000,
+    create_artifact: bool = False,
+    persist: bool = False,
+) -> pd.DataFrame:
+    """Run all e5 subflows."""
+    start = (
+        datetime.now()
+        if not offset and start is None
+        else get_period_start_from_pit(start, offset, period)
+    )
+    timespan = IndicatorTimeSpan(period=period, start=start)
+    subflows_results = [
+        e5_for_level(level, timespan, environment, chunk_size=chunk_size)
+        for level in levels
+    ]
+    indicators = pd.concat(subflows_results, ignore_index=True)
+    description = f"e5 report at {timespan.start} (period: {timespan.period.value})"
+    flow_name = runtime.flow_run.name
+    export_indicators(
+        indicators, environment, flow_name, description, create_artifact, persist
+    )
+    return indicators

--- a/src/prefect/indicators/run.py
+++ b/src/prefect/indicators/run.py
@@ -4,6 +4,7 @@
 
 # extract
 from .extract.e4 import e4
+from .extract.e5 import e5
 
 # historicize
 from .historicize.up import up

--- a/src/prefect/indicators/strategy.py
+++ b/src/prefect/indicators/strategy.py
@@ -5,6 +5,7 @@ from quality.expectations.parameters import HISTORY_STRATEGY_FIELD as QUA_STRATE
 
 # extract
 from .extract.e4 import HISTORY_STRATEGY_FIELD as E4_STRATEGY
+from .extract.e5 import HISTORY_STRATEGY_FIELD as E5_STRATEGY
 
 # infrastructure
 from .infrastructure.i1 import HISTORY_STRATEGY_FIELD as I1_STRATEGY
@@ -28,6 +29,7 @@ STRATEGY = {
     "i7": I7_STRATEGY,
     "t1": T1_STRATEGY,
     "e4": E4_STRATEGY,
+    "e5": E5_STRATEGY,
     "u5": U5_STRATEGY,
     "u6": U6_STRATEGY,
     "u9": U9_STRATEGY,

--- a/src/prefect/prefect.yaml
+++ b/src/prefect/prefect.yaml
@@ -91,7 +91,24 @@ deployments:
     work_pool:
       name: indicators
       work_queue_name: default
-  
+
+  - name: e5-daily
+    entrypoint: indicators/extract/e5.py:e5
+    concurrency_limit: 10
+    schedules:
+      - cron: "39 5 * * *"
+        timezone: "Europe/Paris"
+        active: true
+    parameters:
+      environment: production
+      levels: [0]
+      period: d
+      create_artifact: false
+      persist: true
+    work_pool:
+      name: indicators
+      work_queue_name: default
+
   - name: u5-daily
     entrypoint: indicators/usage/u5.py:u5
     concurrency_limit: 10

--- a/src/prefect/tests/extract/test_e5.py
+++ b/src/prefect/tests/extract/test_e5.py
@@ -1,0 +1,113 @@
+"""QualiCharge prefect indicators tests: extract.
+
+E4: the list of points of charge in activity.
+"""
+
+from datetime import datetime
+
+import pytest  # type: ignore
+from sqlalchemy import text
+
+from indicators.extract import e5
+from indicators.models import IndicatorPeriod, IndicatorTimeSpan, Level, PeriodDuration
+from indicators.types import Environment
+from tests.parameters import (
+    PARAM_FLOW,
+    PARAM_VALUE,
+    PARAMETERS_CHUNK,
+)
+
+# expected result
+N_LEVEL = [7, 378, 696, 1940, 1064]
+N_LEVEL_NATIONAL = 4593
+N_DPTS = 109
+N_NAT_REG_DPT_EPCI_CITY_OU = 36984
+
+TIMESPAN = IndicatorTimeSpan(start=datetime(2024, 12, 28), period=IndicatorPeriod.DAY)
+TIMESPAN_QUERY = IndicatorTimeSpan(
+    start=TIMESPAN.start - PeriodDuration.MONTH.value,
+    period=IndicatorPeriod.MONTH,
+)
+PARAMETERS_FLOW = [prm + (lvl,) for prm, lvl in zip(PARAM_FLOW, N_LEVEL, strict=True)]
+PARAMETERS_VALUE = [prm + (lvl,) for prm, lvl in zip(PARAM_VALUE, N_LEVEL, strict=True)]
+
+
+@pytest.mark.parametrize("level,query,expected", PARAMETERS_VALUE[1:])
+def test_task_get_values_for_target(db_connection, level, query, expected):
+    """Test the `get_values_for_target` task."""
+    result = db_connection.execute(text(query))
+    indexes = list(result.scalars().all())
+    poc_extract = e5.get_values_for_targets.fn(
+        level, TIMESPAN, indexes, Environment.TEST
+    )
+    assert len(set(poc_extract["level_id"])) == len(indexes)
+
+
+def test_task_get_values_for_target_unexpected_level():
+    """Test the `get_values_for_target` task (unknown level)."""
+    with pytest.raises(NotImplementedError, match="Unsupported level"):
+        e5.get_values_for_targets.fn(Level.NATIONAL, TIMESPAN, [], Environment.TEST)
+
+
+@pytest.mark.parametrize("level,query,targets,expected", PARAMETERS_FLOW)
+def test_flow_e5_for_level(db_connection, level, query, targets, expected):
+    """Test the `e5_for_level` flow."""
+    indicators = e5.e5_for_level(level, TIMESPAN, Environment.TEST, chunk_size=1000)
+    assert (
+        int(indicators.loc[indicators["target"].isin(targets), "value"].sum())
+        == expected
+    )
+
+
+@pytest.mark.parametrize("chunk_size", PARAMETERS_CHUNK)
+def test_flow_e5_for_level_with_various_chunk_sizes(chunk_size):
+    """Test the `e5_for_level` flow with various chunk sizes."""
+    level, query, targets, expected = PARAMETERS_FLOW[2]
+    indicators = e5.e5_for_level(
+        level, TIMESPAN, Environment.TEST, chunk_size=chunk_size
+    )
+    assert (
+        int(indicators.loc[indicators["target"].isin(targets), "value"].sum())
+        == expected
+    )
+
+
+def test_flow_e5_national():
+    """Test the `e5_national` flow."""
+    indicators = e5.e5_national(TIMESPAN, TIMESPAN_QUERY, Environment.TEST)
+    assert int(indicators["value"].sum()) == N_LEVEL_NATIONAL
+
+
+def test_flow_e5():
+    """Test the `e5` flow."""
+    all_levels = [
+        Level.NATIONAL,
+        Level.REGION,
+        Level.DEPARTMENT,
+        Level.CITY,
+        Level.EPCI,
+        Level.OPERATIONALUNIT,
+    ]
+    indicators = e5.e5(
+        Environment.TEST,
+        all_levels,
+        start=TIMESPAN.start,
+        period=TIMESPAN.period.value,
+        create_artifact=False,
+    )
+    assert list(indicators["level"].unique()) == all_levels
+
+
+def test_flow_e5_persistence(indicators_db_engine):
+    """Test the `e5` flow."""
+    indicators = e5.e5(
+        Environment.TEST,
+        [Level.NATIONAL],
+        start=TIMESPAN.start,
+        period=TIMESPAN.period.value,
+        persist=True,
+    )
+
+    with indicators_db_engine.connect() as connection:
+        result = connection.execute(text("SELECT COUNT(*) FROM test WHERE code = 'e5'"))
+        assert result.one()[0] == len(indicators)


### PR DESCRIPTION
## Purpose

- Historical data regarding the relationships between stations and charge points is unavailable; consequently, aggregating station sessions or statuses for a past date cannot be considered valid.
- Calculating saturation for highway stations requires access to 15 days of historical data for each station.

## Proposal

- [x] Add indicator e5 (the e5 indicator records `id_station_itinerance`, `puissance_nominale`, `latitude` and `longitude` for each `id_pdc_itinerance`)


Note : The complete list of indicators is available on `Resana/Qualicharge/projet/indicateurs/indicateurs.xlsx`
