### PR TITLE
🔖(prefect) improve indicators e2 and e3

### DIFF
--- a/src/prefect/CHANGELOG.md
+++ b/src/prefect/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to
 - Add OperationalUnit level for infrastructure and usage indicators
 - Add a 15-day offset for session indicators (u5, u6, u9, u10, u11, u14, e4)
 - Replace `statique` by `_pointdecharge` + `_station` for usage indicators u5, u6, u9, u10, u11, u14
+- Filter statuses and sessions for e2 and e3
 
 ### Fixed
 

--- a/src/prefect/indicators/extract/e2_e3.py
+++ b/src/prefect/indicators/extract/e2_e3.py
@@ -5,7 +5,7 @@ E3: daily states of stations in activity.
 """
 
 import os
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 import pandas as pd
 from prefect import flow, runtime, task
@@ -39,6 +39,7 @@ ID_POC: str = "id_pdc_itinerance"
 ID_STATION: str = "id_station_itinerance"
 SATURATION_RATIO = 0.1
 OVERLOAD_RATIO = 0.2
+MAX_SESSION_DURATION_HOURS: float = 10
 
 
 def read_s3_data(day: date, environment: str, bucket: str) -> pd.DataFrame:
@@ -80,15 +81,18 @@ def get_sampled_state_poc(
     statuses: pd.DataFrame,
 ) -> pd.DataFrame:
     """Extract complete POC with sessions and statuses."""
+    min_duration = timedelta(minutes=24 * 60 / samples_per_day)
+    max_duration = timedelta(hours=MAX_SESSION_DURATION_HOURS)
     timestamp = pd.Timestamp(day.isoformat() + "T00:00:00+00:00")
     pocs_with_sessions = sessions[ID_POC].unique()
     pocs_with_statuses = statuses[ID_POC].unique()
 
     attributes_statuses = [ID_POC, "horodatage", "etat_pdc"]
-    statuses = statuses[attributes_statuses]
+    statuses = statuses[attributes_statuses].copy()
+    statuses["horodatage"] = statuses["horodatage"].astype("datetime64[s, UTC]")
 
     attributes_sessions = [ID_POC, "start", "end"]
-    sessions = sessions[attributes_sessions]
+    sessions = sessions[attributes_sessions].copy()
     sessions["start"] = sessions["start"].astype("datetime64[s, UTC]")
     sessions["end"] = sessions["end"].astype("datetime64[s, UTC]")
 
@@ -99,8 +103,9 @@ def get_sampled_state_poc(
             "id_pdc_itinerance": pocs_with_statuses,
         }
     )
+    init_statuses["horodatage"] = pd.to_datetime(init_statuses["horodatage"], utc=True)
     sampled_statuses = to_sampled_statuses(
-        statuses, init_statuses, timestamp, samples_per_day
+        statuses, init_statuses, timestamp, samples_per_day, min_duration=min_duration
     )
 
     init_sessions = pd.DataFrame(
@@ -111,7 +116,12 @@ def get_sampled_state_poc(
         }
     )
     sampled_sessions = to_sampled_sessions(
-        sessions, init_sessions, timestamp, samples_per_day
+        sessions,
+        init_sessions,
+        timestamp,
+        samples_per_day,
+        min_duration=min_duration,
+        max_duration=max_duration,
     )
 
     return to_sampled_state_poc(sampled_sessions, sampled_statuses)
@@ -139,7 +149,7 @@ def get_sampled_state_poc_for_chunk(
 
 
 @flow(
-    flow_run_name="meta-d-{start:%y-%m-%d}",
+    flow_run_name="meta-e2e3-d",
 )
 def e2_e3(  # noqa: PLR0913
     environment: Environment,

--- a/src/prefect/indicators/extract/utils.py
+++ b/src/prefect/indicators/extract/utils.py
@@ -55,6 +55,7 @@ def to_sampled_statuses(
     init_data: pd.DataFrame,
     timestamp: pd.Timestamp,
     samples_per_day: int,
+    min_duration: timedelta = timedelta(),
 ) -> pd.DataFrame:
     """Generate sampled statuses for a given date.
 
@@ -78,8 +79,21 @@ def to_sampled_statuses(
     state["f_id_pdc_itinerance"] = list(state["id_pdc_itinerance"])[1 : len(state)] + [
         "aucun"
     ]
+    # remove statuses with short duration
+    state["duration"] = state["f_horodatage"] - state["horodatage"]
+    filtered_state = state[
+        (state["duration"] > min_duration)
+        | (state["id_pdc_itinerance"] != state["f_id_pdc_itinerance"])
+    ].copy()
+    filtered_state["f_horodatage"] = list(filtered_state["horodatage"])[
+        1 : len(filtered_state)
+    ] + [samples[samples_per_day]]
+    filtered_state["f_id_pdc_itinerance"] = list(filtered_state["id_pdc_itinerance"])[
+        1 : len(filtered_state)
+    ] + ["aucun"]
 
-    crossed = pd.merge(state, periode, how="cross")
+    # create sampled statuses
+    crossed = pd.merge(filtered_state, periode, how="cross")
     sampled = crossed[
         (
             (crossed["id_pdc_itinerance"].eq(crossed["f_id_pdc_itinerance"]))
@@ -98,11 +112,13 @@ def to_sampled_statuses(
     )
 
 
-def to_sampled_sessions(
+def to_sampled_sessions(  # noqa: PLR0913
     data: pd.DataFrame,
     init_data: pd.DataFrame,
     timestamp: pd.Timestamp,
     samples_per_day: int,
+    min_duration: timedelta = timedelta(),
+    max_duration: timedelta = timedelta(hours=24),
 ) -> pd.DataFrame:
     """Generate sampled sessions for a given date.
 
@@ -120,9 +136,21 @@ def to_sampled_sessions(
     sessions = pd.concat([data, init_data]).sort_values(
         by=["id_pdc_itinerance", "start"]
     )
-    sessions["occupation_pdc"] = "occupe"
+    # remove invalid sessions : duplicates, short duration, long duration
+    unic = ["start", "end", "id_pdc_itinerance"]
+    sessions["duration"] = sessions["end"] - sessions["start"]
+    filtered_sessions = (
+        sessions[
+            (sessions["duration"] > min_duration)
+            & (sessions["duration"] < max_duration)
+        ]
+        .copy()
+        .drop_duplicates(subset=unic)
+    )
 
-    crossed = pd.merge(sessions, periode, how="cross")
+    # create sampled sessions
+    filtered_sessions["occupation_pdc"] = "occupe"
+    crossed = pd.merge(filtered_sessions, periode, how="cross")
     sampled = crossed[
         (
             (crossed["periode"] >= crossed["start"])
@@ -288,11 +316,12 @@ def to_state_grp_h(
     sampled["periode_h"] = sampled["periode"].dt.hour
     sampled["periode"] = sampled["periode"].dt.date
 
-    sampled_h = sampled.groupby([group_name, "periode", "periode_h"]).agg("sum")
+    sampled_h = sampled.groupby([group_name, "nb_pdc", "periode", "periode_h"]).agg(
+        "sum"
+    )
     sampled_h = sampled_h / nb_ech_hour
     for etat in ["hs", "inactif", "sature", "surcharge", "actif"]:
         sampled_h[etat] = sampled_h[etat] * 60
-    sampled_h["nb_pdc"] = sampled_h["nb_pdc"].astype("int")
 
     sampled_h["sature_h"] = (sampled_h["sature"] + sampled_h["hs"]) >= duree_etat_min
     sampled_h["surcharge_h"] = ~sampled_h["sature_h"] & (

--- a/src/prefect/prefect.yaml
+++ b/src/prefect/prefect.yaml
@@ -93,10 +93,14 @@ deployments:
   - name: e2_e3-daily
     entrypoint: indicators/extract/e2_e3.py:e2_e3
     concurrency_limit: 10
+    schedules:
+      - cron: "45 5 * * *"
+        timezone: "Europe/Paris"
+        active: true
     parameters:
       environment: production
       min_power: 75
-      offset: -16
+      offset: -22
       create_artifact: false
       persist: true
     work_pool:

--- a/src/prefect/tests/extract/test_utils.py
+++ b/src/prefect/tests/extract/test_utils.py
@@ -1,6 +1,6 @@
 """QualiCharge prefect indicators tests: extract.utils."""
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 import pandas as pd
 from pandas import NamedAgg
@@ -12,6 +12,7 @@ from indicators.types import Environment
 DATE = datetime(2025, 1, 1)
 SATURATION_RATIO = 0.1
 OVERLOAD_RATIO = 0.2
+LEN_RES = 48
 
 
 def test_get_pdc_station_for_day():
@@ -51,14 +52,39 @@ def test_to_sampled_sessions() -> None:
     pdc = test["id_pdc_itinerance"].unique()
     init = pd.DataFrame(
         {
-            "start": [timestamp + pd.Timedelta(days=-1)] * len(pdc),
-            "end": [timestamp + pd.Timedelta(hours=-1)] * len(pdc),
+            "start": [timestamp + pd.Timedelta(hours=-1)] * len(pdc),
+            "end": [timestamp + pd.Timedelta(hours=0.5)] * len(pdc),
             "id_pdc_itinerance": pdc,
         }
     )
     res = utils.to_sampled_sessions(test, init, timestamp, samples_per_day)
-
+    assert res.iloc[0]["occupation_pdc"] == "occupe"
+    assert res.iloc[1]["occupation_pdc"] == "occupe"
     assert res.iloc[5]["occupation_pdc"] == "f_libre"
+    assert res.iloc[6]["occupation_pdc"] == "occupe"
+    assert res.iloc[34]["occupation_pdc"] == "occupe"
+
+    res_min = utils.to_sampled_sessions(
+        test, init, timestamp, samples_per_day, min_duration=timedelta(hours=1.2)
+    )
+    assert res_min.iloc[1]["occupation_pdc"] == "f_libre"
+
+    res_max = utils.to_sampled_sessions(
+        test, init, timestamp, samples_per_day, max_duration=timedelta(hours=3)
+    )
+    assert res_max.iloc[34]["occupation_pdc"] == "f_libre"  # !!
+
+    end = [6.1, 2.7, 5, 7.5, 12.1, 15.1, 22.6]
+    test = pd.DataFrame(
+        {
+            "start": [timestamp + pd.Timedelta(hours=val) for val in start],
+            "end": [timestamp + pd.Timedelta(hours=val) for val in end],
+            "id_pdc_itinerance": ["p1", "p2", "p2", "p1", "p2", "p1", "p2"],
+        }
+    )
+    res = utils.to_sampled_sessions(test, init, timestamp, samples_per_day)
+
+    assert res.iloc[5]["occupation_pdc"] == "occupe"
     assert res.iloc[6]["occupation_pdc"] == "occupe"
 
 
@@ -92,9 +118,16 @@ def test_to_sampled_statuses() -> None:
         }
     )
     res = utils.to_sampled_statuses(test, init, timestamp, samples_per_day)
-
+    assert len(res) == LEN_RES
     assert res.iloc[25]["etat_pdc"] == "en_service"
     assert res.iloc[26]["etat_pdc"] == "hors_service"
+
+    res = utils.to_sampled_statuses(
+        test, init, timestamp, samples_per_day, timedelta(hours=1.9)
+    )
+    assert len(res) == LEN_RES
+    assert res.iloc[25]["etat_pdc"] == "en_service"
+    assert res.iloc[26]["etat_pdc"] == "en_service"
 
 
 def test_to_sampled_state_poc_and_to_state_poc_d() -> None:


### PR DESCRIPTION
## Purpose

- Calculating indicators E2 and E3 based on statuses and sessions requires excluding inconsistent data.
- Two main types of inconsistency have been identified:
  - sessions with an incorrect end date render the indicators invalid up to that date,
  - very short-duration sessions and statuses (anomalies) generate significant errors.

## Proposal

- [x] exclude sessions with inconsistent durations
- [x] exclude transitional statuses
- [x] enable daily calculation of indicators

Notes:
- Service level (DMR) and dynamic data quality metrics will be addressed in a future PR.
- The complete list of indicators is available in the file `Resana/Qualicharge/projet/indicateurs/indicateurs.xlsx`