### PR TITLE
🐛(prefect) Include decommissioned charge points

### DIFF
--- a/src/prefect/CHANGELOG.md
+++ b/src/prefect/CHANGELOG.md
@@ -60,5 +60,6 @@ and this project adheres to
   - ERRT : add 'inconnu' statuses
 - Add OperationalUnit level for infrastructure and usage indicators
 - Add a 15-day offset for session indicators (u5, u6, u9, u10, u11, u14, e4)
+- Replace `statique` by `_pointdecharge` + `_station` for usage indicators u5, u6, u9, u10, u11, u14
 
 [unreleased]: https://github.com/MTES-MCT/qualicharge/

--- a/src/prefect/indicators/usage/u10.py
+++ b/src/prefect/indicators/usage/u10.py
@@ -33,7 +33,9 @@ SELECT
     $level_id AS level_id
 FROM
     SESSION
-    INNER JOIN statique ON point_de_charge_id = pdc_id
+    INNER JOIN _Pointdecharge ON _Pointdecharge.id = point_de_charge_id
+    INNER JOIN _Station ON _Station.id = station_id
+    INNER JOIN localisation ON localisation.id = _Station.localisation_id
     $join_extras
 WHERE
     $timespan
@@ -61,7 +63,7 @@ def get_values_for_targets(
     """Fetch sessions given input level, timestamp and target index."""
     query_template = Template(NUM_SESSIONS_FOR_LEVEL_QUERY_TEMPLATE)
     query_params = {"indexes": ",".join(f"'{i}'" for i in map(str, indexes))}
-    query_params |= get_num_for_level_query_params(level)
+    query_params |= get_num_for_level_query_params(level, use_statique=False)
     query_params |= get_timespan_filter_query_params(timespan, session=True)
     with Session(get_api_db_engine(environment)) as session:
         return pd.read_sql_query(

--- a/src/prefect/indicators/usage/u11.py
+++ b/src/prefect/indicators/usage/u11.py
@@ -33,7 +33,9 @@ SELECT
     $level_id AS level_id
 FROM
     SESSION
-    INNER JOIN statique ON point_de_charge_id = pdc_id
+    INNER JOIN _Pointdecharge ON _Pointdecharge.id = point_de_charge_id
+    INNER JOIN _Station ON _Station.id = station_id
+    INNER JOIN localisation ON localisation.id = _Station.localisation_id
     $join_extras
 WHERE
     $timespan
@@ -65,7 +67,7 @@ def get_values_for_targets(
     """Fetch sessions given input level, timestamp and target index."""
     query_template = Template(NUM_SUCCESSFUL_SESSIONS_FOR_LEVEL_QUERY_TEMPLATE)
     query_params = {"indexes": ",".join(f"'{i}'" for i in map(str, indexes))}
-    query_params |= get_num_for_level_query_params(level)
+    query_params |= get_num_for_level_query_params(level, use_statique=False)
     query_params |= get_timespan_filter_query_params(timespan, session=True)
     with Session(get_api_db_engine(environment)) as session:
         return pd.read_sql_query(

--- a/src/prefect/indicators/usage/u14.py
+++ b/src/prefect/indicators/usage/u14.py
@@ -34,18 +34,18 @@ ENERGY_BY_DELIVERY_TEMPLATE = """
 WITH
   Stations AS (
     SELECT
-      Station.id,
+      _Station.id,
       operational_unit_id,
       code_insee_commune,
       raccordement = 'Direct' AS is_direct,
       $is_valid_pdl AS is_valid_pdl,
       $is_dc AS is_dc
     FROM
-      Pointdecharge
-      LEFT JOIN Station ON Station.id = station_id
+      _Pointdecharge
+      LEFT JOIN _Station ON _Station.id = station_id
       LEFT JOIN Localisation ON Localisation.id = localisation_id
     GROUP BY
-      station.id,
+      _station.id,
       code_insee_commune,
       operational_unit_id,
       is_direct,
@@ -55,11 +55,12 @@ WITH
     SELECT
       code,
       $alimentation AS alimentation,
-      Pointdecharge.id AS pdc_id,
+      _Pointdecharge.id AS pdc_id,
       code_insee_commune,
-      puissance_nominale
+      puissance_nominale,
+      operational_unit_id
     FROM
-      Pointdecharge
+      _Pointdecharge
       LEFT JOIN Stations ON stations.id = station_id
       LEFT JOIN Operationalunit ON operational_unit_id = Operationalunit.id
   ),
@@ -99,7 +100,7 @@ QUERY_NATIONAL_TEMPLATE = """
 WITH
   Stations AS (
     SELECT
-      Station.id,
+      _Station.id,
       id_station_itinerance,
       operational_unit_id,
       code_insee_commune,
@@ -107,11 +108,11 @@ WITH
       $is_valid_pdl AS is_valid_pdl,
       $is_dc AS is_dc
     FROM
-      Pointdecharge
-      LEFT JOIN Station ON Station.id = station_id
+      _Pointdecharge
+      LEFT JOIN _Station ON _Station.id = station_id
       LEFT JOIN Localisation ON Localisation.id = localisation_id
     GROUP BY
-      Station.id,
+      _Station.id,
       id_station_itinerance,
       code_insee_commune,
       operational_unit_id,
@@ -121,11 +122,11 @@ WITH
   Statiques AS (
     SELECT
       $alimentation AS alimentation,
-      Pointdecharge.id AS pdc_id,
+      _Pointdecharge.id AS pdc_id,
       station_id,
       puissance_nominale
     FROM
-      Pointdecharge
+      _Pointdecharge
       LEFT JOIN Stations ON stations.id = station_id
   ),
   Sessions_uniques AS (
@@ -167,7 +168,7 @@ def get_values_for_targets(
     query_template = Template(ENERGY_BY_DELIVERY_TEMPLATE)
     query_params = {"indexes": ",".join(f"'{i}'" for i in map(str, indexes))}
     query_params |= IS_VALID_PDL | IS_DC | ALIMENTATION
-    query_params |= get_num_for_level_query_params(level)
+    query_params |= get_num_for_level_query_params(level, use_statique=False)
     query_params |= get_timespan_filter_query_params(timespan, session=True)
     with Session(get_api_db_engine(environment)) as session:
         return pd.read_sql_query(

--- a/src/prefect/indicators/usage/u5.py
+++ b/src/prefect/indicators/usage/u5.py
@@ -34,7 +34,9 @@ SELECT
     $level_id AS level_id
 FROM
     Session
-    INNER JOIN statique ON point_de_charge_id = pdc_id
+    INNER JOIN _Pointdecharge ON _Pointdecharge.id = point_de_charge_id
+    INNER JOIN _Station ON _Station.id = station_id
+    INNER JOIN localisation ON localisation.id = _Station.localisation_id
     $join_extras
 WHERE
     $timespan
@@ -67,7 +69,7 @@ def get_values_for_targets(
     """Fetch sessions given input level, timestamp and target index."""
     query_template = Template(HOURLY_SESSIONS_QUERY_TEMPLATE)
     query_params = {"indexes": ",".join(f"'{i}'" for i in map(str, indexes))}
-    query_params |= get_num_for_level_query_params(level)
+    query_params |= get_num_for_level_query_params(level, use_statique=False)
     query_params |= get_timespan_filter_query_params(timespan, session=True)
     with Session(get_api_db_engine(environment)) as session:
         return pd.read_sql_query(

--- a/src/prefect/indicators/usage/u6.py
+++ b/src/prefect/indicators/usage/u6.py
@@ -48,7 +48,9 @@ SELECT
     $level_id AS level_id
 FROM
     filtered_session
-    INNER JOIN statique ON point_de_charge_id = pdc_id
+    INNER JOIN _Pointdecharge ON _Pointdecharge.id = point_de_charge_id
+    INNER JOIN _Station ON _Station.id = station_id
+    INNER JOIN localisation ON localisation.id = _Station.localisation_id
     LEFT JOIN puissance ON puissance_nominale::numeric <@ category
     $join_extras
 WHERE
@@ -77,7 +79,8 @@ SELECT
     category
 FROM
     filtered_session
-    INNER JOIN statique ON point_de_charge_id = pdc_id
+    INNER JOIN _Pointdecharge ON _Pointdecharge.id = point_de_charge_id
+    INNER JOIN _Station ON _Station.id = station_id
     LEFT JOIN puissance ON puissance_nominale::numeric <@ category
 GROUP BY
     category
@@ -95,7 +98,7 @@ def get_values_for_targets(
     query_template = Template(DURATION_FOR_LEVEL_QUERY_TEMPLATE)
     query_params = {"indexes": ",".join(f"'{i}'" for i in map(str, indexes))}
     query_params |= POWER_RANGE_CTE
-    query_params |= get_num_for_level_query_params(level)
+    query_params |= get_num_for_level_query_params(level, use_statique=False)
     query_params |= get_timespan_filter_query_params(timespan, session=True)
     with Session(get_api_db_engine(environment)) as session:
         return pd.read_sql_query(

--- a/src/prefect/indicators/usage/u9.py
+++ b/src/prefect/indicators/usage/u9.py
@@ -48,7 +48,9 @@ SELECT
     $level_id AS level_id
 FROM
     fitered_session
-    INNER JOIN statique ON point_de_charge_id = pdc_id
+    INNER JOIN _Pointdecharge ON _Pointdecharge.id = point_de_charge_id
+    INNER JOIN _Station ON _Station.id = station_id
+    INNER JOIN localisation ON localisation.id = _Station.localisation_id
     LEFT JOIN puissance ON puissance_nominale::numeric <@ category
     $join_extras
 WHERE
@@ -77,7 +79,8 @@ SELECT
     category
 FROM
     fitered_session
-    INNER JOIN statique ON point_de_charge_id = pdc_id
+    INNER JOIN _Pointdecharge ON _Pointdecharge.id = point_de_charge_id
+    INNER JOIN _Station ON _Station.id = station_id
     LEFT JOIN puissance ON puissance_nominale::numeric <@ category
 GROUP BY
     category
@@ -95,7 +98,7 @@ def get_values_for_targets(
     query_template = Template(ENERGY_FOR_LEVEL_QUERY_TEMPLATE)
     query_params = {"indexes": ",".join(f"'{i}'" for i in map(str, indexes))}
     query_params |= POWER_RANGE_CTE
-    query_params |= get_num_for_level_query_params(level)
+    query_params |= get_num_for_level_query_params(level, use_statique=False)
     query_params |= get_timespan_filter_query_params(timespan, session=True)
     with Session(get_api_db_engine(environment)) as session:
         return pd.read_sql_query(

--- a/src/prefect/indicators/utils.py
+++ b/src/prefect/indicators/utils.py
@@ -106,22 +106,28 @@ def get_timespan_filter_query_params(timespan: IndicatorTimeSpan, session: bool 
     }
 
 
-def get_num_for_level_query_params(level: Level):
-    """Get level_id and join_extras query parameters."""
-    match level:
-        case Level.CITY:
+def get_num_for_level_query_params(level: Level, use_statique: bool = True) -> dict:
+    """Get level_id and join_extras query parameters.
+
+    Args:
+        level: the Level enum value for which to get query parameters.
+        use_statique: True for queries with `statique`,
+                      False for queries with `_pointdecharge` (default: True).
+    """
+    match (level, use_statique):
+        case (Level.CITY, _):
             return {
                 "level_id": "City.id",
                 "join_extras": "INNER JOIN City ON code_insee_commune = City.code",
             }
-        case Level.EPCI:
+        case (Level.EPCI, _):
             return {
                 "level_id": "EPCI.id",
                 "join_extras": """
                     INNER JOIN City ON code_insee_commune = City.code
                     INNER JOIN EPCI ON City.epci_id = EPCI.id""",
             }
-        case Level.DEPARTMENT:
+        case (Level.DEPARTMENT, _):
             return {
                 "level_id": "Department.id",
                 "join_extras": """
@@ -129,7 +135,7 @@ def get_num_for_level_query_params(level: Level):
                     INNER JOIN Department ON City.department_id = Department.id
                     """,
             }
-        case Level.REGION:
+        case (Level.REGION, _):
             return {
                 "level_id": "Region.id",
                 "join_extras": """
@@ -138,13 +144,20 @@ def get_num_for_level_query_params(level: Level):
                     INNER JOIN Region ON Department.region_id = Region.id
                     """,
             }
-        case Level.OPERATIONALUNIT:
+        case (Level.OPERATIONALUNIT, True):
             return {
                 "level_id": "Operationalunit.id",
                 "join_extras": """
                     INNER JOIN Pointdecharge ON Pointdecharge.id = pdc_id
                     INNER JOIN Station ON station.id = station_id
                     INNER JOIN Operationalunit ON Station.operational_unit_id = Operationalunit.id
+                    """,  # noqa: E501
+            }
+        case (Level.OPERATIONALUNIT, False):
+            return {
+                "level_id": "Operationalunit.id",
+                "join_extras": """
+                    INNER JOIN Operationalunit ON operational_unit_id = Operationalunit.id
                     """,  # noqa: E501
             }
         case _:


### PR DESCRIPTION
## Purpose

- usage indicators are calculated with `statique` table that excludes decommissioned charge points.
- Consequently, a portion of the sessions is not taken into account in usage indicators.

## Proposal
- [x] Replace `statique` by `_pointdecharge` + `_station` in SQL query for usage indicators u5, u6, u9, u10, u11, u14.