### PR TITLE
🔖(api:patch) bump release to 0.34.1

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 - Add tariffs support
 
+## [0.34.1] - 2026-07-10
+
 ### Changed 
 
 #### Dependencies
@@ -779,7 +781,8 @@ update` command
 
 - Implement base FastAPI app
 
-[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.34.0...main
+[unreleased]: https://github.com/MTES-MCT/qualicharge/compare/v0.34.1...main
+[0.34.1]: https://github.com/MTES-MCT/qualicharge/compare/v0.34.0...v0.34.1
 [0.34.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.33.1...v0.34.0
 [0.33.1]: https://github.com/MTES-MCT/qualicharge/compare/v0.33.0...v0.33.1
 [0.33.0]: https://github.com/MTES-MCT/qualicharge/compare/v0.32.0...v0.33.0

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qualicharge"
-version = "0.34.0"
+version = "0.34.1"
 requires-python = "~=3.12.0"
 dependencies = [
     "alembic==1.18.5",

--- a/src/api/uv.lock
+++ b/src/api/uv.lock
@@ -1568,7 +1568,7 @@ wheels = [
 
 [[package]]
 name = "qualicharge"
-version = "0.34.0"
+version = "0.34.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
### Changed

#### Dependencies

- Upgrade `alembic` to `1.18.5`
- Upgrade `cachetools` to `7.1.4`
- Upgrade `fastapi` to `0.139.0`
- Upgrade `geopandas` to `1.1.4`
- Upgrade `pandas` to `3.0.3`
- Upgrade `psycopg` to `3.3.4`
- Upgrade `pyarrow` to `24.0.0`
- Upgrade `pydantic` to `2.13.4`
- Upgrade `pydantic-settings` to `2.14.2`
- Upgrade `PyJWT` to `2.12.1`
- Upgrade `python-multipart` to `0.0.31`
- Upgrade `sentry-sdk` to `2.64.0`
- Upgrade `sqlmodel` to `0.0.39`
- Upgrade `typer` to `0.26.8`
