### PR TITLE
🔖(prefect) add e2 and e3 indicators

### DIFF
--- a/src/prefect/CHANGELOG.md
+++ b/src/prefect/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 - Add usage indicator u14
 - Add extract indicator e5
 - Add extract indicator e1
+- Add extract indicators e2 and e3
 
 #### Quality
 

--- a/src/prefect/indicators/extract/e1.py
+++ b/src/prefect/indicators/extract/e1.py
@@ -5,15 +5,13 @@ E1: the list of stations of pools in activity.
 data : id_pool
 """
 
-from datetime import date, datetime, timedelta
-from string import Template
+from datetime import date, datetime
 
 import geopandas as gpd  # type: ignore
 import pandas as pd  # type: ignore
 from prefect import flow, runtime, task
-from sqlalchemy.orm import Session
 
-from indicators.db import get_indicators_db_engine
+from indicators.extract.utils import get_pdc_station_for_day
 from indicators.models import IndicatorPeriod, Level
 from indicators.types import Environment
 from indicators.utils import (
@@ -24,41 +22,7 @@ from indicators.utils import (
 )
 
 HISTORY_STRATEGY_FIELD: str = "mean"
-PDC_STATION_FOR_DAY_TEMPLATE = """
-SELECT
-  value,
-  extras
-FROM
-  $environment
-WHERE
-  code = 'e5' and level = 0  and period = 'd' and target = '00'
-  AND timestamp >= '$from_date'
-  AND timestamp < '$to_date'
-ORDER BY
-  value desc
-"""
 PERIOD = IndicatorPeriod.DAY
-
-
-@task
-def get_pdc_station_for_day(from_date: date, environment: Environment) -> pd.DataFrame:
-    """Get points of charge and stations for a given day."""
-    query_template = Template(PDC_STATION_FOR_DAY_TEMPLATE)
-    query_params = {
-        "from_date": from_date,
-        "to_date": from_date + timedelta(days=1),
-        "environment": environment.value,
-    }
-    with Session(get_indicators_db_engine()) as session:
-        e5_data = pd.read_sql_query(
-            query_template.substitute(query_params), con=session.connection()
-        )
-    if e5_data.empty:
-        return pd.DataFrame()
-    pdc_station = pd.DataFrame(e5_data["extras"][0])
-    if len(pdc_station) != e5_data["value"][0]:
-        return pd.DataFrame()
-    return pdc_station
 
 
 @task

--- a/src/prefect/indicators/extract/e2_e3.py
+++ b/src/prefect/indicators/extract/e2_e3.py
@@ -1,0 +1,248 @@
+"""QualiCharge prefect indicators: state historicization.
+
+E2: daily states of charge points in activity.
+E3: daily states of stations in activity.
+"""
+
+import os
+from datetime import date, datetime
+
+import pandas as pd
+from prefect import flow, runtime, task
+from prefect.cache_policies import NONE
+from prefect.futures import wait
+
+from indicators.extract.utils import (
+    get_pdc_station_for_day,
+    to_sampled_sessions,
+    to_sampled_state_grp,
+    to_sampled_state_poc,
+    to_sampled_statuses,
+    to_state_grp_d,
+    to_state_grp_h,
+    to_state_poc_d,
+)
+from indicators.models import IndicatorPeriod, Level
+from indicators.types import Environment
+from indicators.utils import (
+    export_indicators,
+    get_period_start_from_pit,
+)
+
+HISTORY_STRATEGY_FIELD: str = "mean"
+PERIOD = IndicatorPeriod.DAY
+CHUNK_SIZE: int = 2000
+SAMPLES: int = 288  # 5 min
+SATURE_H: int = 45  # minimum duration (min) of saturation to have a saturated hour
+
+ID_POC: str = "id_pdc_itinerance"
+ID_STATION: str = "id_station_itinerance"
+SATURATION_RATIO = 0.1
+OVERLOAD_RATIO = 0.2
+
+
+def read_s3_data(day: date, environment: str, bucket: str) -> pd.DataFrame:
+    """Read S3 data for state historicization."""
+    dir_path = f"{bucket}/{day.year}/{day.month}/{day.day}"
+    file_path = f"{dir_path}/{environment}.parquet"
+    s3_path = f"s3://{file_path}"
+    s3_endpoint_url = os.environ.get("S3_ENDPOINT_URL", "")
+    df = pd.read_parquet(
+        s3_path,
+        engine="pyarrow",
+        dtype_backend="pyarrow",
+        storage_options={"endpoint_url": s3_endpoint_url},
+    )  # type: ignore[call-overload]
+    return df
+
+
+def read_statics(day: date, environment: Environment, min_power: float) -> pd.DataFrame:
+    """Read static data for POC and stations."""
+    statics = get_pdc_station_for_day(day, environment)
+    statics["unite"] = statics["id_pdc_itinerance"].str[:5]
+    return statics[statics["puissance_nominale"] >= min_power]
+
+
+def filter_statuses_sessions(
+    sessions: pd.DataFrame, statuses: pd.DataFrame, statics: pd.DataFrame
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Filter statuses and sessions with statics data."""
+    sessions = sessions[sessions[ID_POC].isin(statics[ID_POC])].copy()
+    active_poc = sessions[ID_POC].unique()
+    statuses = statuses[statuses[ID_POC].isin(active_poc)].copy()
+    return (statuses, sessions)
+
+
+def get_sampled_state_poc(
+    day: date,
+    samples_per_day: int,
+    sessions: pd.DataFrame,
+    statuses: pd.DataFrame,
+) -> pd.DataFrame:
+    """Extract complete POC with sessions and statuses."""
+    timestamp = pd.Timestamp(day.isoformat() + "T00:00:00+00:00")
+    pocs_with_sessions = sessions[ID_POC].unique()
+    pocs_with_statuses = statuses[ID_POC].unique()
+
+    attributes_statuses = [ID_POC, "horodatage", "etat_pdc"]
+    statuses = statuses[attributes_statuses]
+
+    attributes_sessions = [ID_POC, "start", "end"]
+    sessions = sessions[attributes_sessions]
+    sessions["start"] = sessions["start"].astype("datetime64[s, UTC]")
+    sessions["end"] = sessions["end"].astype("datetime64[s, UTC]")
+
+    init_statuses = pd.DataFrame(
+        {
+            "horodatage": [timestamp + pd.Timedelta(days=-1)] * len(pocs_with_statuses),
+            "etat_pdc": ["en_service"] * len(pocs_with_statuses),
+            "id_pdc_itinerance": pocs_with_statuses,
+        }
+    )
+    sampled_statuses = to_sampled_statuses(
+        statuses, init_statuses, timestamp, samples_per_day
+    )
+
+    init_sessions = pd.DataFrame(
+        {
+            "start": [timestamp + pd.Timedelta(days=-1)] * len(pocs_with_sessions),
+            "end": [timestamp + pd.Timedelta(hours=-1)] * len(pocs_with_sessions),
+            "id_pdc_itinerance": pocs_with_sessions,
+        }
+    )
+    sampled_sessions = to_sampled_sessions(
+        sessions, init_sessions, timestamp, samples_per_day
+    )
+
+    return to_sampled_state_poc(sampled_sessions, sampled_statuses)
+
+
+@task(task_run_name="sampled_chunk-d-00-{day:%y-%m-%d}", cache_policy=NONE)
+def get_sampled_state_poc_for_chunk(
+    day: date,
+    samples_per_day: int,
+    statics_chunk: pd.DataFrame,
+    sessions: pd.DataFrame,
+    statuses: pd.DataFrame,
+) -> pd.DataFrame:
+    """Calculate sampled_state_poc for a chunk."""
+    statuses_chunk, sessions_chunk = filter_statuses_sessions(
+        sessions, statuses, statics_chunk
+    )
+    sampled_state_poc_chunk = get_sampled_state_poc(
+        day,
+        samples_per_day,
+        sessions_chunk,
+        statuses_chunk,
+    )
+    return sampled_state_poc_chunk
+
+
+@flow(
+    flow_run_name="meta-d-{start:%y-%m-%d}",
+)
+def e2_e3(  # noqa: PLR0913
+    environment: Environment,
+    min_power: float,
+    start: datetime | None = None,
+    offset: int = -1,
+    chunk_size: int = CHUNK_SIZE,
+    samples_per_day: int = SAMPLES,
+    create_artifact: bool = False,
+    persist: bool = False,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Run all e2 and e3 subflows."""
+    start = (
+        datetime.now()
+        if not offset and start is None
+        else get_period_start_from_pit(start, offset, PERIOD)
+    )
+    day = start.date()
+    statuses = read_s3_data(day, environment, "qualicharge-statuses")
+    sessions = read_s3_data(day, environment, "qualicharge-sessions")
+    statics = read_statics(day, environment, min_power)
+    chunks = [
+        statics.iloc[i : i + chunk_size] for i in range(0, len(statics), chunk_size)
+    ]
+    futures = [
+        get_sampled_state_poc_for_chunk.submit(
+            day,
+            samples_per_day,
+            chunk,
+            sessions,
+            statuses,
+        )  # type: ignore[call-overload]
+        for chunk in chunks
+    ]
+    wait(futures)
+
+    sampled_state_poc = pd.concat(
+        [future.result() for future in futures], ignore_index=True
+    )
+    state_poc_d = to_state_poc_d(sampled_state_poc, samples_per_day)
+
+    indicators_e2 = pd.DataFrame(
+        {
+            "target": "00",
+            "value": len(state_poc_d),
+            "code": "e2",
+            "level": Level.NATIONAL,
+            "period": PERIOD,
+            "timestamp": day.isoformat(),
+            "category": None,
+            "extras": [
+                {
+                    "id_pdc_itinerance": list(state_poc_d[ID_POC]),
+                    "occupe": list(state_poc_d["occupe"]),
+                    "hors_service": list(state_poc_d["hors_service"]),
+                    "libre": list(state_poc_d["libre"]),
+                }
+            ],
+        }
+    )
+    desc_e2 = f"e2 report at {day} (period: {PERIOD})"
+    flow_name_e2 = "e2-" + runtime.flow_run.name
+    export_indicators(
+        indicators_e2, environment, flow_name_e2, desc_e2, create_artifact, persist
+    )
+
+    sample_state_station = to_sampled_state_grp(
+        sampled_state_poc, statics, ID_STATION, SATURATION_RATIO, OVERLOAD_RATIO
+    )
+
+    state_station_h = to_state_grp_h(
+        sample_state_station, ID_STATION, SAMPLES, SATURE_H
+    )
+    state_station_d = to_state_grp_d(state_station_h, ID_STATION)
+
+    indicators_e3 = pd.DataFrame(
+        {
+            "target": "00",
+            "value": len(state_station_d),
+            "code": "e3",
+            "level": Level.NATIONAL,
+            "period": PERIOD,
+            "timestamp": day.isoformat(),
+            "category": None,
+            "extras": [
+                {
+                    "id_station_itinerance": list(state_station_d[ID_STATION]),
+                    "nb_pdc": list(state_station_d["nb_pdc"]),
+                    "nb_h": list(state_station_d["nb_h"]),
+                    "hs": list(state_station_d["hs"]),
+                    "inactif": list(state_station_d["inactif"]),
+                    "sature_cum": list(state_station_d["sature_cum"]),
+                    "sature_max": list(state_station_d["sature_max"]),
+                    "surcharge": list(state_station_d["surcharge"]),
+                    "actif": list(state_station_d["actif"]),
+                }
+            ],
+        }
+    )
+
+    desc_e3 = f"e3 report at {day} (period: {PERIOD})"
+    flow_name_e3 = "e3-" + runtime.flow_run.name
+    export_indicators(
+        indicators_e3, environment, flow_name_e3, desc_e3, create_artifact, persist
+    )
+    return (indicators_e2, indicators_e3)

--- a/src/prefect/indicators/extract/utils.py
+++ b/src/prefect/indicators/extract/utils.py
@@ -1,0 +1,342 @@
+"""QualiCharge prefect indicators: extract.utils.
+
+Common indicators functions and constants.
+"""
+
+from datetime import date, timedelta
+from string import Template
+
+import pandas as pd
+from pandas import NamedAgg
+from sqlalchemy.orm import Session
+
+from indicators.db import get_indicators_db_engine
+from indicators.models import IndicatorPeriod
+from indicators.types import Environment
+
+PDC_STATION_FOR_DAY_TEMPLATE = """
+SELECT
+  value,
+  extras
+FROM
+  $environment
+WHERE
+  code = 'e5' and level = 0  and period = 'd' and target = '00'
+  AND timestamp >= '$from_date'
+  AND timestamp < '$to_date'
+ORDER BY
+  value desc
+"""
+PERIOD = IndicatorPeriod.DAY
+
+
+def get_pdc_station_for_day(from_date: date, environment: Environment) -> pd.DataFrame:
+    """Get points of charge and stations for a given day."""
+    query_template = Template(PDC_STATION_FOR_DAY_TEMPLATE)
+    query_params = {
+        "from_date": from_date,
+        "to_date": from_date + timedelta(days=1),
+        "environment": environment.value,
+    }
+    with Session(get_indicators_db_engine()) as session:
+        e5_data = pd.read_sql_query(
+            query_template.substitute(query_params), con=session.connection()
+        )
+    if e5_data.empty:
+        return pd.DataFrame()
+    pdc_station = pd.DataFrame(e5_data["extras"][0])
+    if len(pdc_station) != e5_data["value"][0]:
+        return pd.DataFrame()
+    return pdc_station
+
+
+def to_sampled_statuses(
+    data: pd.DataFrame,
+    init_data: pd.DataFrame,
+    timestamp: pd.Timestamp,
+    samples_per_day: int,
+) -> pd.DataFrame:
+    """Generate sampled statuses for a given date.
+
+    Generation is based on a set of statuses and initial values.
+    The output states ('etat_pdc') are either 'en_service' or 'hors_service'.
+    The 'inconnu' value is not taken into account.
+    """
+    samples = pd.date_range(
+        start=timestamp,
+        end=timestamp + pd.Timedelta(days=1),
+        periods=samples_per_day + 1,
+    )
+    periode = pd.DataFrame({"periode": samples[0:samples_per_day]})
+    state = pd.concat([data, init_data]).sort_values(
+        by=["id_pdc_itinerance", "horodatage"]
+    )
+    state = state[(state["etat_pdc"] != "inconnu")]
+    state["f_horodatage"] = list(state["horodatage"])[1 : len(state)] + [
+        samples[samples_per_day]
+    ]
+    state["f_id_pdc_itinerance"] = list(state["id_pdc_itinerance"])[1 : len(state)] + [
+        "aucun"
+    ]
+
+    crossed = pd.merge(state, periode, how="cross")
+    sampled = crossed[
+        (
+            (crossed["id_pdc_itinerance"].eq(crossed["f_id_pdc_itinerance"]))
+            & (crossed["periode"] >= crossed["horodatage"])
+            & (crossed["periode"] < crossed["f_horodatage"])
+        )
+        | (
+            ~(crossed["id_pdc_itinerance"].eq(crossed["f_id_pdc_itinerance"]))
+            & (crossed["periode"] >= crossed["horodatage"])
+        )
+    ]
+    sampled = sampled[["periode", "etat_pdc", "id_pdc_itinerance"]]
+
+    return sampled.sort_values(by=["id_pdc_itinerance", "periode"]).reset_index(
+        drop=True
+    )
+
+
+def to_sampled_sessions(
+    data: pd.DataFrame,
+    init_data: pd.DataFrame,
+    timestamp: pd.Timestamp,
+    samples_per_day: int,
+) -> pd.DataFrame:
+    """Generate sampled sessions for a given date.
+
+    Generation is based on a set of sessions and initial values.
+    Input data: set of sessions and initial values.
+    The output states ('occupation_pdc') are either 'occupe' or 'libre'.
+    The 'inconnu' value is not taken into account.
+    """
+    samples = pd.date_range(
+        start=timestamp,
+        end=timestamp + pd.Timedelta(days=1),
+        periods=samples_per_day + 1,
+    )
+    periode = pd.DataFrame({"periode": samples[0:samples_per_day]})
+    sessions = pd.concat([data, init_data]).sort_values(
+        by=["id_pdc_itinerance", "start"]
+    )
+    sessions["occupation_pdc"] = "occupe"
+
+    crossed = pd.merge(sessions, periode, how="cross")
+    sampled = crossed[
+        (
+            (crossed["periode"] >= crossed["start"])
+            & (crossed["periode"] < crossed["end"])
+        )
+    ]
+    sampled = sampled[["periode", "occupation_pdc", "id_pdc_itinerance"]]
+    non_occupe = pd.merge(
+        periode,
+        pd.DataFrame({"id_pdc_itinerance": sessions["id_pdc_itinerance"].unique()}),
+        how="cross",
+    )
+    sampled = pd.merge(
+        non_occupe, sampled, how="left", on=["id_pdc_itinerance", "periode"]
+    ).fillna("f_libre")
+
+    return sampled.sort_values(by=["id_pdc_itinerance", "periode"]).reset_index(
+        drop=True
+    )
+
+
+def to_sampled_state_poc(
+    sessions: pd.DataFrame, statuses: pd.DataFrame
+) -> pd.DataFrame:
+    """Combine the states derived from sessions with those derived from statuses.
+
+    The session 'occupe' state takes precedence over the status state.
+    A session's 'f_libre' (not occupied) state translates to the 'hors_service' state if
+    the status state is 'hors_service'; otherwise, it translates to the 'libre' state.
+    """
+    merged = pd.merge(
+        sessions, statuses, how="outer", on=["id_pdc_itinerance", "periode"]
+    ).fillna("aaa")
+
+    # ! The state names are chosen so that alphabetical sorting respects
+    # the order of priority.
+    merged["state"] = (
+        merged[["etat_pdc", "occupation_pdc"]]
+        .agg("max", axis=1)
+        .replace("en_service", "libre")
+    )
+    merged = merged[["id_pdc_itinerance", "periode", "state"]].replace(
+        "f_libre", "libre"
+    )
+
+    return merged.sort_values(by=["id_pdc_itinerance", "periode"]).reset_index(
+        drop=True
+    )
+
+
+def to_state_poc_d(state_poc: pd.DataFrame, samples_per_day: int) -> pd.DataFrame:
+    """Generate daily states for the charge points based on their sampled state.
+
+    The time spent in each state is returne d in minutes.
+    """
+    sampled = state_poc[["id_pdc_itinerance", "state"]].reset_index()
+    sampled["occupe"] = sampled["state"] == "occupe"
+    sampled["hors_service"] = sampled["state"] == "hors_service"
+    sampled["libre"] = sampled["state"] == "libre"
+
+    state_d = sampled.groupby(["id_pdc_itinerance"]).agg("sum").reset_index()
+
+    for etat in ["occupe", "hors_service", "libre"]:
+        state_d[etat] = state_d[etat] * 60 * 24 / samples_per_day
+
+    return state_d[["id_pdc_itinerance", "occupe", "hors_service", "libre"]]
+
+
+def to_sampled_state_grp(
+    state_poc: pd.DataFrame,
+    pdc_group: pd.DataFrame,
+    group_name: str,
+    saturation_ratio: float,
+    overload_ratio: float,
+) -> pd.DataFrame:
+    """Generate the aggregated states of a set of charge points.
+
+    "surcharge" occurs when the number of charge points falls below 'overload_ratio'
+    value, and "sature" occurs below 'saturation_ratio' value.
+    Each state is represented by a boolean value as well as an aggregated numeric value
+    ('hs': 1, 'inactif': 2, 'actif': 3, 'surcharge': 4, 'sature': 5).
+    """
+    nb_pdc = (
+        pdc_group.groupby([group_name])
+        .count()
+        .rename(columns={"id_pdc_itinerance": "nb_pdc"})
+    )
+    merged = pd.merge(state_poc, pdc_group, how="left", on="id_pdc_itinerance")
+    merged["occupe"] = merged["state"] == "occupe"
+    merged["hors_service"] = merged["state"] == "hors_service"
+    merged["libre"] = merged["state"] == "libre"
+
+    grouped = (
+        merged[[group_name, "periode", "occupe", "hors_service", "libre"]]
+        .groupby([group_name, "periode"])
+        .sum()
+        .reset_index()
+    )
+    grouped = pd.merge(grouped, nb_pdc, how="left", on=group_name)
+
+    grouped["hs"] = (grouped["libre"] + grouped["occupe"] == 0) & (
+        grouped["hors_service"] > 0
+    )
+    grouped["inactif"] = ~grouped["hs"] & (grouped["occupe"] == 0)
+    grouped["sature"] = (
+        ~grouped["hs"]
+        & ~grouped["inactif"]
+        & (grouped["libre"] / grouped["nb_pdc"] < saturation_ratio)
+    )
+    grouped["surcharge"] = (
+        ~grouped["hs"]
+        & ~grouped["inactif"]
+        & ~grouped["sature"]
+        & (grouped["libre"] / grouped["nb_pdc"] < overload_ratio)
+    )
+    grouped["actif"] = (
+        ~grouped["hs"]
+        & ~grouped["inactif"]
+        & ~grouped["sature"]
+        & ~grouped["surcharge"]
+    )
+    grouped["state"] = (
+        grouped["hs"]
+        + grouped["inactif"] * 2
+        + grouped["actif"] * 3
+        + grouped["surcharge"] * 4
+        + grouped["sature"] * 5
+    )
+
+    return grouped[
+        [
+            group_name,
+            "periode",
+            "occupe",
+            "hors_service",
+            "libre",
+            "nb_pdc",
+            "hs",
+            "inactif",
+            "sature",
+            "surcharge",
+            "actif",
+            "state",
+        ]
+    ]
+
+
+def to_state_grp_h(
+    state_grp: pd.DataFrame,
+    group_name: str,
+    samples_per_day: int,
+    duree_etat_min: float,
+) -> pd.DataFrame:
+    """Generate hourly states based on the sampled state of a set of charge points.
+
+    The time spent in each state is returned in minutes.
+    Two boolean hourly states, 'sature_h' and 'surcharge_h', are calculated based on a
+    threshold for the time spent in the state.
+    """
+    nb_ech_hour = samples_per_day / 24
+
+    sampled = state_grp.reset_index()
+    sampled["periode_h"] = sampled["periode"].dt.hour
+    sampled["periode"] = sampled["periode"].dt.date
+
+    sampled_h = sampled.groupby([group_name, "periode", "periode_h"]).agg("sum")
+    sampled_h = sampled_h / nb_ech_hour
+    for etat in ["hs", "inactif", "sature", "surcharge", "actif"]:
+        sampled_h[etat] = sampled_h[etat] * 60
+    sampled_h["nb_pdc"] = sampled_h["nb_pdc"].astype("int")
+
+    sampled_h["sature_h"] = (sampled_h["sature"] + sampled_h["hs"]) >= duree_etat_min
+    sampled_h["surcharge_h"] = ~sampled_h["sature_h"] & (
+        (sampled_h["surcharge"] + sampled_h["sature"] + sampled_h["hs"])
+        >= duree_etat_min
+    )
+
+    sampled_h = sampled_h.reset_index()
+
+    return sampled_h[
+        [
+            group_name,
+            "periode",
+            "periode_h",
+            "nb_pdc",
+            "hs",
+            "inactif",
+            "sature",
+            "surcharge",
+            "actif",
+            "sature_h",
+            "surcharge_h",
+        ]
+    ]
+
+
+def to_state_grp_d(
+    state_grp_h: pd.DataFrame,
+    group_name: str,
+) -> pd.DataFrame:
+    """Generate daily states from the hourly state of a set of charge points.
+
+    The time spent in each state is returned in minutes.
+    """
+    grouped = state_grp_h.groupby([group_name, "periode"])
+    state_grp_d = grouped.agg(
+        nb_pdc=NamedAgg("nb_pdc", "max"),
+        nb_h=NamedAgg("periode", "count"),
+        hs=NamedAgg("hs", "sum"),
+        inactif=NamedAgg("inactif", "sum"),
+        sature_cum=NamedAgg("sature", "sum"),
+        sature_max=NamedAgg("sature", "max"),
+        surcharge=NamedAgg("surcharge", "sum"),
+        actif=NamedAgg("actif", "sum"),
+    ).reset_index()
+
+    return state_grp_d

--- a/src/prefect/indicators/run.py
+++ b/src/prefect/indicators/run.py
@@ -4,6 +4,7 @@
 
 # extract
 from .extract.e1 import e1
+from .extract.e2_e3 import e2_e3
 from .extract.e4 import e4
 from .extract.e5 import e5
 

--- a/src/prefect/indicators/strategy.py
+++ b/src/prefect/indicators/strategy.py
@@ -5,6 +5,7 @@ from quality.expectations.parameters import HISTORY_STRATEGY_FIELD as QUA_STRATE
 
 # extract
 from .extract.e1 import HISTORY_STRATEGY_FIELD as E1_STRATEGY
+from .extract.e2_e3 import HISTORY_STRATEGY_FIELD as E2_E3_STRATEGY
 from .extract.e4 import HISTORY_STRATEGY_FIELD as E4_STRATEGY
 from .extract.e5 import HISTORY_STRATEGY_FIELD as E5_STRATEGY
 
@@ -30,6 +31,7 @@ STRATEGY = {
     "i7": I7_STRATEGY,
     "t1": T1_STRATEGY,
     "e1": E1_STRATEGY,
+    "e2_e3": E2_E3_STRATEGY,
     "e4": E4_STRATEGY,
     "e5": E5_STRATEGY,
     "u5": U5_STRATEGY,

--- a/src/prefect/prefect.yaml
+++ b/src/prefect/prefect.yaml
@@ -90,6 +90,19 @@ deployments:
       name: indicators
       work_queue_name: default
 
+  - name: e2_e3-daily
+    entrypoint: indicators/extract/e2_e3.py:e2_e3
+    concurrency_limit: 10
+    parameters:
+      environment: production
+      min_power: 75
+      offset: -16
+      create_artifact: false
+      persist: true
+    work_pool:
+      name: indicators
+      work_queue_name: default
+
   - name: e4-daily
     entrypoint: indicators/extract/e4.py:e4
     concurrency_limit: 10

--- a/src/prefect/tests/extract/test_e2_e3.py
+++ b/src/prefect/tests/extract/test_e2_e3.py
@@ -1,0 +1,188 @@
+"""QualiCharge prefect indicators tests: function state."""
+
+from datetime import date
+
+from sqlalchemy import text
+
+from cooling import IfExistStrategy
+from cooling.sessions import cool_sessions_for_period
+from cooling.statuses import cool_statuses_for_period
+from indicators.extract import e2_e3, e5
+from indicators.models import IndicatorPeriod, Level
+from indicators.types import Environment
+
+MIN_POWER = 50
+SAMPLES = 288  # 5 min
+DATE = date(2024, 12, 28)
+ID_POC = "id_pdc_itinerance"
+LEN_SESSIONS = 4835
+LEN_STATUSES = 14386
+LEN_SAMPLED_STATE_POC = 506304
+LEN_STATE_POC = 1758
+LEN_STATE_STATION = 1287
+
+
+def test_read_s3_data() -> None:
+    """Test read_s3_data function."""
+    cool_sessions_for_period(
+        DATE,
+        DATE,
+        Environment.TEST,
+        if_exists=IfExistStrategy.IGNORE,
+    )
+    sessions = e2_e3.read_s3_data(
+        DATE,
+        Environment.TEST,
+        "qualicharge-sessions",
+    )
+    assert not sessions.empty
+
+
+def test_read_static_data() -> None:
+    """Test read_static_data function."""
+    e5_df = e5.e5(
+        Environment.TEST,
+        [Level.NATIONAL],
+        start=DATE + IndicatorPeriod.DAY.duration,
+        period=IndicatorPeriod.DAY,
+        persist=True,
+    )
+    statics = e2_e3.read_statics(
+        day=DATE, environment=Environment.TEST, min_power=MIN_POWER
+    )
+    assert not e5_df.empty
+    assert not statics.empty
+
+
+def test_filter_statuses_sessions() -> None:
+    """Test filter_statuses_sessions function."""
+    cool_sessions_for_period(
+        DATE,
+        DATE,
+        Environment.TEST,
+        if_exists=IfExistStrategy.IGNORE,
+    )
+    sessions = e2_e3.read_s3_data(
+        DATE,
+        Environment.TEST,
+        "qualicharge-sessions",
+    )
+    cool_statuses_for_period(
+        DATE,
+        DATE,
+        Environment.TEST,
+        if_exists=IfExistStrategy.IGNORE,
+    )
+    statuses = e2_e3.read_s3_data(
+        DATE,
+        Environment.TEST,
+        "qualicharge-statuses",
+    )
+    statics = e2_e3.read_statics(DATE, Environment.TEST, MIN_POWER)
+    statuses, sessions = e2_e3.filter_statuses_sessions(sessions, statuses, statics)
+    assert not statuses.empty
+    assert not sessions.empty
+    assert set(sessions[ID_POC].unique()).issubset(set(statics[ID_POC].unique()))
+    assert set(statuses[ID_POC].unique()).issubset(set(sessions[ID_POC].unique()))
+
+
+def test_get_sampled_state_poc() -> None:
+    """Test get_sampled_state_poc function."""
+    cool_sessions_for_period(
+        DATE,
+        DATE,
+        Environment.TEST,
+        if_exists=IfExistStrategy.IGNORE,
+    )
+    sessions = e2_e3.read_s3_data(
+        DATE,
+        Environment.TEST,
+        "qualicharge-sessions",
+    )
+    assert len(sessions) == LEN_SESSIONS
+    cool_statuses_for_period(
+        DATE,
+        DATE,
+        Environment.TEST,
+        if_exists=IfExistStrategy.IGNORE,
+    )
+    statuses = e2_e3.read_s3_data(
+        DATE,
+        Environment.TEST,
+        "qualicharge-statuses",
+    )
+    assert len(statuses) == LEN_STATUSES
+    statics = e2_e3.read_statics(DATE, Environment.TEST, MIN_POWER)
+    statuses, sessions = e2_e3.filter_statuses_sessions(sessions, statuses, statics)
+    e2_e3_sampled_state_poc = e2_e3.get_sampled_state_poc(
+        DATE,
+        SAMPLES,
+        sessions,
+        statuses,
+    )
+    assert not e2_e3_sampled_state_poc.empty
+    assert len(e2_e3_sampled_state_poc) == LEN_SAMPLED_STATE_POC
+
+
+def test_flow_e2_e3(indicators_db_engine):
+    """Test the `e2_e3` flow."""
+    cool_sessions_for_period(
+        DATE,
+        DATE,
+        Environment.TEST,
+        if_exists=IfExistStrategy.IGNORE,
+    )
+    sessions = e2_e3.read_s3_data(
+        DATE,
+        Environment.TEST,
+        "qualicharge-sessions",
+    )
+    cool_statuses_for_period(
+        DATE,
+        DATE,
+        Environment.TEST,
+        if_exists=IfExistStrategy.IGNORE,
+    )
+    statuses = e2_e3.read_s3_data(
+        DATE,
+        Environment.TEST,
+        "qualicharge-statuses",
+    )
+    statics = e2_e3.read_statics(DATE, Environment.TEST, MIN_POWER)
+    statuses, sessions = e2_e3.filter_statuses_sessions(sessions, statuses, statics)
+
+    indicators_e2, indicators_e3 = e2_e3.e2_e3(
+        Environment.TEST,
+        MIN_POWER,
+        start=DATE,
+        offset=0,
+        create_artifact=False,
+    )
+    assert list(indicators_e2["value"])[0] == LEN_STATE_POC
+    assert list(indicators_e3["value"])[0] == LEN_STATE_STATION
+
+    indicators_chunk_light_e2, indicators_chunk_light_e3 = e2_e3.e2_e3(
+        Environment.TEST,
+        MIN_POWER,
+        start=DATE,
+        offset=0,
+        chunk_size=200,
+        create_artifact=False,
+    )
+    assert list(indicators_chunk_light_e2["value"])[0] == LEN_STATE_POC
+    assert list(indicators_chunk_light_e3["value"])[0] == LEN_STATE_STATION
+
+    indicators_persistent_e2, indicators_persistent_e3 = e2_e3.e2_e3(
+        Environment.TEST,
+        MIN_POWER,
+        start=DATE,
+        offset=0,
+        create_artifact=False,
+        persist=True,
+    )
+    with indicators_db_engine.connect() as connection:
+        result = connection.execute(text("SELECT COUNT(*) FROM test WHERE code = 'e2'"))
+        assert result.one()[0] == len(indicators_persistent_e2)
+    with indicators_db_engine.connect() as connection:
+        result = connection.execute(text("SELECT COUNT(*) FROM test WHERE code = 'e3'"))
+        assert result.one()[0] == len(indicators_persistent_e3)

--- a/src/prefect/tests/extract/test_utils.py
+++ b/src/prefect/tests/extract/test_utils.py
@@ -1,0 +1,280 @@
+"""QualiCharge prefect indicators tests: extract.utils."""
+
+from datetime import date, datetime
+
+import pandas as pd
+from pandas import NamedAgg
+
+from indicators.extract import e5, utils
+from indicators.models import IndicatorPeriod, Level
+from indicators.types import Environment
+
+DATE = datetime(2025, 1, 1)
+SATURATION_RATIO = 0.1
+OVERLOAD_RATIO = 0.2
+
+
+def test_get_pdc_station_for_day():
+    """Test the `get_pdc_station_for_day` function."""
+    e5.e5(
+        Environment.TEST,
+        [Level.NATIONAL],
+        start=DATE + IndicatorPeriod.DAY.duration,
+        period=IndicatorPeriod.DAY.value,
+        persist=True,
+    )
+    poc_station = utils.get_pdc_station_for_day(DATE, Environment.TEST)
+    assert not poc_station.empty
+    assert set(poc_station.columns) == {
+        "latitude",
+        "longitude",
+        "puissance_nominale",
+        "id_pdc_itinerance",
+        "id_station_itinerance",
+    }
+
+
+def test_to_sampled_sessions() -> None:
+    """Test to_sampled_sessions function."""
+    samples_per_day = 24
+    timestamp = pd.Timestamp("2025-04-25T00:00:00+02:00")
+    start = [1, 1.2, 3, 5.5, 9, 13.1, 20]
+    end = [2.1, 2.7, 5, 7.5, 12.1, 15.1, 22.6]
+
+    test = pd.DataFrame(
+        {
+            "start": [timestamp + pd.Timedelta(hours=val) for val in start],
+            "end": [timestamp + pd.Timedelta(hours=val) for val in end],
+            "id_pdc_itinerance": ["p1", "p2", "p2", "p1", "p2", "p1", "p2"],
+        }
+    )
+    pdc = test["id_pdc_itinerance"].unique()
+    init = pd.DataFrame(
+        {
+            "start": [timestamp + pd.Timedelta(days=-1)] * len(pdc),
+            "end": [timestamp + pd.Timedelta(hours=-1)] * len(pdc),
+            "id_pdc_itinerance": pdc,
+        }
+    )
+    res = utils.to_sampled_sessions(test, init, timestamp, samples_per_day)
+
+    assert res.iloc[5]["occupation_pdc"] == "f_libre"
+    assert res.iloc[6]["occupation_pdc"] == "occupe"
+
+
+def test_to_sampled_statuses() -> None:
+    """Test to_sampled_statuses function."""
+    samples_per_day = 24
+    timestamp = pd.Timestamp("2025-04-25T00:00:00+02:00")
+    valeurs = [1, 1.2, 3, 3.5, 5, 6.1, 12]
+
+    test = pd.DataFrame(
+        {
+            "horodatage": [timestamp + pd.Timedelta(hours=val) for val in valeurs],
+            "etat_pdc": [
+                "en_service",
+                "hors_service",
+                "en_service",
+                "en_service",
+                "hors_service",
+                "en_service",
+                "hors_service",
+            ],
+            "id_pdc_itinerance": ["p1", "p2", "p2", "p1", "p2", "p1", "p2"],
+        }
+    )
+    pdc = test["id_pdc_itinerance"].unique()
+    init = pd.DataFrame(
+        {
+            "horodatage": [timestamp + pd.Timedelta(days=-1)] * len(pdc),
+            "etat_pdc": ["en_service"] * len(pdc),
+            "id_pdc_itinerance": pdc,
+        }
+    )
+    res = utils.to_sampled_statuses(test, init, timestamp, samples_per_day)
+
+    assert res.iloc[25]["etat_pdc"] == "en_service"
+    assert res.iloc[26]["etat_pdc"] == "hors_service"
+
+
+def test_to_sampled_state_poc_and_to_state_poc_d() -> None:
+    """Test to_sampled_state_poc and to_state_poc_d functions."""
+    samples_per_day = 3
+    sessions = pd.DataFrame(
+        {
+            "id_pdc_itinerance": ["p1", "p1", "p1", "p2", "p2", "p2", "p3", "p3", "p3"],
+            "periode": [0, 1, 2, 0, 1, 2, 0, 1, 2],
+            "occupation_pdc": [
+                "occupe",
+                "f_libre",
+                "occupe",
+                "f_libre",
+                "occupe",
+                "f_libre",
+                "f_libre",
+                "occupe",
+                "f_libre",
+            ],
+        }
+    )
+    statuses = pd.DataFrame(
+        {
+            "id_pdc_itinerance": ["p1", "p1", "p1", "p3", "p3", "p3", "p4", "p4", "p4"],
+            "periode": [0, 1, 2, 0, 1, 2, 0, 1, 2],
+            "etat_pdc": [
+                "hors_service",
+                "hors_service",
+                "en_service",
+                "en_service",
+                "hors_service",
+                "hors_service",
+                "en_service",
+                "hors_service",
+                "en_service",
+            ],
+        }
+    )
+    merged = utils.to_sampled_state_poc(sessions, statuses)
+    assert list(merged["state"][0:4]) == ["occupe", "hors_service", "occupe", "libre"]
+
+    merged_d = utils.to_state_poc_d(merged, samples_per_day)
+    assert list(merged_d["id_pdc_itinerance"]) == ["p1", "p2", "p3", "p4"]
+    assert list(merged_d["occupe"]) == [960.0, 480.0, 480.0, 0.0]
+    assert list(merged_d["hors_service"]) == [480.0, 0.0, 480.0, 480.0]
+    assert list(merged_d["libre"]) == [0.0, 960.0, 480.0, 960.0]
+
+
+def test_to_sampled_state_grp_and_to_state_grp_h() -> None:
+    """Test to_sampled_state_grp and to_state_grp_h functions."""
+    test = pd.DataFrame(
+        {
+            "id_pdc_itinerance": ["p1", "p1", "p1", "p2", "p2", "p2", "p3", "p3", "p3"],
+            "periode": [0, 1, 2, 0, 1, 2, 0, 1, 2],
+            "state": [
+                "occupe",
+                "hors_service",
+                "occupe",
+                "libre",
+                "occupe",
+                "libre",
+                "libre",
+                "occupe",
+                "hors_service",
+            ],
+        }
+    )
+    stations = pd.DataFrame(
+        {
+            "id_pdc_itinerance": ["p1", "p2", "p3"],
+            "id_station_itinerance": ["s1", "s1", "s2"],
+        }
+    )
+    state_grp = utils.to_sampled_state_grp(
+        test, stations, "id_station_itinerance", SATURATION_RATIO, OVERLOAD_RATIO
+    )
+    assert list(state_grp["state"]) == [3, 5, 3, 2, 5, 1]
+    assert list(state_grp["surcharge"]) == [False] * 6
+    assert list(state_grp["sature"]) == [False, True, False] * 2
+    assert list(state_grp["hs"]) == [False] * 5 + [True]
+    assert list(state_grp["actif"]) == [True, False, True, False, False, False]
+    assert list(state_grp["inactif"]) == [False, False, False, True, False, False]
+
+    test = pd.DataFrame(
+        {
+            "id_pdc_itinerance": [
+                "p1",
+                "p1",
+                "p1",
+                "p1",
+                "p1",
+                "p1",
+                "p2",
+                "p2",
+                "p2",
+                "p2",
+                "p2",
+                "p2",
+            ],
+            "periode": [0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5],
+            "state": [
+                "occupe",
+                "hors_service",
+                "occupe",
+                "occupe",
+                "hors_service",
+                "libre",
+                "libre",
+                "libre",
+                "occupe",
+                "hors_service",
+                "hors_service",
+                "libre",
+            ],
+        }
+    )
+    stations = pd.DataFrame(
+        {"id_pdc_itinerance": ["p1", "p2"], "id_station_itinerance": ["s1", "s1"]}
+    )
+    state_grp = utils.to_sampled_state_grp(
+        test, stations, "id_station_itinerance", SATURATION_RATIO, OVERLOAD_RATIO
+    )
+    assert list(state_grp["state"]) == [3, 2, 5, 5, 1, 2]
+
+    samples_per_day = 144
+    intervals = 24 * 60 / samples_per_day
+    state_grp["periode"] = pd.Timestamp(
+        "2025-01-20 15:00:00", tz="UTC"
+    ) + pd.to_timedelta(state_grp["periode"] * 10, unit="min")
+    state_grp_h = utils.to_state_grp_h(
+        state_grp,
+        "id_station_itinerance",
+        samples_per_day=samples_per_day,
+        duree_etat_min=75,
+    )
+    assert state_grp_h["hs"][0] == intervals
+    assert state_grp_h["inactif"][0] == intervals * 2
+    assert state_grp_h["sature"][0] == intervals * 2
+    assert state_grp_h["surcharge"][0] == 0
+    assert state_grp_h["actif"][0] == intervals
+
+
+def test_to_state_grp_d() -> None:
+    """Test to_state_grp_d function."""
+    state_grp_test = pd.DataFrame(
+        {
+            "id_station_itinerance": ["s1", "s1"],
+            "periode": date(2026, 1, 15),
+            "periode_h": [1, 2],
+            "nb_pdc": 2,
+            "hs": [10, 15],
+            "inactif": [20, 30],
+            "sature": [20, 10],
+            "surcharge": [0, 5],
+            "actif": [10, 15],
+            "sature_h": [False, True],
+            "surcharge_h": [True, True],
+        }
+    )
+    grouped = state_grp_test.groupby(["id_station_itinerance", "periode"])
+    grouped.agg(
+        nb_pdc=NamedAgg("nb_pdc", "max"),
+        nb_h=NamedAgg("periode", "count"),
+        hs=NamedAgg("hs", "sum"),
+        inactif=NamedAgg("inactif", "sum"),
+        sature_cum=NamedAgg("sature", "sum"),
+        sature_max=NamedAgg("sature", "max"),
+        surcharge=NamedAgg("surcharge", "sum"),
+        actif=NamedAgg("actif", "sum"),
+    ).reset_index()
+
+    state_grp_d = utils.to_state_grp_d(state_grp_test, "id_station_itinerance")
+    assert state_grp_d["id_station_itinerance"][0] == "s1"
+    assert state_grp_d["periode"][0] == date(2026, 1, 15)
+    assert state_grp_d["nb_pdc"][0] == 2 * 1
+    assert state_grp_d["nb_h"][0] == 2 * 1
+    assert state_grp_d["hs"][0] == 25 * 1
+    assert state_grp_d["inactif"][0] == 50 * 1
+    assert state_grp_d["sature_cum"][0] == 30 * 1
+    assert state_grp_d["sature_max"][0] == 20 * 1
+    assert state_grp_d["surcharge"][0] == 5 * 1
+    assert state_grp_d["actif"][0] == 25 * 1


### PR DESCRIPTION
## Purpose

- DMR data analysis requires calculating, for each charge-point and station, the daily cumulative duration spent in each macro-state (eg saturation, overload, full-utilization...)
- Two indicators are defined to store this data (e2 for charge points and e3 for stations)

## Proposal

- [x] calculate e2 indicator
- [x] calculate e3 indicator

Notes : 
- The scheduled deployment via Prefect for e2 and e3 is not included in this PR; it will be scheduled in a subsequent PR following operational validation.
- Future PRs will incorporate full-utilization data,  status quality data and pool (eg service areas) data
- The complete list of indicators is available on `Resana/Qualicharge/projet/indicateurs/indicateurs.xlsx`