### PR TITLE
🐛(prefect) Add a 15-day offset for session indicators

### DIFF
--- a/src/prefect/CHANGELOG.md
+++ b/src/prefect/CHANGELOG.md
@@ -58,5 +58,6 @@ and this project adheres to
   - LONS : extend threshold to 7 days
   - ERRT : add 'inconnu' statuses
 - Add OperationalUnit level for infrastructure and usage indicators
+- Add a 15-day offset for session indicators (u5, u6, u9, u10, u11, u14, e4)
 
 [unreleased]: https://github.com/MTES-MCT/qualicharge/

--- a/src/prefect/prefect.yaml
+++ b/src/prefect/prefect.yaml
@@ -85,6 +85,7 @@ deployments:
     parameters:
       environment: production
       levels: [0, 1]
+      offset: -16
       period: d
       create_artifact: false
       persist: true
@@ -119,6 +120,7 @@ deployments:
     parameters:
       environment: production
       levels: [0, 1]
+      offset: -16
       period: d
       create_artifact: true
       persist: true
@@ -136,6 +138,7 @@ deployments:
     parameters:
       environment: production
       levels: [0, 1]
+      offset: -16
       period: d
       create_artifact: true
       persist: true
@@ -153,6 +156,7 @@ deployments:
     parameters:
       environment: production
       levels: [0, 1, 5]
+      offset: -16
       period: d
       create_artifact: true
       persist: true
@@ -170,6 +174,7 @@ deployments:
     parameters:
       environment: production
       levels: [0, 1, 5]
+      offset: -16
       period: d
       create_artifact: true
       persist: true
@@ -187,6 +192,7 @@ deployments:
     parameters:
       environment: production
       levels: [0, 1]
+      offset: -16
       period: d
       create_artifact: true
       persist: true
@@ -238,6 +244,7 @@ deployments:
     parameters:
       environment: production
       levels: [0, 1, 5]
+      offset: -16
       period: d
       create_artifact: true
       persist: true


### PR DESCRIPTION
## Purpose

- Session-related usage indicators are calculated using data from the previous day, whereas sessions are loaded over a 15-day period. 
- Consequently, a portion of the sessions (approximately 50%) is not taken into account.

## Proposal
- [x] Apply a 16-day offset instead of a 1-day offset for indicators e4, u5, u6, u9, u10, u11, and u14.