### PR TITLE
🐛(api) fix geo fixtures download in migrations

### DIFF
--- a/src/api/CHANGELOG.md
+++ b/src/api/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to
 - Require at least one target when creating a tariff
 - Store only raw tariff non-null fields
 
+### Fixed
+
+- Add redirection support for database fixture download in migrations
+
 ## [0.34.1] - 2026-07-10
 
 ### Changed

--- a/src/api/qualicharge/migrations/versions/f5416bc7dd5f_import_admin_geo_fixtures.py
+++ b/src/api/qualicharge/migrations/versions/f5416bc7dd5f_import_admin_geo_fixtures.py
@@ -56,7 +56,7 @@ def download_fixtures() -> Dict[str, AdministrativeBoundary]:
     # Download
     for level, ab in boundaries.items():
         print(f"Downloading {level} file to {ab.path}...")
-        response = httpx.get(ab.url)
+        response = httpx.get(ab.url, follow_redirects=True)
         with open(ab.path, "wb") as output_file:
             output_file.write(gzip.decompress(response.content))
 


### PR DESCRIPTION
## Purpose

When running database migrations from the start, since imported dataset moved, one need to support HTTP redirects (302 status) to fetch databasets from their new location.

## Proposal

- [x] fix target migration
