### PR TITLE
✨(api) require at least one target when creating a tariff

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - Add tariffs support
 
+### Changed
+
+- Require at least one target when creating a tariff
+
 ## [0.34.1] - 2026-07-10
 
 ### Changed 

--- a/src/api/qualicharge/factories/tariff.py
+++ b/src/api/qualicharge/factories/tariff.py
@@ -8,6 +8,7 @@ from polyfactory.factories.dataclass_factory import DataclassFactory
 from polyfactory.factories.pydantic_factory import ModelFactory
 from polyfactory.factories.sqlalchemy_factory import SQLAlchemyFactory
 
+from ..fixtures.operational_units import prefixes
 from ..models.tariff import (
     PointDeChargeTariffCreate,
     TariffCreate,
@@ -16,7 +17,14 @@ from ..models.tariff import (
     TariffObject,
 )
 from ..schemas.tariff import PointDeChargeTariff, Tariff
-from . import AuditableSQLModelFactory, SoftDeleteFactoryMixin
+from . import AuditableSQLModelFactory, FrenchDataclassFactory, SoftDeleteFactoryMixin
+
+
+def _generate_id_pdc_itinerance() -> str:
+    """Generate a point of charge roaming identifier."""
+    prefix = DataclassFactory.__random__.choice(prefixes)
+    suffix = FrenchDataclassFactory.__faker__.pystr_format("E######")
+    return f"{prefix}{suffix}"
 
 
 class TariffElementFactory(ModelFactory[TariffElement]):
@@ -70,7 +78,7 @@ class TariffCreateFactory(ModelFactory[TariffCreate]):
     """Tariff creation payload factory."""
 
     tariff = Use(TariffObjectFactory.build)
-    targets: list[str] = []
+    targets = Use(lambda: [_generate_id_pdc_itinerance()])
 
 
 class PointDeChargeTariffCreateFactory(ModelFactory[PointDeChargeTariffCreate]):
@@ -80,7 +88,7 @@ class PointDeChargeTariffCreateFactory(ModelFactory[PointDeChargeTariffCreate]):
     original_last_updated = Use(
         lambda: datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=1)
     )
-    id_pdc_itinerance = Use(lambda: ["FRS63E0001"])
+    id_pdc_itinerance = Use(lambda: [_generate_id_pdc_itinerance()])
 
 
 class TariffFactory(SoftDeleteFactoryMixin, AuditableSQLModelFactory[Tariff]):

--- a/src/api/qualicharge/models/tariff.py
+++ b/src/api/qualicharge/models/tariff.py
@@ -198,7 +198,7 @@ class TariffObject(TariffPayloadModel):
 class TariffCreate(SQLModel):
     """Tariff creation payload."""
 
-    targets: List[IdPdcItinerance] = Field(default_factory=list)
+    targets: List[IdPdcItinerance] = Field(min_length=1)
     tariff: TariffObject
 
 

--- a/src/api/tests/api/v1/routers/test_tariff.py
+++ b/src/api/tests/api/v1/routers/test_tariff.py
@@ -179,40 +179,59 @@ def test_tariff_api_workflow(db_session, client_auth):
     assert len(associations) == n_pdcs
 
 
-def test_create_tariff_without_targets(db_session, client_auth):
-    """Test tariff creation without associated charge points."""
+@pytest.mark.parametrize(
+    ("target_data", "error_type", "error_message"),
+    (
+        pytest.param({}, "missing", "Field required", id="missing"),
+        pytest.param(
+            {"targets": []},
+            "too_short",
+            "List should have at least 1 item after validation, not 0",
+            id="empty",
+        ),
+        pytest.param(
+            {"targets": None},
+            "list_type",
+            "Input should be a valid list",
+            id="null",
+        ),
+    ),
+)
+def test_create_tariff_rejects_missing_empty_or_null_targets(
+    db_session,
+    client_auth,
+    target_data,
+    error_type,
+    error_message,
+):
+    """Test tariff creation rejects payloads without associated charge points."""
     start = datetime.now(timezone.utc) - timedelta(days=1)
     end = datetime.now(timezone.utc) + timedelta(days=1)
+    payload = _tariff_payload("tariff-1", start, end, ["FRS63E0001"])
+    del payload["targets"]
+    payload.update(target_data)
 
     response = client_auth.post(
         "/tariff/",
-        json=_tariff_payload("tariff-1", start, end, []),
+        json=payload,
     )
 
-    assert response.status_code == status.HTTP_201_CREATED
-    created = response.json()
-    tariff_id = UUID(created["id"])
-    assert created["id_pdc_itinerance"] == []
-    assert db_session.get(Tariff, tariff_id) is not None
-    assert (
-        db_session.exec(
-            select(PointDeChargeTariff).where(
-                PointDeChargeTariff.tariff_id == tariff_id
-            )
-        ).all()
-        == []
-    )
-
-    response = client_auth.get(f"/tariff/{tariff_id}")
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json()["id_pdc_itinerance"] == []
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    errors = response.json()["detail"]
+    assert len(errors) == 1
+    assert errors[0]["loc"] == ["body", "targets"]
+    assert errors[0]["type"] == error_type
+    assert errors[0]["msg"] == error_message
+    assert db_session.exec(select(Tariff)).all() == []
 
 
 def test_create_tariff_stores_extra_raw_fields(db_session, client_auth):
     """Test tariff creation stores validated payload with extra fields."""
+    save_statiques(db_session, StatiqueFactory.batch(1))
+    pdc = db_session.exec(select(PointDeCharge)).one()
     start = datetime.now(timezone.utc) - timedelta(days=1)
     end = datetime.now(timezone.utc) + timedelta(days=1)
-    payload = _tariff_payload("tariff-1", start, end, [])
+    payload = _tariff_payload("tariff-1", start, end, [pdc.id_pdc_itinerance])
     payload["tariff"]["custom_tariff"] = {"source": "operator"}
     payload["tariff"]["elements"][0]["custom_element"] = "element-extra"
     payload["tariff"]["elements"][0]["price_components"][0]["billing_unit"] = "kWh"
@@ -235,12 +254,17 @@ def test_create_tariff_rejects_invalid_known_field(client_auth):
     """Test tariff creation still validates known tariff fields."""
     start = datetime.now(timezone.utc) - timedelta(days=1)
     end = datetime.now(timezone.utc) + timedelta(days=1)
-    payload = _tariff_payload("tariff-1", start, end, [])
+    payload = _tariff_payload("tariff-1", start, end, ["FRS63E0001"])
     payload["tariff"]["currency"] = "USD"
 
     response = client_auth.post("/tariff/", json=payload)
 
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    errors = response.json()["detail"]
+    assert len(errors) == 1
+    assert errors[0]["loc"] == ["body", "tariff", "currency"]
+    assert errors[0]["type"] == "literal_error"
+    assert errors[0]["msg"] == "Input should be 'EUR'"
 
 
 def test_create_tariff_with_unknown_pdc_rolls_back(db_session, client_auth):
@@ -787,11 +811,13 @@ def test_apply_tariff_with_forbidden_tariff_for_user(db_session, client_auth):
 
 def test_apply_tariff_with_unknown_pdc_rolls_back(db_session, client_auth):
     """Test applying a tariff to an unknown PDC returns a 404."""
+    save_statiques(db_session, StatiqueFactory.batch(1))
+    pdc = db_session.exec(select(PointDeCharge)).one()
     start = datetime.now(timezone.utc) - timedelta(days=1)
     end = datetime.now(timezone.utc) + timedelta(days=1)
     response = client_auth.post(
         "/tariff/",
-        json=_tariff_payload("tariff-1", start, end, []),
+        json=_tariff_payload("tariff-1", start, end, [pdc.id_pdc_itinerance]),
     )
     assert response.status_code == status.HTTP_201_CREATED
     tariff_id = UUID(response.json()["id"])
@@ -803,14 +829,11 @@ def test_apply_tariff_with_unknown_pdc_rolls_back(db_session, client_auth):
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json()["detail"] == "Point of charge does not exist"
-    assert (
-        db_session.exec(
-            select(PointDeChargeTariff).where(
-                PointDeChargeTariff.tariff_id == tariff_id
-            )
-        ).all()
-        == []
-    )
+    associations = db_session.exec(
+        select(PointDeChargeTariff).where(PointDeChargeTariff.tariff_id == tariff_id)
+    ).all()
+    assert len(associations) == 1
+    assert associations[0].point_de_charge_id == pdc.id
 
 
 def test_deleted_tariff_is_hidden(db_session, client_auth):

--- a/src/api/tests/models/test_tariff.py
+++ b/src/api/tests/models/test_tariff.py
@@ -1,5 +1,6 @@
 """QualiCharge tariff models tests."""
 
+import re
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -36,7 +37,8 @@ def test_tariff_create_factory():
     payload = TariffCreateFactory.build()
 
     assert payload.tariff.tariff_id
-    assert payload.targets == []
+    assert payload.targets
+    assert re.fullmatch(r"FR[A-Z0-9]{3}E[0-9]{6}", payload.targets[0])
 
 
 def test_point_de_charge_tariff_create_factory():
@@ -45,7 +47,8 @@ def test_point_de_charge_tariff_create_factory():
 
     assert payload.original_id
     assert payload.original_last_updated is not None
-    assert payload.id_pdc_itinerance == ["FRS63E0001"]
+    assert payload.id_pdc_itinerance
+    assert re.fullmatch(r"FR[A-Z0-9]{3}E[0-9]{6}", payload.id_pdc_itinerance[0])
 
 
 def test_tariff_object_alias():


### PR DESCRIPTION
Reject tariff creation payloads with missing or empty targets, and update tariff tests/factories to use valid associated charge points.