### PR TITLE
🗃️(api) store only non-null tariff fields as raw

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -15,10 +15,11 @@ and this project adheres to
 ### Changed
 
 - Require at least one target when creating a tariff
+- Store only raw tariff non-null fields
 
 ## [0.34.1] - 2026-07-10
 
-### Changed 
+### Changed
 
 #### Dependencies
 
@@ -82,20 +83,20 @@ and this project adheres to
 - Upgrade `sqlmodel` to `0.0.37`
 - Upgrade `typer` to `0.24.1`
 
-### Fixed 
+### Fixed
 
-- Recommission a station when at least one related charge point is 
+- Recommission a station when at least one related charge point is
   recommissioned
 
 ## [0.33.0] - 2026-02-06
 
-### Changed 
+### Changed
 
 - Check SIREN validity (checksum) before ingestion
 - Require the `Statique.raccordement` field to be filled
 - Require the `Statique.num_pdl` field to be filled for direct connections
 - Ensure the `Statique.puissance_nominale` field is in [1.3 ; 4000]
-- Improve `Statique.id_pdc_itinerance` and `Statique.id_station_itinerance` 
+- Improve `Statique.id_pdc_itinerance` and `Statique.id_station_itinerance`
   fields validation regex patterns
 - Ensure the `Session.energy` field is in [0 ; 1000]
 - Ensure session do not last more than a week
@@ -223,11 +224,11 @@ and this project adheres to
 ### Changed
 
 - mark the following static fields as required:
-    - `nom_amenageur`
-    - `siren_amenageur`
-    - `contact_amenageur`
-    - `nom_operateur`
-    - `telephone_operateur`
+  - `nom_amenageur`
+  - `siren_amenageur`
+  - `contact_amenageur`
+  - `nom_operateur`
+  - `telephone_operateur`
 
 #### Dependencies
 
@@ -280,9 +281,9 @@ update` command
 
 - Add a configurable retention policy for `Status` and `Session` data
 - Create new database indexes:
-    - `ix_pointdecharge_station_id`
-    - `ix_station_amenageur_id`
-    - `ix_station_operateur_id`
+  - `ix_pointdecharge_station_id`
+  - `ix_station_amenageur_id`
+  - `ix_station_operateur_id`
 
 ### Changed
 
@@ -301,10 +302,10 @@ update` command
 ### Removed
 
 - Drop database indexes:
-    - `status_horodatage_idx`
-    - `ix_status_horodatage_pdc_id`
-    - `session_start_idx`
-    - `ix_session_start_pdc_id`
+  - `status_horodatage_idx`
+  - `ix_status_horodatage_pdc_id`
+  - `session_start_idx`
+  - `ix_session_start_pdc_id`
 
 ## [0.24.0] - 2025-06-11
 
@@ -340,8 +341,8 @@ update` command
 ### Added
 
 - Introduce two new database connection settings:
-    - `DB_CONNECTION_POOL_CHECK`
-    - `DB_CONNECTION_POOL_RECYCLE`
+  - `DB_CONNECTION_POOL_CHECK`
+  - `DB_CONNECTION_POOL_RECYCLE`
 
 ### Changed
 

--- a/src/api/qualicharge/api/v1/routers/tariff.py
+++ b/src/api/qualicharge/api/v1/routers/tariff.py
@@ -183,8 +183,7 @@ async def list_(  # noqa: PLR0913
         Query(
             title="Point de charge",
             description=(
-                "Filter tariffs by `id_pdc_itinerance` "
-                "(can be provided multiple times)"
+                "Filter tariffs by `id_pdc_itinerance` (can be provided multiple times)"
             ),
         ),
     ] = None,
@@ -297,20 +296,20 @@ async def create(
     session: Session = Depends(get_session),
 ) -> TariffRead:
     """Create a tariff and optionally associate it with charge points."""
-    created_tariff: Tariff
-    ids_pdc_itinerance: list[IdPdcItinerance]
+    raw = tariff.tariff.model_dump(
+        mode="json", by_alias=True, exclude_none=True, exclude_computed_fields=True
+    )
+    created_tariff = Tariff(
+        original_id=tariff.tariff.tariff_id,
+        original_last_updated=tariff.tariff.last_updated,
+        raw=raw,
+        start=tariff.tariff.tariff_application_date,
+        end=tariff.tariff.end_date_time,
+        created_by_id=user.id,
+        updated_by_id=user.id,
+    )
     try:
         with session.begin_nested():
-            raw = tariff.tariff.model_dump(by_alias=True, mode="json")
-            created_tariff = Tariff(
-                original_id=tariff.tariff.tariff_id,
-                original_last_updated=tariff.tariff.last_updated,
-                raw=raw,
-                start=tariff.tariff.tariff_application_date,
-                end=tariff.tariff.end_date_time,
-                created_by_id=user.id,
-                updated_by_id=user.id,
-            )
             session.add(created_tariff)
             session.flush()
             ids_pdc_itinerance = _add_tariff_associations(

--- a/src/api/tests/api/v1/routers/test_tariff.py
+++ b/src/api/tests/api/v1/routers/test_tariff.py
@@ -250,6 +250,28 @@ def test_create_tariff_stores_extra_raw_fields(db_session, client_auth):
     assert response.json()["raw"] == db_tariff.raw
 
 
+def test_create_tariff_stores_raw_without_null_fields(db_session, client_auth):
+    """Test tariff creation stores validated payload without null fields."""
+    save_statiques(db_session, StatiqueFactory.batch(1))
+    pdc = db_session.exec(select(PointDeCharge)).one()
+    start = datetime.now(timezone.utc) - timedelta(days=1)
+    end = datetime.now(timezone.utc) + timedelta(days=1)
+    payload = _tariff_payload("tariff-1", start, end, [pdc.id_pdc_itinerance])
+    payload["tariff"]["min_price"] = None
+    payload["tariff"]["max_price"] = None
+
+    response = client_auth.post("/tariff/", json=payload)
+
+    assert response.status_code == status.HTTP_201_CREATED
+    tariff_id = UUID(response.json()["id"])
+    db_tariff = db_session.get(Tariff, tariff_id)
+    assert db_tariff is not None
+    assert "min_price" not in db_tariff.raw
+    assert "max_price" not in db_tariff.raw
+
+    assert response.json()["raw"] == db_tariff.raw
+
+
 def test_create_tariff_rejects_invalid_known_field(client_auth):
     """Test tariff creation still validates known tariff fields."""
     start = datetime.now(timezone.utc) - timedelta(days=1)


### PR DESCRIPTION
## Purpose

We want to store validated raw data and ignore null fields that are not relevant for our usage. Extra fields are dropped before saving and this is what we expect.

## Proposal

- [x] drop null fields before saving
