### PR TITLE
🐛(prefect) Define a correct time range for queries using `lateststatus` table

### DIFF
--- a/src/prefect/CHANGELOG.md
+++ b/src/prefect/CHANGELOG.md
@@ -62,4 +62,8 @@ and this project adheres to
 - Add a 15-day offset for session indicators (u5, u6, u9, u10, u11, u14, e4)
 - Replace `statique` by `_pointdecharge` + `_station` for usage indicators u5, u6, u9, u10, u11, u14
 
+### Fixed
+
+- Define a correct time range for queries using `lateststatus`
+
 [unreleased]: https://github.com/MTES-MCT/qualicharge/

--- a/src/prefect/indicators/extract/e5.py
+++ b/src/prefect/indicators/extract/e5.py
@@ -26,7 +26,6 @@ from indicators.utils import (
     get_num_for_level_query_params,
     get_period_start_from_pit,
     get_targets_for_level,
-    get_timespan_filter_query_params,
 )
 
 HISTORY_STRATEGY_FIELD: str = "mean"
@@ -44,7 +43,8 @@ FROM
     $join_extras
 WHERE
     $level_id IN ($indexes)
-    AND $timespan
+    AND horodatage >= timestamp $start
+
 GROUP BY
     statique.id_pdc_itinerance,
     statique.id_station_itinerance,
@@ -64,7 +64,7 @@ FROM
     lateststatus
     INNER JOIN statique ON lateststatus.id_pdc_itinerance = statique.id_pdc_itinerance
 WHERE
-    $timespan
+    horodatage >= timestamp $start
 GROUP BY
     statique.id_pdc_itinerance,
     statique.id_station_itinerance,
@@ -77,7 +77,7 @@ GROUP BY
 @task(task_run_name="values-for-target-{level:02d}", cache_policy=NONE)
 def get_values_for_targets(
     level: Level,
-    timespan: IndicatorTimeSpan,
+    start: datetime,
     indexes: List[UUID],
     environment: Environment,
 ) -> pd.DataFrame:
@@ -85,7 +85,7 @@ def get_values_for_targets(
     query_template = Template(LIST_POCS_FOR_LEVEL_QUERY_TEMPLATE)
     query_params: dict = {"indexes": ",".join(f"'{i}'" for i in map(str, indexes))}
     query_params |= get_num_for_level_query_params(level)
-    query_params |= get_timespan_filter_query_params(timespan, session=False)
+    query_params |= {"start": f"'{start.isoformat(sep=' ')}'"}
     with Session(get_api_db_engine(environment)) as session:
         return pd.read_sql_query(
             query_template.substitute(query_params), con=session.connection()
@@ -102,12 +102,9 @@ def e5_for_level(
     chunk_size: int = settings.DEFAULT_CHUNK_SIZE,
 ) -> pd.DataFrame:
     """Calculate e5 for a level."""
-    timespan_query = IndicatorTimeSpan(
-        start=timespan.start - PeriodDuration.MONTH.value,
-        period=IndicatorPeriod.MONTH,
-    )
+    start_lateststatus = timespan.start - PeriodDuration.MONTH.value
     if level == Level.NATIONAL:
-        return e5_national(timespan, timespan_query, environment)
+        return e5_national(timespan, start_lateststatus, environment)
     targets = get_targets_for_level(level, environment)
     ids = targets["id"]
     chunks = (
@@ -116,7 +113,7 @@ def e5_for_level(
         else [ids.to_numpy()]
     )
     futures = [
-        get_values_for_targets.submit(level, timespan_query, chunk, environment)  # type: ignore[call-overload]
+        get_values_for_targets.submit(level, start_lateststatus, chunk, environment)  # type: ignore[call-overload]
         for chunk in chunks
     ]
     wait(futures)
@@ -175,12 +172,12 @@ def e5_for_level(
 )
 def e5_national(
     timespan: IndicatorTimeSpan,
-    timespan_query: IndicatorTimeSpan,
+    start: datetime,
     environment: Environment,
 ) -> pd.DataFrame:
     """Calculate e5 at the national level."""
     query_template = Template(QUERY_NATIONAL_TEMPLATE)
-    query_params = get_timespan_filter_query_params(timespan_query, session=False)
+    query_params = {"start": f"'{start.isoformat(sep=' ')}'"}
     with Session(get_api_db_engine(environment)) as session:
         result = pd.read_sql_query(
             query_template.substitute(query_params), con=session.connection()

--- a/src/prefect/tests/extract/test_e1.py
+++ b/src/prefect/tests/extract/test_e1.py
@@ -12,7 +12,7 @@ from indicators.models import IndicatorPeriod, IndicatorTimeSpan, Level
 from indicators.types import Environment
 
 # expected result
-N_POOLS_STATIONS = 363
+N_POOLS_STATIONS = 403
 
 TIMESPAN = IndicatorTimeSpan(start=datetime(2025, 1, 1), period=IndicatorPeriod.DAY)
 

--- a/src/prefect/tests/extract/test_e5.py
+++ b/src/prefect/tests/extract/test_e5.py
@@ -18,16 +18,13 @@ from tests.parameters import (
 )
 
 # expected result
-N_LEVEL = [7, 378, 696, 1940, 1064]
-N_LEVEL_NATIONAL = 4593
+N_LEVEL = [13, 715, 1254, 3638, 1944]
+N_LEVEL_NATIONAL = 8667
 N_DPTS = 109
 N_NAT_REG_DPT_EPCI_CITY_OU = 36984
 
 TIMESPAN = IndicatorTimeSpan(start=datetime(2024, 12, 28), period=IndicatorPeriod.DAY)
-TIMESPAN_QUERY = IndicatorTimeSpan(
-    start=TIMESPAN.start - PeriodDuration.MONTH.value,
-    period=IndicatorPeriod.MONTH,
-)
+START = TIMESPAN.start - PeriodDuration.MONTH.value
 PARAMETERS_FLOW = [prm + (lvl,) for prm, lvl in zip(PARAM_FLOW, N_LEVEL, strict=True)]
 PARAMETERS_VALUE = [prm + (lvl,) for prm, lvl in zip(PARAM_VALUE, N_LEVEL, strict=True)]
 
@@ -37,16 +34,14 @@ def test_task_get_values_for_target(db_connection, level, query, expected):
     """Test the `get_values_for_target` task."""
     result = db_connection.execute(text(query))
     indexes = list(result.scalars().all())
-    poc_extract = e5.get_values_for_targets.fn(
-        level, TIMESPAN, indexes, Environment.TEST
-    )
+    poc_extract = e5.get_values_for_targets.fn(level, START, indexes, Environment.TEST)
     assert len(set(poc_extract["level_id"])) == len(indexes)
 
 
 def test_task_get_values_for_target_unexpected_level():
     """Test the `get_values_for_target` task (unknown level)."""
     with pytest.raises(NotImplementedError, match="Unsupported level"):
-        e5.get_values_for_targets.fn(Level.NATIONAL, TIMESPAN, [], Environment.TEST)
+        e5.get_values_for_targets.fn(Level.NATIONAL, START, [], Environment.TEST)
 
 
 @pytest.mark.parametrize("level,query,targets,expected", PARAMETERS_FLOW)
@@ -74,7 +69,7 @@ def test_flow_e5_for_level_with_various_chunk_sizes(chunk_size):
 
 def test_flow_e5_national():
     """Test the `e5_national` flow."""
-    indicators = e5.e5_national(TIMESPAN, TIMESPAN_QUERY, Environment.TEST)
+    indicators = e5.e5_national(TIMESPAN, START, Environment.TEST)
     assert int(indicators["value"].sum()) == N_LEVEL_NATIONAL
 
 


### PR DESCRIPTION
## Purpose

- The e5 indicator uses a query on the `lateststatus` table with filtering based on a time interval (TimeSpan).
- This filtering method is unsuitable for selecting recently used charge points and must be replaced by a simple date.

## Proposal

- [x] Replace the TimeSpan by a date in the queries